### PR TITLE
fix: add repository field and ci improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
 
 concurrency:

--- a/packages/bullmq/package.json
+++ b/packages/bullmq/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.1-alpha.0",
   "description": "BullMQ queue adapter for BetterNotify.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-notify/better-notify",
+    "directory": "packages/bullmq"
+  },
   "files": [
     "dist",
     "README.md",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.1-alpha.0",
   "description": "End-to-end typed email contracts, sender, and webhook router for Node.js.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-notify/better-notify",
+    "directory": "packages/core"
+  },
   "files": [
     "dist",
     "README.md",

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.1-alpha.0",
   "description": "Email channel plugin for betternotify.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-notify/better-notify",
+    "directory": "packages/email"
+  },
   "files": [
     "dist",
     "README.md",

--- a/packages/handlebars/package.json
+++ b/packages/handlebars/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.1-alpha.0",
   "description": "Handlebars adapter for BetterNotify.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-notify/better-notify",
+    "directory": "packages/handlebars"
+  },
   "files": [
     "dist",
     "README.md",

--- a/packages/mjml/package.json
+++ b/packages/mjml/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.1-alpha.0",
   "description": "MJML adapter for BetterNotify.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-notify/better-notify",
+    "directory": "packages/mjml"
+  },
   "files": [
     "dist",
     "README.md",

--- a/packages/push/package.json
+++ b/packages/push/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.1-alpha.0",
   "description": "Push notification channel plugin for betternotify.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-notify/better-notify",
+    "directory": "packages/push"
+  },
   "files": [
     "dist",
     "README.md",

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.1-alpha.0",
   "description": "React Email adapter for BetterNotify.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-notify/better-notify",
+    "directory": "packages/react-email"
+  },
   "files": [
     "dist",
     "README.md",

--- a/packages/resend/package.json
+++ b/packages/resend/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.1-alpha.0",
   "description": "Resend provider for BetterNotify.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-notify/better-notify",
+    "directory": "packages/resend"
+  },
   "files": [
     "dist",
     "README.md",

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.1-alpha.0",
   "description": "AWS SES provider and webhook adapter for BetterNotify.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-notify/better-notify",
+    "directory": "packages/ses"
+  },
   "files": [
     "dist",
     "README.md",

--- a/packages/sms/package.json
+++ b/packages/sms/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.1-alpha.0",
   "description": "SMS channel plugin for betternotify.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-notify/better-notify",
+    "directory": "packages/sms"
+  },
   "files": [
     "dist",
     "README.md",

--- a/packages/smtp/package.json
+++ b/packages/smtp/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.1-alpha.0",
   "description": "Nodemailer-backed SMTP transport for BetterNotify.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-notify/better-notify",
+    "directory": "packages/smtp"
+  },
   "files": [
     "dist",
     "README.md",

--- a/turbo/generators/templates/package/package.json.hbs
+++ b/turbo/generators/templates/package/package.json.hbs
@@ -1,5 +1,5 @@
 { "name": "@betternotify/{{kebab name}}", "version": "0.1.0", "description": "{{description}}",
-"license": "MIT", "files": ["dist", "README.md", "LICENSE"], "type": "module", "exports": { ".": {
+"license": "MIT", "repository": { "type": "git", "url": "https://github.com/better-notify/better-notify", "directory": "packages/{{kebab name}}" }, "files": ["dist", "README.md", "LICENSE"], "type": "module", "exports": { ".": {
 "types": "./dist/index.d.ts", "default": "./dist/index.js" } }, "scripts": { "build":
 "NODE_OPTIONS='--import tsx/esm' rolldown -c", "typecheck": "tsc --noEmit", "test": "vitest run" },
 "dependencies": { "@betternotify/core": "workspace:*" }, "devDependencies": {


### PR DESCRIPTION
# Overview

Fix npm provenance publish failures and CI trigger scope.

# What's changed and why?

- **`packages/*/package.json`** — Added `repository` field with `url` and `directory` to all 11 packages. Required by npm provenance verification during publish.
- **`.github/workflows/ci.yml`** — Removed `push` trigger so CI only runs on pull requests.
- **`turbo/generators/templates/package/package.json.hbs`** — Updated the package generator template to include the `repository` field automatically.

# How to test

1. Run `pnpm gen` and scaffold a new package — verify the generated `package.json` includes the `repository` field.
2. Merge and confirm the release-please publish step passes provenance checks.