### PR TITLE
fix: use alpha prerelease versions for release-please

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,13 +1,13 @@
 {
-  "packages/core": "0.0.1",
-  "packages/email": "0.0.1",
-  "packages/sms": "0.0.1",
-  "packages/push": "0.0.1",
-  "packages/react-email": "0.0.1",
-  "packages/mjml": "0.0.1",
-  "packages/handlebars": "0.0.1",
-  "packages/smtp": "0.0.1",
-  "packages/ses": "0.0.1",
-  "packages/resend": "0.0.1",
-  "packages/bullmq": "0.0.1"
+  "packages/core": "0.0.1-alpha.0",
+  "packages/email": "0.0.1-alpha.0",
+  "packages/sms": "0.0.1-alpha.0",
+  "packages/push": "0.0.1-alpha.0",
+  "packages/react-email": "0.0.1-alpha.0",
+  "packages/mjml": "0.0.1-alpha.0",
+  "packages/handlebars": "0.0.1-alpha.0",
+  "packages/smtp": "0.0.1-alpha.0",
+  "packages/ses": "0.0.1-alpha.0",
+  "packages/resend": "0.0.1-alpha.0",
+  "packages/bullmq": "0.0.1-alpha.0"
 }

--- a/packages/bullmq/package.json
+++ b/packages/bullmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betternotify/bullmq",
-  "version": "0.0.1",
+  "version": "0.0.1-alpha.0",
   "description": "BullMQ queue adapter for BetterNotify.",
   "license": "MIT",
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betternotify/core",
-  "version": "0.0.1",
+  "version": "0.0.1-alpha.0",
   "description": "End-to-end typed email contracts, sender, and webhook router for Node.js.",
   "license": "MIT",
   "files": [

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betternotify/email",
-  "version": "0.0.1",
+  "version": "0.0.1-alpha.0",
   "description": "Email channel plugin for betternotify.",
   "license": "MIT",
   "files": [

--- a/packages/handlebars/package.json
+++ b/packages/handlebars/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betternotify/handlebars",
-  "version": "0.0.1",
+  "version": "0.0.1-alpha.0",
   "description": "Handlebars adapter for BetterNotify.",
   "license": "MIT",
   "files": [

--- a/packages/mjml/package.json
+++ b/packages/mjml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betternotify/mjml",
-  "version": "0.0.1",
+  "version": "0.0.1-alpha.0",
   "description": "MJML adapter for BetterNotify.",
   "license": "MIT",
   "files": [

--- a/packages/push/package.json
+++ b/packages/push/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betternotify/push",
-  "version": "0.0.1",
+  "version": "0.0.1-alpha.0",
   "description": "Push notification channel plugin for betternotify.",
   "license": "MIT",
   "files": [

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betternotify/react-email",
-  "version": "0.0.1",
+  "version": "0.0.1-alpha.0",
   "description": "React Email adapter for BetterNotify.",
   "license": "MIT",
   "files": [

--- a/packages/resend/package.json
+++ b/packages/resend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betternotify/resend",
-  "version": "0.0.1",
+  "version": "0.0.1-alpha.0",
   "description": "Resend provider for BetterNotify.",
   "license": "MIT",
   "files": [

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betternotify/ses",
-  "version": "0.0.1",
+  "version": "0.0.1-alpha.0",
   "description": "AWS SES provider and webhook adapter for BetterNotify.",
   "license": "MIT",
   "files": [

--- a/packages/sms/package.json
+++ b/packages/sms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betternotify/sms",
-  "version": "0.0.1",
+  "version": "0.0.1-alpha.0",
   "description": "SMS channel plugin for betternotify.",
   "license": "MIT",
   "files": [

--- a/packages/smtp/package.json
+++ b/packages/smtp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betternotify/smtp",
-  "version": "0.0.1",
+  "version": "0.0.1-alpha.0",
   "description": "Nodemailer-backed SMTP transport for BetterNotify.",
   "license": "MIT",
   "files": [

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "bump-patch-for-minor-pre-major": true,
   "prerelease": true,
   "include-component-in-tag": true,
+  "separate-pull-requests": false,
   "packages": {
     "packages/core": {
       "release-type": "node",


### PR DESCRIPTION
# Overview

Fix release-please producing stable versions instead of alpha prereleases.

# What's changed and why?

Release-please PR #5 was bumping to `0.0.2` (stable) instead of alpha versions, even though `prerelease: true` and `prerelease-type: "alpha"` were configured. The root cause is that the manifest and package versions were set to stable `0.0.1` — release-please needs prerelease versions to continue the prerelease chain.

- `.release-please-manifest.json` — updated all 11 package versions from `0.0.1` to `0.0.1-alpha.0`
- `packages/*/package.json` (11 files) — updated version field from `0.0.1` to `0.0.1-alpha.0`
- `release-please-config.json` — explicitly set `separate-pull-requests: false`

# How to test

1. Merge this PR
2. Verify release-please regenerates PR #5 with alpha versions (e.g. `0.0.2-alpha.0`)