### PR TITLE
feat(bullmq): implement BullMQ adapter and createWorker runtime

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 turbo/generators/templates
 **/CHANGELOG.md
+**/routeTree.gen.ts

--- a/packages/bullmq/package.json
+++ b/packages/bullmq/package.json
@@ -31,7 +31,11 @@
   "devDependencies": {
     "@internal/rolldown-config": "workspace:*",
     "@internal/tsconfig": "workspace:*",
+    "bullmq": "catalog:",
+    "ioredis": "catalog:",
+    "ioredis-mock": "^8.13.1",
     "rolldown": "catalog:",
+    "tslib": "^2.8.1",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/bullmq/src/index.test.ts
+++ b/packages/bullmq/src/index.test.ts
@@ -74,12 +74,12 @@ describe('bullmq() — enqueue', () => {
     expect(opts).toMatchObject({ delay: 5000, priority: 2, jobId: 'custom-id' });
   });
 
-  it('falls back to crypto.randomUUID() when job.id is undefined', async () => {
+  it('throws when BullMQ returns no job id', async () => {
     mockJobAdd.mockResolvedValue({ id: undefined });
     const adapter = bullmq({ connection: baseConnection });
-    const result = await adapter.enqueue(makePayload());
-    expect(typeof result.jobId).toBe('string');
-    expect(result.jobId.length).toBeGreaterThan(0);
+    await expect(adapter.enqueue(makePayload())).rejects.toThrow(
+      'BullMQ enqueued job for route "test.send" but returned no id',
+    );
   });
 });
 

--- a/packages/bullmq/src/index.test.ts
+++ b/packages/bullmq/src/index.test.ts
@@ -1,10 +1,175 @@
-import { describe, expect, it } from 'vitest';
-import { bullmq } from './index.js';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { EmailJobPayload } from '@betternotify/core/queue';
 
-describe('@betternotify/bullmq (stub)', () => {
-  it('throws not-implemented at construction', () => {
-    expect(() => bullmq({ connection: { url: 'redis://localhost:6379' } })).toThrow(
-      /not implemented/,
-    );
+const mockJobAdd = vi.fn();
+const mockQueueClose = vi.fn();
+const mockWorkerClose = vi.fn();
+const mockWaitUntilReady = vi.fn().mockResolvedValue(undefined);
+
+let capturedProcessor:
+  | ((job: { data: unknown; id: string; attemptsMade: number }) => Promise<void>)
+  | undefined;
+
+vi.mock('bullmq', () => {
+  class FakeQueue {
+    add = mockJobAdd;
+    close = mockQueueClose;
+  }
+  class FakeWorker {
+    waitUntilReady = mockWaitUntilReady;
+    close = mockWorkerClose;
+    constructor(
+      _name: string,
+      processor: (job: { data: unknown; id: string; attemptsMade: number }) => Promise<void>,
+    ) {
+      capturedProcessor = processor;
+    }
+  }
+  return { Queue: FakeQueue, Worker: FakeWorker };
+});
+
+const { bullmq } = await import('./index.js');
+
+const baseConnection = { host: 'localhost', port: 6379 };
+
+const makePayload = (route = 'test.send'): EmailJobPayload => ({
+  _v: 1,
+  route,
+  input: { name: 'Alice' },
+  messageId: 'msg-1',
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedProcessor = undefined;
+  mockJobAdd.mockResolvedValue({ id: 'job-42' });
+  mockQueueClose.mockResolvedValue(undefined);
+  mockWorkerClose.mockResolvedValue(undefined);
+  mockWaitUntilReady.mockResolvedValue(undefined);
+});
+
+describe('bullmq() — enqueue', () => {
+  it('calls queue.add() with the payload and returns EnqueueResult', async () => {
+    const adapter = bullmq({ connection: baseConnection });
+    const payload = makePayload();
+    const result = await adapter.enqueue(payload);
+
+    expect(mockJobAdd).toHaveBeenCalledOnce();
+    const [jobName, jobData] = mockJobAdd.mock.calls[0] as [string, unknown];
+    expect(jobName).toBe('test.send');
+    expect(jobData).toEqual(payload);
+
+    expect(result).toEqual({
+      jobId: 'job-42',
+      route: 'test.send',
+      messageId: 'msg-1',
+    });
+  });
+
+  it('passes delay, priority, jobId from EnqueueOptions to queue.add()', async () => {
+    const adapter = bullmq({ connection: baseConnection });
+    await adapter.enqueue(makePayload(), { delay: 5000, priority: 2, jobId: 'custom-id' });
+
+    const [, , opts] = mockJobAdd.mock.calls[0] as [string, unknown, Record<string, unknown>];
+    expect(opts).toMatchObject({ delay: 5000, priority: 2, jobId: 'custom-id' });
+  });
+
+  it('falls back to crypto.randomUUID() when job.id is undefined', async () => {
+    mockJobAdd.mockResolvedValue({ id: undefined });
+    const adapter = bullmq({ connection: baseConnection });
+    const result = await adapter.enqueue(makePayload());
+    expect(typeof result.jobId).toBe('string');
+    expect(result.jobId.length).toBeGreaterThan(0);
+  });
+});
+
+describe('bullmq() — subscribe', () => {
+  it('creates a Worker and calls waitUntilReady()', async () => {
+    const adapter = bullmq({ connection: baseConnection });
+    const handler = vi.fn().mockResolvedValue(undefined);
+    await adapter.subscribe(handler);
+
+    expect(mockWaitUntilReady).toHaveBeenCalledOnce();
+  });
+
+  it('calls the handler with a JobEnvelope when the worker processes a job', async () => {
+    const adapter = bullmq({ connection: baseConnection });
+    const handler = vi.fn().mockResolvedValue(undefined);
+    await adapter.subscribe(handler);
+
+    const payload = makePayload();
+    await capturedProcessor!({ data: payload, id: 'job-1', attemptsMade: 0 });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith({
+      payload,
+      attempt: 1,
+      jobId: 'job-1',
+    });
+  });
+
+  it('increments attempt correctly (attemptsMade is 0-based)', async () => {
+    const adapter = bullmq({ connection: baseConnection });
+    const handler = vi.fn().mockResolvedValue(undefined);
+    await adapter.subscribe(handler);
+
+    const payload = makePayload();
+    await capturedProcessor!({ data: payload, id: 'j', attemptsMade: 2 });
+    const envelope = (handler.mock.calls[0] as [{ attempt: number }])[0];
+    expect(envelope.attempt).toBe(3);
+  });
+
+  it('propagates handler rejection so BullMQ can handle retry/DLQ', async () => {
+    const adapter = bullmq({ connection: baseConnection });
+    const boom = new Error('process failed');
+    const handler = vi.fn().mockRejectedValue(boom);
+    await adapter.subscribe(handler);
+
+    await expect(
+      capturedProcessor!({ data: makePayload(), id: 'j', attemptsMade: 0 }),
+    ).rejects.toThrow('process failed');
+  });
+});
+
+describe('bullmq() — close', () => {
+  it('calls close on both queue and worker when both exist', async () => {
+    const adapter = bullmq({ connection: baseConnection });
+    await adapter.enqueue(makePayload());
+    await adapter.subscribe(vi.fn());
+    await adapter.close();
+
+    expect(mockQueueClose).toHaveBeenCalledOnce();
+    expect(mockWorkerClose).toHaveBeenCalledOnce();
+  });
+
+  it('skips worker close when only queue was created', async () => {
+    const adapter = bullmq({ connection: baseConnection });
+    await adapter.enqueue(makePayload());
+    await expect(adapter.close()).resolves.toBeUndefined();
+    expect(mockQueueClose).toHaveBeenCalledOnce();
+    expect(mockWorkerClose).not.toHaveBeenCalled();
+  });
+
+  it('is safe to call before any use', async () => {
+    const adapter = bullmq({ connection: baseConnection });
+    await expect(adapter.close()).resolves.toBeUndefined();
+    expect(mockQueueClose).not.toHaveBeenCalled();
+    expect(mockWorkerClose).not.toHaveBeenCalled();
+  });
+});
+
+describe('bullmq() — connection variants', () => {
+  it('accepts url-based connection', async () => {
+    const adapter = bullmq({ connection: { url: 'redis://localhost:6379' } });
+    await adapter.enqueue(makePayload());
+    expect(mockJobAdd).toHaveBeenCalledOnce();
+  });
+
+  it('accepts host/port/password connection', async () => {
+    const adapter = bullmq({
+      connection: { host: '127.0.0.1', port: 6380, password: 'secret' },
+    });
+    await adapter.enqueue(makePayload());
+    expect(mockJobAdd).toHaveBeenCalledOnce();
   });
 });

--- a/packages/bullmq/src/index.test.ts
+++ b/packages/bullmq/src/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NotifyRpcError } from '@betternotify/core';
 import type { EmailJobPayload } from '@betternotify/core/queue';
 
 const mockJobAdd = vi.fn();
@@ -74,12 +75,14 @@ describe('bullmq() — enqueue', () => {
     expect(opts).toMatchObject({ delay: 5000, priority: 2, jobId: 'custom-id' });
   });
 
-  it('throws when BullMQ returns no job id', async () => {
+  it('throws NotifyRpcError when BullMQ returns no job id', async () => {
     mockJobAdd.mockResolvedValue({ id: undefined });
     const adapter = bullmq({ connection: baseConnection });
-    await expect(adapter.enqueue(makePayload())).rejects.toThrow(
-      'BullMQ enqueued job for route "test.send" but returned no id',
-    );
+    await expect(adapter.enqueue(makePayload())).rejects.toThrow(NotifyRpcError);
+    await expect(adapter.enqueue(makePayload())).rejects.toMatchObject({
+      code: 'PROVIDER',
+      message: 'BullMQ enqueued job for route "test.send" but returned no id',
+    });
   });
 });
 

--- a/packages/bullmq/src/index.test.ts
+++ b/packages/bullmq/src/index.test.ts
@@ -11,6 +11,11 @@ let capturedProcessor:
   | ((job: { data: unknown; id: string; attemptsMade: number }) => Promise<void>)
   | undefined;
 
+vi.mock('ioredis', () => {
+  class FakeIORedis {}
+  return { default: FakeIORedis };
+});
+
 vi.mock('bullmq', () => {
   class FakeQueue {
     add = mockJobAdd;

--- a/packages/bullmq/src/index.ts
+++ b/packages/bullmq/src/index.ts
@@ -1,5 +1,6 @@
 import { Queue, Worker as BullWorker } from 'bullmq';
 import type { ConnectionOptions } from 'bullmq';
+import IORedis from 'ioredis';
 import { NotifyRpcError } from '@betternotify/core';
 import type {
   QueueAdapter,
@@ -28,7 +29,7 @@ const QUEUE_NAME = 'betternotify';
 
 const resolveConnection = (connection: BullmqOptions['connection']): ConnectionOptions => {
   if (typeof connection === 'object' && 'url' in connection) {
-    return connection.url as unknown as ConnectionOptions;
+    return new IORedis(connection.url) as unknown as ConnectionOptions;
   }
   return connection as ConnectionOptions;
 };

--- a/packages/bullmq/src/index.ts
+++ b/packages/bullmq/src/index.ts
@@ -1,9 +1,16 @@
-import { NotifyRpcNotImplementedError } from '@betternotify/core';
-import type { QueueAdapter } from '@betternotify/core/queue';
+import { Queue, Worker as BullWorker } from 'bullmq';
+import type { ConnectionOptions } from 'bullmq';
+import type {
+  QueueAdapter,
+  EmailJobPayload,
+  EnqueueOptions,
+  EnqueueResult,
+  JobHandler,
+} from '@betternotify/core/queue';
 
 /** @experimental BullMQ queue adapter — not yet implemented; ships in v0.3. */
 export type BullmqOptions = {
-  connection: { url: string } | { host: string; port: number; password?: string };
+  connection: { url: string } | { host: string; port: number; password?: string } | ConnectionOptions;
   prefix?: string;
   defaultJobOptions?: {
     attempts?: number;
@@ -13,7 +20,72 @@ export type BullmqOptions = {
   };
 };
 
-/** @experimental BullMQ queue adapter — not yet implemented; ships in v0.3. */
-export const bullmq = (_opts: BullmqOptions): QueueAdapter => {
-  throw new NotifyRpcNotImplementedError('@betternotify/bullmq queue adapter (v0.3)');
+const QUEUE_NAME = 'betternotify';
+
+const resolveConnection = (connection: BullmqOptions['connection']): ConnectionOptions => {
+  if (typeof connection === 'object' && 'url' in connection) {
+    return connection.url as unknown as ConnectionOptions;
+  }
+  return connection as ConnectionOptions;
+};
+
+export const bullmq = (opts: BullmqOptions): QueueAdapter => {
+  const connection = resolveConnection(opts.connection);
+  let queue: Queue | null = null;
+  let worker: BullWorker | null = null;
+
+  const getQueue = (): Queue => {
+    if (!queue) {
+      queue = new Queue(QUEUE_NAME, {
+        connection,
+        prefix: opts.prefix,
+        defaultJobOptions: opts.defaultJobOptions,
+      });
+    }
+    return queue;
+  };
+
+  return {
+    async enqueue(payload: EmailJobPayload, jobOpts?: EnqueueOptions): Promise<EnqueueResult> {
+      const q = getQueue();
+      const job = await q.add(payload.route, payload, {
+        delay: jobOpts?.delay,
+        priority: jobOpts?.priority,
+        jobId: jobOpts?.jobId,
+      });
+      return {
+        jobId: job.id ?? crypto.randomUUID(),
+        route: payload.route,
+        messageId: payload.messageId,
+      };
+    },
+
+    async subscribe(handler: JobHandler): Promise<void> {
+      worker = new BullWorker(
+        QUEUE_NAME,
+        async (job) => {
+          await handler({
+            payload: job.data as EmailJobPayload,
+            attempt: job.attemptsMade + 1,
+            jobId: job.id ?? '',
+          });
+        },
+        {
+          connection,
+          prefix: opts.prefix,
+          autorun: true,
+        },
+      );
+      await worker.waitUntilReady();
+    },
+
+    async close(): Promise<void> {
+      const closers: Promise<void>[] = [];
+      if (queue) closers.push(queue.close());
+      if (worker) closers.push(worker.close());
+      await Promise.all(closers);
+      queue = null;
+      worker = null;
+    },
+  };
 };

--- a/packages/bullmq/src/index.ts
+++ b/packages/bullmq/src/index.ts
@@ -56,8 +56,11 @@ export const bullmq = (opts: BullmqOptions): QueueAdapter => {
         priority: jobOpts?.priority,
         jobId: jobOpts?.jobId,
       });
+      if (!job.id) {
+        throw new Error(`BullMQ enqueued job for route "${payload.route}" but returned no id`);
+      }
       return {
-        jobId: job.id ?? crypto.randomUUID(),
+        jobId: job.id,
         route: payload.route,
         messageId: payload.messageId,
       };
@@ -67,10 +70,11 @@ export const bullmq = (opts: BullmqOptions): QueueAdapter => {
       worker = new BullWorker(
         QUEUE_NAME,
         async (job) => {
+          const jobId = job.id ?? '';
           await handler({
             payload: job.data as EmailJobPayload,
             attempt: job.attemptsMade + 1,
-            jobId: job.id ?? '',
+            jobId,
           });
         },
         {

--- a/packages/bullmq/src/index.ts
+++ b/packages/bullmq/src/index.ts
@@ -1,5 +1,6 @@
 import { Queue, Worker as BullWorker } from 'bullmq';
 import type { ConnectionOptions } from 'bullmq';
+import { NotifyRpcError } from '@betternotify/core';
 import type {
   QueueAdapter,
   EmailJobPayload,
@@ -57,7 +58,12 @@ export const bullmq = (opts: BullmqOptions): QueueAdapter => {
         jobId: jobOpts?.jobId,
       });
       if (!job.id) {
-        throw new Error(`BullMQ enqueued job for route "${payload.route}" but returned no id`);
+        throw new NotifyRpcError({
+          message: `BullMQ enqueued job for route "${payload.route}" but returned no id`,
+          code: 'PROVIDER',
+          route: payload.route,
+          messageId: payload.messageId,
+        });
       }
       return {
         jobId: job.id,

--- a/packages/bullmq/src/index.ts
+++ b/packages/bullmq/src/index.ts
@@ -1,4 +1,5 @@
 import { NotifyRpcNotImplementedError } from '@betternotify/core';
+import type { QueueAdapter } from '@betternotify/core/queue';
 
 /** @experimental BullMQ queue adapter — not yet implemented; ships in v0.3. */
 export type BullmqOptions = {
@@ -13,6 +14,6 @@ export type BullmqOptions = {
 };
 
 /** @experimental BullMQ queue adapter — not yet implemented; ships in v0.3. */
-export const bullmq = (_opts: BullmqOptions): never => {
+export const bullmq = (_opts: BullmqOptions): QueueAdapter => {
   throw new NotifyRpcNotImplementedError('@betternotify/bullmq queue adapter (v0.3)');
 };

--- a/packages/bullmq/src/index.ts
+++ b/packages/bullmq/src/index.ts
@@ -10,7 +10,10 @@ import type {
 
 /** @experimental BullMQ queue adapter — not yet implemented; ships in v0.3. */
 export type BullmqOptions = {
-  connection: { url: string } | { host: string; port: number; password?: string } | ConnectionOptions;
+  connection:
+    | { url: string }
+    | { host: string; port: number; password?: string }
+    | ConnectionOptions;
   prefix?: string;
   defaultJobOptions?: {
     attempts?: number;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./queue": {
+      "types": "./dist/queue.d.ts",
+      "default": "./dist/queue.js"
+    },
     "./worker": {
       "types": "./dist/worker.d.ts",
       "default": "./dist/worker.js"

--- a/packages/core/rolldown.config.ts
+++ b/packages/core/rolldown.config.ts
@@ -3,6 +3,7 @@ import { baseConfig } from '@internal/rolldown-config';
 export default baseConfig({
   entries: {
     index: 'src/index.ts',
+    queue: 'src/queue/index.ts',
     worker: 'src/worker.ts',
     webhook: 'src/webhook.ts',
     transports: 'src/transports/index.ts',

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -297,6 +297,10 @@ export const createClient = <R extends AnyCatalog, Channels extends ChannelMap =
   }
 
   const close = async (): Promise<void> => {
+    if (options.queue) {
+      const [err] = await handlePromise(options.queue.close());
+      if (err) baseLogger.error('queue adapter close failed', { err });
+    }
     for (let i = plugins.length - 1; i >= 0; i--) {
       const plugin = plugins[i];
       if (!plugin) continue;

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -8,6 +8,12 @@ import type { AnyChannel, ChannelDefinition, ChannelMap, TransportsFor } from '.
 import type { Transport, TransportResult } from './transport.js';
 import { consoleLogger, type LoggerLike } from './logger.js';
 import { handlePromise } from './lib/handle-promise.js';
+import type {
+  QueueAdapter,
+  EnqueueOptions,
+  EnqueueResult,
+  EmailJobPayload,
+} from './queue/types.js';
 
 export type ChannelSendResult<TData = unknown> = {
   messageId: string;
@@ -116,6 +122,8 @@ export type CreateClientOptions<R extends AnyCatalog, Channels extends ChannelMa
   catalog: R;
   channels: Channels;
   transportsByChannel: Partial<TransportsFor<Channels>>;
+  /** Queue adapter enabling `.queue()` on route methods. Omitting it leaves `.queue()` throwing CHANNEL_NOT_QUEUEABLE. */
+  queue?: QueueAdapter;
   ctx?: CtxOf<R>;
   hooks?: ClientHooks<R>;
   logger?: LoggerLike;
@@ -143,7 +151,7 @@ type ChannelRouteMethods<TArgs> = {
     entries: ReadonlyArray<TArgs>,
     opts?: BatchOptions,
   ): Promise<BatchResult<ChannelSendResult>>;
-  queue(...args: unknown[]): Promise<never>;
+  queue(args: TArgs, opts?: EnqueueOptions): Promise<EnqueueResult>;
   render(input: unknown, opts?: { ctx?: unknown }): Promise<unknown>;
 };
 
@@ -537,14 +545,22 @@ export const createClient = <R extends AnyCatalog, Channels extends ChannelMap =
         }
         return { okCount, errorCount, results };
       },
-      queue: () =>
-        Promise.reject(
-          new NotifyRpcError({
-            message: `Channel "${channelDef.channel}" does not support queueing.`,
+      queue: async (rawArgs: unknown, queueOpts?: EnqueueOptions): Promise<EnqueueResult> => {
+        if (!options.queue) {
+          throw new NotifyRpcError({
+            message: `No queue adapter configured. Pass queue: adapter to createClient().`,
             code: 'CHANNEL_NOT_QUEUEABLE',
             route: flatKey,
-          }),
-        ),
+          });
+        }
+        const messageId = crypto.randomUUID();
+        const [validateErr, input] = await handlePromise(
+          validate(channelDef.schema, (rawArgs as { input?: unknown })?.input, { route: flatKey }),
+        );
+        if (validateErr) throw validateErr;
+        const payload: EmailJobPayload = { _v: 1, route: flatKey, input, messageId };
+        return options.queue.enqueue(payload, queueOpts);
+      },
       render: async (input: unknown, renderOpts?: { ctx?: unknown }) => {
         const channel = channels[channelDef.channel];
         if (!channel?.previewRender) {

--- a/packages/core/src/queue/index.ts
+++ b/packages/core/src/queue/index.ts
@@ -1,0 +1,8 @@
+export type {
+  EmailJobPayload,
+  EnqueueOptions,
+  EnqueueResult,
+  JobEnvelope,
+  JobHandler,
+  QueueAdapter,
+} from './types.js';

--- a/packages/core/src/queue/types.ts
+++ b/packages/core/src/queue/types.ts
@@ -1,0 +1,70 @@
+/**
+ * Serializable job payload stored in the queue backend.
+ * All fields must be JSON-serializable — no Dates, Buffers, or functions.
+ */
+export type EmailJobPayload = {
+  /** Protocol version — lets workers reject/DLQ payloads from incompatible schema revisions. */
+  readonly _v: 1;
+  /** Dot-path catalog route, e.g. "transactional.welcome". */
+  readonly route: string;
+  /** Validated, JSON-serializable input captured at enqueue time. */
+  readonly input: unknown;
+  /** Originating message ID set by the sender at enqueue time; used for tracing and idempotency. */
+  readonly messageId: string;
+};
+
+/** Per-call options accepted by `.queue(input, opts)`. */
+export type EnqueueOptions = {
+  /** Milliseconds to delay execution from now. */
+  delay?: number;
+  /** Backend priority bucket. Lower values mean higher priority in BullMQ. */
+  priority?: number;
+  /** Caller-supplied stable job ID for deduplication across retries. */
+  jobId?: string;
+};
+
+/** Return value of `.queue()` — confirms the job is durably persisted. */
+export type EnqueueResult = {
+  jobId: string;
+  route: string;
+  messageId: string;
+};
+
+/**
+ * Envelope passed to the worker job handler.
+ * The adapter enriches the raw payload with backend-level metadata.
+ */
+export type JobEnvelope = {
+  payload: EmailJobPayload;
+  /** 1-based attempt number, incremented by the adapter on each retry. */
+  attempt: number;
+  /** Backend-native job ID; matches EnqueueResult.jobId when available. */
+  jobId: string;
+};
+
+/** Function signature for the worker's job handler, called once per job by the adapter. */
+export type JobHandler = (job: JobEnvelope) => Promise<void>;
+
+/**
+ * QueueAdapter — the thin interface between @betternotify/core and a concrete queue backend.
+ *
+ * Implementations (e.g. @betternotify/bullmq) must satisfy this contract.
+ * The adapter owns serialization, retry scheduling, and DLQ routing.
+ */
+export type QueueAdapter = {
+  /**
+   * Persist a job to the queue. Called by the sender's `.queue()` method.
+   * Must resolve with a stable jobId once the job is durably stored.
+   */
+  enqueue(payload: EmailJobPayload, opts?: EnqueueOptions): Promise<EnqueueResult>;
+
+  /**
+   * Begin consuming jobs. The adapter calls `handler` for each ready job,
+   * awaits the returned promise, and handles retry/DLQ on rejection.
+   * Called once by `createWorker()`.
+   */
+  subscribe(handler: JobHandler): Promise<void>;
+
+  /** Drain in-flight jobs and release all backend connections. */
+  close(): Promise<void>;
+};

--- a/packages/core/src/worker.test.ts
+++ b/packages/core/src/worker.test.ts
@@ -6,7 +6,6 @@ import type { AnyCatalog } from './catalog.js';
 import type { QueueAdapter, JobEnvelope, JobHandler } from './queue/types.js';
 import type { Channel } from './channel/types.js';
 
-// Minimal fake channel that renders input as-is
 const fakeChannel: Channel<'fake', any, any, any, any> = {
   name: 'fake',
   createBuilder: () => ({
@@ -69,7 +68,6 @@ const makeTransport = (): Transport & { sent: unknown[] } => {
   };
 };
 
-// In-memory queue adapter: subscribe() registers handler; push() invokes it
 const makeQueue = (): QueueAdapter & { push: (job: JobEnvelope) => Promise<void> } => {
   let subscribedHandler: JobHandler | undefined;
   return {

--- a/packages/core/src/worker.test.ts
+++ b/packages/core/src/worker.test.ts
@@ -1,21 +1,332 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createWorker } from './worker.js';
-import { NotifyRpcNotImplementedError } from './errors.js';
+import { NotifyRpcError, NotifyRpcValidationError } from './errors.js';
 import type { Transport } from './transports/types.js';
 import type { AnyCatalog } from './catalog.js';
-import type { QueueAdapter } from './queue/types.js';
+import type { QueueAdapter, JobEnvelope, JobHandler } from './queue/types.js';
+import type { Channel } from './channel/types.js';
 
-describe('worker stubs', () => {
-  it('createWorker() throws NotifyRpcNotImplementedError', () => {
+// Minimal fake channel that renders input as-is
+const fakeChannel: Channel<'fake', any, any, any, any> = {
+  name: 'fake',
+  createBuilder: () => ({
+    _channel: 'fake',
+    _finalize: (id: string) => ({
+      id,
+      channel: 'fake',
+      schema: {
+        '~standard': {
+          version: 1,
+          vendor: 'fake',
+          validate: (v: unknown) => ({ value: v }),
+        },
+      } as any,
+      middleware: [],
+      runtime: {},
+      _args: undefined as never,
+      _rendered: undefined as never,
+    }),
+  }),
+  finalize: (s: any, id: string) => s._finalize(id),
+  validateArgs: (a: unknown) => a,
+  render: vi.fn().mockResolvedValue({ html: '<p>hello</p>' }),
+  _transport: undefined as never,
+};
+
+const makeCatalog = (route = 'welcome'): AnyCatalog => ({
+  _brand: 'Catalog',
+  _ctx: undefined as never,
+  definitions: {
+    [route]: {
+      id: route,
+      channel: 'fake',
+      schema: {
+        '~standard': {
+          version: 1,
+          vendor: 'fake',
+          validate: (v: unknown) => ({ value: v }),
+        },
+      } as any,
+      middleware: [],
+      runtime: {},
+      _args: undefined as never,
+      _rendered: undefined as never,
+    },
+  },
+  nested: {},
+  routes: [route],
+});
+
+const makeTransport = (): Transport & { sent: unknown[] } => {
+  const sent: unknown[] = [];
+  return {
+    name: 'mock',
+    sent,
+    send: vi.fn(async (rendered) => {
+      sent.push(rendered);
+      return { ok: true as const, data: {} };
+    }),
+  };
+};
+
+// In-memory queue adapter: subscribe() registers handler; push() invokes it
+const makeQueue = (): QueueAdapter & { push: (job: JobEnvelope) => Promise<void> } => {
+  let subscribedHandler: JobHandler | undefined;
+  return {
+    async enqueue() {
+      return { jobId: 'q-1', route: 'welcome', messageId: 'm-1' };
+    },
+    async subscribe(handler) {
+      subscribedHandler = handler;
+    },
+    async close() {},
+    async push(job: JobEnvelope) {
+      if (!subscribedHandler) throw new Error('Worker not started');
+      await subscribedHandler(job);
+    },
+  };
+};
+
+type EnvelopeOverride = { route?: string; attempt?: number; jobId?: string };
+
+const makeEnvelope = (override: EnvelopeOverride = {}): JobEnvelope => ({
+  payload: {
+    _v: 1,
+    route: override.route ?? 'welcome',
+    input: { name: 'Alice' },
+    messageId: 'msg-1',
+  },
+  attempt: override.attempt ?? 1,
+  jobId: override.jobId ?? 'job-1',
+});
+
+describe('createWorker — happy path', () => {
+  it('start() wires subscribe; job flows through render + send', async () => {
+    const catalog = makeCatalog();
+    const transport = makeTransport();
+    const queue = makeQueue();
+    vi.mocked(fakeChannel.render).mockResolvedValue({ html: '<p>hello</p>' });
+
+    const worker = createWorker({ catalog, channels: { fake: fakeChannel }, transport, queue });
+    await worker.start();
+    await queue.push(makeEnvelope());
+
+    expect(transport.send).toHaveBeenCalledOnce();
+    expect(transport.sent[0]).toEqual({ html: '<p>hello</p>' });
+  });
+
+  it('emits completed event after successful processing', async () => {
+    const catalog = makeCatalog();
+    const transport = makeTransport();
+    const queue = makeQueue();
+    vi.mocked(fakeChannel.render).mockResolvedValue({ html: '' });
+
+    const worker = createWorker({ catalog, channels: { fake: fakeChannel }, transport, queue });
+    const completed = vi.fn();
+    worker.on('completed', completed);
+    await worker.start();
+    await queue.push(makeEnvelope());
+
+    expect(completed).toHaveBeenCalledOnce();
+  });
+
+  it('passes context from opts.context to channel.render', async () => {
+    const catalog = makeCatalog();
+    const transport = makeTransport();
+    const queue = makeQueue();
+    const renderFn = vi.fn().mockResolvedValue({ html: '' });
+    vi.mocked(fakeChannel.render).mockImplementation(renderFn);
+
+    const ctx = { requestId: 'req-abc' };
+    const worker = createWorker({
+      catalog,
+      channels: { fake: fakeChannel },
+      transport,
+      queue,
+      context: () => ctx,
+    });
+    await worker.start();
+    const envelope = makeEnvelope();
+    await queue.push(envelope);
+
+    const [, , passedCtx] = renderFn.mock.calls[0] as [unknown, unknown, unknown];
+    expect(passedCtx).toEqual(ctx);
+  });
+
+  it('defaults context to {} when opts.context is omitted', async () => {
+    const catalog = makeCatalog();
+    const transport = makeTransport();
+    const queue = makeQueue();
+    const renderFn = vi.fn().mockResolvedValue({ html: '' });
+    vi.mocked(fakeChannel.render).mockImplementation(renderFn);
+
+    const worker = createWorker({ catalog, channels: { fake: fakeChannel }, transport, queue });
+    await worker.start();
+    await queue.push(makeEnvelope());
+
+    const [, , passedCtx] = renderFn.mock.calls[0] as [unknown, unknown, unknown];
+    expect(passedCtx).toEqual({});
+  });
+});
+
+describe('createWorker — validation failures (DLQ path)', () => {
+  it('throws on payload._v !== 1', async () => {
+    const catalog = makeCatalog();
+    const transport = makeTransport();
+    const queue = makeQueue();
+
+    const worker = createWorker({ catalog, channels: { fake: fakeChannel }, transport, queue });
+    await worker.start();
+
+    const badEnvelope: JobEnvelope = {
+      payload: { _v: 99 as unknown as 1, route: 'welcome', input: {}, messageId: 'm' },
+      attempt: 1,
+      jobId: 'j',
+    };
+    await expect(queue.push(badEnvelope)).rejects.toThrow(NotifyRpcError);
+    expect(transport.send).not.toHaveBeenCalled();
+  });
+
+  it('throws NotifyRpcError on unknown route', async () => {
+    const catalog = makeCatalog('welcome');
+    const transport = makeTransport();
+    const queue = makeQueue();
+
+    const worker = createWorker({ catalog, channels: { fake: fakeChannel }, transport, queue });
+    await worker.start();
+
+    await expect(queue.push(makeEnvelope({ route: 'no.such.route' }))).rejects.toThrow(
+      NotifyRpcError,
+    );
+    expect(transport.send).not.toHaveBeenCalled();
+  });
+
+  it('throws NotifyRpcValidationError when input fails schema validation', async () => {
+    const failingSchema = {
+      '~standard': {
+        version: 1 as const,
+        vendor: 'test',
+        validate: (_v: unknown) => ({
+          issues: [{ message: 'required', path: [{ key: 'name' }] }],
+        }),
+      },
+    };
     const catalog: AnyCatalog = {
       _brand: 'Catalog',
       _ctx: undefined as never,
-      definitions: {},
+      definitions: {
+        welcome: {
+          id: 'welcome',
+          channel: 'fake',
+          schema: failingSchema as any,
+          middleware: [],
+          runtime: {},
+          _args: undefined as never,
+          _rendered: undefined as never,
+        },
+      },
       nested: {},
-      routes: [],
+      routes: ['welcome'],
     };
-    const transport = {} as Transport;
-    const queue = {} as QueueAdapter;
-    expect(() => createWorker({ catalog, transport, queue })).toThrow(NotifyRpcNotImplementedError);
+
+    const transport = makeTransport();
+    const queue = makeQueue();
+
+    const worker = createWorker({ catalog, channels: { fake: fakeChannel }, transport, queue });
+    await worker.start();
+
+    await expect(queue.push(makeEnvelope())).rejects.toThrow(NotifyRpcValidationError);
+    expect(transport.send).not.toHaveBeenCalled();
+  });
+
+  it('throws CONFIG error when channel not registered in channels map', async () => {
+    const catalog = makeCatalog();
+    const transport = makeTransport();
+    const queue = makeQueue();
+
+    const worker = createWorker({ catalog, channels: {}, transport, queue });
+    await worker.start();
+
+    await expect(queue.push(makeEnvelope())).rejects.toThrow(NotifyRpcError);
+    expect(transport.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('createWorker — render failures (DLQ path)', () => {
+  it('wraps render errors in NotifyRpcError with RENDER code', async () => {
+    const catalog = makeCatalog();
+    const transport = makeTransport();
+    const queue = makeQueue();
+    vi.mocked(fakeChannel.render).mockRejectedValue(new Error('template broke'));
+
+    const worker = createWorker({ catalog, channels: { fake: fakeChannel }, transport, queue });
+    await worker.start();
+
+    const err = await queue.push(makeEnvelope()).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(NotifyRpcError);
+    expect((err as NotifyRpcError).code).toBe('RENDER');
+    expect(transport.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('createWorker — transport failures (DLQ path)', () => {
+  it('throws PROVIDER error when transport.send rejects', async () => {
+    const catalog = makeCatalog();
+    const transport = makeTransport();
+    vi.mocked(transport.send).mockRejectedValue(new Error('send boom'));
+    const queue = makeQueue();
+    vi.mocked(fakeChannel.render).mockResolvedValue({ html: '' });
+
+    const worker = createWorker({ catalog, channels: { fake: fakeChannel }, transport, queue });
+    await worker.start();
+
+    const err = await queue.push(makeEnvelope()).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(NotifyRpcError);
+    expect((err as NotifyRpcError).code).toBe('PROVIDER');
+  });
+
+  it('throws PROVIDER error when transport.send returns { ok: false }', async () => {
+    const catalog = makeCatalog();
+    const transport = makeTransport();
+    vi.mocked(transport.send).mockResolvedValue({ ok: false, error: new Error('soft fail') });
+    const queue = makeQueue();
+    vi.mocked(fakeChannel.render).mockResolvedValue({ html: '' });
+
+    const worker = createWorker({ catalog, channels: { fake: fakeChannel }, transport, queue });
+    await worker.start();
+
+    const err = await queue.push(makeEnvelope()).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(NotifyRpcError);
+    expect((err as NotifyRpcError).code).toBe('PROVIDER');
+  });
+
+  it('emits failed event when processing fails', async () => {
+    const catalog = makeCatalog();
+    const transport = makeTransport();
+    const queue = makeQueue();
+    vi.mocked(fakeChannel.render).mockRejectedValue(new Error('boom'));
+
+    const worker = createWorker({ catalog, channels: { fake: fakeChannel }, transport, queue });
+    const failed = vi.fn();
+    worker.on('failed', failed);
+    await worker.start();
+
+    await queue.push(makeEnvelope()).catch(() => {});
+    expect(failed).toHaveBeenCalledOnce();
+  });
+});
+
+describe('createWorker — close', () => {
+  it('close() calls queue.close()', async () => {
+    const catalog = makeCatalog();
+    const transport = makeTransport();
+    const closeSpy = vi.fn().mockResolvedValue(undefined);
+    const queue = { ...makeQueue(), close: closeSpy };
+
+    const worker = createWorker({ catalog, channels: { fake: fakeChannel }, transport, queue });
+    await worker.start();
+    await worker.close();
+
+    expect(closeSpy).toHaveBeenCalledOnce();
   });
 });

--- a/packages/core/src/worker.test.ts
+++ b/packages/core/src/worker.test.ts
@@ -3,6 +3,7 @@ import { createWorker } from './worker.js';
 import { NotifyRpcNotImplementedError } from './errors.js';
 import type { Transport } from './transports/types.js';
 import type { AnyCatalog } from './catalog.js';
+import type { QueueAdapter } from './queue/types.js';
 
 describe('worker stubs', () => {
   it('createWorker() throws NotifyRpcNotImplementedError', () => {
@@ -14,7 +15,7 @@ describe('worker stubs', () => {
       routes: [],
     };
     const transport = {} as Transport;
-    const queue = {};
+    const queue = {} as QueueAdapter;
     expect(() => createWorker({ catalog, transport, queue })).toThrow(NotifyRpcNotImplementedError);
   });
 });

--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -19,7 +19,6 @@ export type CreateWorkerOptions<R extends AnyCatalog, Ctx> = {
   channels: ChannelMap;
   transport: Transport;
   queue: QueueAdapter;
-  concurrency?: number;
   context?: (params: { job: JobEnvelope }) => Ctx;
 };
 
@@ -69,9 +68,24 @@ export const createWorker = <R extends AnyCatalog, Ctx = {}>(
       });
     }
 
-    const ctx = context?.({ job }) ?? ({} as Ctx);
+    let ctx: Ctx;
+    try {
+      ctx = context?.({ job }) ?? ({} as Ctx);
+    } catch (e) {
+      const ctxErr = e instanceof Error ? e : new Error(String(e));
+      throw new NotifyRpcError({
+        message: `Context factory threw for route "${payload.route}": ${ctxErr.message}`,
+        code: 'CONFIG',
+        route: payload.route,
+        messageId: payload.messageId,
+        cause: ctxErr,
+      });
+    }
 
-    const [renderErr, rendered] = await handlePromise(channel.render(def as never, { input }, ctx));
+    const [renderErr, _rendered] = await handlePromise(
+      Promise.resolve().then(() => channel.render(def as never, { input }, ctx)),
+    );
+    const rendered = _rendered as NonNullable<typeof _rendered>;
     if (renderErr) {
       throw new NotifyRpcError({
         message: `Render failed for route "${payload.route}": ${renderErr.message}`,
@@ -88,7 +102,9 @@ export const createWorker = <R extends AnyCatalog, Ctx = {}>(
       attempt: job.attempt,
     };
 
-    const [sendThrow, sendReturn] = await handlePromise(transport.send(rendered, sendCtx));
+    const [sendThrow, sendReturn] = await handlePromise(
+      Promise.resolve().then(() => transport.send(rendered, sendCtx)),
+    );
     const failure: Error | null = sendThrow
       ? sendThrow
       : sendReturn && sendReturn.ok === false
@@ -110,10 +126,18 @@ export const createWorker = <R extends AnyCatalog, Ctx = {}>(
   const handler = async (job: JobEnvelope): Promise<void> => {
     const [err] = await handlePromise(processJob(job));
     if (err) {
-      for (const h of failedHandlers) h(job, err);
+      for (const h of failedHandlers) {
+        try {
+          h(job, err);
+        } catch {}
+      }
       throw err;
     }
-    for (const h of completedHandlers) h(job);
+    for (const h of completedHandlers) {
+      try {
+        h(job);
+      } catch {}
+    }
   };
 
   return {

--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -30,6 +30,7 @@ export const createWorker = <R extends AnyCatalog, Ctx = {}>(
 
   const completedHandlers: Array<(...args: any[]) => void> = [];
   const failedHandlers: Array<(...args: any[]) => void> = [];
+  let startPromise: Promise<void> | null = null;
 
   const processJob = async (job: JobEnvelope): Promise<void> => {
     const { payload } = job;
@@ -53,10 +54,10 @@ export const createWorker = <R extends AnyCatalog, Ctx = {}>(
       });
     }
 
-    const [validateErr, input] = await handlePromise(
+    const validateTuple = await handlePromise(
       validate(def.schema, payload.input, { route: payload.route }),
     );
-    if (validateErr) throw validateErr;
+    if (validateTuple[0]) throw validateTuple[0];
 
     const channel = channels[def.channel] as AnyChannel | undefined;
     if (!channel) {
@@ -82,10 +83,10 @@ export const createWorker = <R extends AnyCatalog, Ctx = {}>(
       });
     }
 
-    const [renderErr, _rendered] = await handlePromise(
-      Promise.resolve().then(() => channel.render(def as never, { input }, ctx)),
+    const renderTuple = await handlePromise(
+      Promise.resolve().then(() => channel.render(def as never, { input: validateTuple[1] }, ctx)),
     );
-    const rendered = _rendered as NonNullable<typeof _rendered>;
+    const renderErr = renderTuple[0];
     if (renderErr) {
       throw new NotifyRpcError({
         message: `Render failed for route "${payload.route}": ${renderErr.message}`,
@@ -95,6 +96,7 @@ export const createWorker = <R extends AnyCatalog, Ctx = {}>(
         cause: renderErr,
       });
     }
+    const rendered = renderTuple[1];
 
     const sendCtx: SendContext = {
       route: payload.route,
@@ -102,9 +104,11 @@ export const createWorker = <R extends AnyCatalog, Ctx = {}>(
       attempt: job.attempt,
     };
 
-    const [sendThrow, sendReturn] = await handlePromise(
+    const sendTuple = await handlePromise(
       Promise.resolve().then(() => transport.send(rendered, sendCtx)),
     );
+    const sendThrow = sendTuple[0];
+    const sendReturn = sendTuple[1];
     const failure: Error | null = sendThrow
       ? sendThrow
       : sendReturn && sendReturn.ok === false
@@ -124,7 +128,8 @@ export const createWorker = <R extends AnyCatalog, Ctx = {}>(
   };
 
   const handler = async (job: JobEnvelope): Promise<void> => {
-    const [err] = await handlePromise(processJob(job));
+    const processTuple = await handlePromise(processJob(job));
+    const err = processTuple[0];
     if (err) {
       for (const h of failedHandlers) {
         try {
@@ -147,7 +152,13 @@ export const createWorker = <R extends AnyCatalog, Ctx = {}>(
     },
 
     async start(): Promise<void> {
-      await queue.subscribe(handler);
+      if (!startPromise) {
+        startPromise = queue.subscribe(handler).catch((err) => {
+          startPromise = null;
+          throw err;
+        });
+      }
+      await startPromise;
     },
 
     async close(): Promise<void> {

--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -6,14 +6,23 @@ import type { AnyChannel, ChannelMap } from './channel/types.js';
 import type { QueueAdapter, JobEnvelope } from './queue/types.js';
 import { handlePromise } from './lib/handle-promise.js';
 
-/** @experimental Layer 5 queue worker — not yet implemented; ships in v0.3. */
+/**
+ * A running notification worker. Call {@link Worker.start | `start()`} to begin consuming jobs
+ * and {@link Worker.close | `close()`} to shut down. Subscribe to `'completed'` and `'failed'`
+ * lifecycle events via {@link Worker.on | `on()`}.
+ */
 export type Worker = {
-  on(event: 'completed' | 'failed', handler: (...args: any[]) => void): void;
+  on(event: 'completed' | 'failed', handler: (...args: any[]) => void | Promise<void>): void;
   start(): Promise<void>;
   close(): Promise<void>;
 };
 
-/** @experimental Layer 5 queue worker — not yet implemented; ships in v0.3. */
+/**
+ * Options for {@link createWorker}.
+ *
+ * @typeParam R - The notification catalog.
+ * @typeParam Ctx - Per-job context type produced by the `context` factory.
+ */
 export type CreateWorkerOptions<R extends AnyCatalog, Ctx> = {
   catalog: R;
   channels: ChannelMap;
@@ -22,7 +31,13 @@ export type CreateWorkerOptions<R extends AnyCatalog, Ctx> = {
   context?: (params: { job: JobEnvelope }) => Ctx;
 };
 
-/** @experimental Layer 5 queue worker — not yet implemented; ships in v0.3. */
+/**
+ * Creates a queue-backed notification worker that validates, renders, and sends
+ * each dequeued job through the provided catalog, channels, and transport.
+ *
+ * @typeParam R - Catalog type to serve.
+ * @typeParam Ctx - Per-job context type returned by `opts.context`.
+ */
 export const createWorker = <R extends AnyCatalog, Ctx = {}>(
   opts: CreateWorkerOptions<R, Ctx>,
 ): Worker => {
@@ -132,16 +147,12 @@ export const createWorker = <R extends AnyCatalog, Ctx = {}>(
     const err = processTuple[0];
     if (err) {
       for (const h of failedHandlers) {
-        try {
-          h(job, err);
-        } catch {}
+        await handlePromise(Promise.resolve().then(() => h(job, err)));
       }
       throw err;
     }
     for (const h of completedHandlers) {
-      try {
-        h(job);
-      } catch {}
+      await handlePromise(Promise.resolve().then(() => h(job)));
     }
   };
 

--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -1,7 +1,10 @@
-import { NotifyRpcNotImplementedError } from './errors.js';
+import { validate } from './schema.js';
+import { NotifyRpcError } from './errors.js';
 import type { AnyCatalog } from './catalog.js';
-import type { Transport } from './transports/types.js';
+import type { Transport, SendContext } from './transport.js';
+import type { AnyChannel, ChannelMap } from './channel/types.js';
 import type { QueueAdapter, JobEnvelope } from './queue/types.js';
+import { handlePromise } from './lib/handle-promise.js';
 
 /** @experimental Layer 5 queue worker — not yet implemented; ships in v0.3. */
 export type Worker = {
@@ -13,6 +16,7 @@ export type Worker = {
 /** @experimental Layer 5 queue worker — not yet implemented; ships in v0.3. */
 export type CreateWorkerOptions<R extends AnyCatalog, Ctx> = {
   catalog: R;
+  channels: ChannelMap;
   transport: Transport;
   queue: QueueAdapter;
   concurrency?: number;
@@ -21,7 +25,111 @@ export type CreateWorkerOptions<R extends AnyCatalog, Ctx> = {
 
 /** @experimental Layer 5 queue worker — not yet implemented; ships in v0.3. */
 export const createWorker = <R extends AnyCatalog, Ctx = {}>(
-  _opts: CreateWorkerOptions<R, Ctx>,
+  opts: CreateWorkerOptions<R, Ctx>,
 ): Worker => {
-  throw new NotifyRpcNotImplementedError('createWorker() (Layer 5)');
+  const { catalog, channels, transport, queue, context } = opts;
+
+  const completedHandlers: Array<(...args: any[]) => void> = [];
+  const failedHandlers: Array<(...args: any[]) => void> = [];
+
+  const processJob = async (job: JobEnvelope): Promise<void> => {
+    const { payload } = job;
+
+    if (payload._v !== 1) {
+      throw new NotifyRpcError({
+        message: `Unsupported job payload version: ${(payload as { _v: unknown })._v}`,
+        code: 'VALIDATION',
+        route: payload.route,
+        messageId: payload.messageId,
+      });
+    }
+
+    const def = catalog.definitions[payload.route];
+    if (!def) {
+      throw new NotifyRpcError({
+        message: `No catalog definition found for route "${payload.route}"`,
+        code: 'CONFIG',
+        route: payload.route,
+        messageId: payload.messageId,
+      });
+    }
+
+    const [validateErr, input] = await handlePromise(
+      validate(def.schema, payload.input, { route: payload.route }),
+    );
+    if (validateErr) throw validateErr;
+
+    const channel = channels[def.channel] as AnyChannel | undefined;
+    if (!channel) {
+      throw new NotifyRpcError({
+        message: `No channel registered for "${def.channel}"`,
+        code: 'CONFIG',
+        route: payload.route,
+        messageId: payload.messageId,
+      });
+    }
+
+    const ctx = context?.({ job }) ?? ({} as Ctx);
+
+    const [renderErr, rendered] = await handlePromise(
+      channel.render(def as never, { input }, ctx),
+    );
+    if (renderErr) {
+      throw new NotifyRpcError({
+        message: `Render failed for route "${payload.route}": ${renderErr.message}`,
+        code: 'RENDER',
+        route: payload.route,
+        messageId: payload.messageId,
+        cause: renderErr,
+      });
+    }
+
+    const sendCtx: SendContext = {
+      route: payload.route,
+      messageId: payload.messageId,
+      attempt: job.attempt,
+    };
+
+    const [sendThrow, sendReturn] = await handlePromise(transport.send(rendered, sendCtx));
+    const failure: Error | null = sendThrow
+      ? sendThrow
+      : sendReturn && sendReturn.ok === false
+        ? sendReturn.error
+        : null;
+    if (failure) {
+      throw failure instanceof NotifyRpcError
+        ? failure
+        : new NotifyRpcError({
+            message: `Transport send failed for route "${payload.route}": ${failure.message}`,
+            code: 'PROVIDER',
+            route: payload.route,
+            messageId: payload.messageId,
+            cause: failure,
+          });
+    }
+  };
+
+  const handler = async (job: JobEnvelope): Promise<void> => {
+    const [err] = await handlePromise(processJob(job));
+    if (err) {
+      for (const h of failedHandlers) h(job, err);
+      throw err;
+    }
+    for (const h of completedHandlers) h(job);
+  };
+
+  return {
+    on(event: 'completed' | 'failed', fn: (...args: any[]) => void): void {
+      if (event === 'completed') completedHandlers.push(fn);
+      else failedHandlers.push(fn);
+    },
+
+    async start(): Promise<void> {
+      await queue.subscribe(handler);
+    },
+
+    async close(): Promise<void> {
+      await queue.close();
+    },
+  };
 };

--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -1,6 +1,7 @@
 import { NotifyRpcNotImplementedError } from './errors.js';
 import type { AnyCatalog } from './catalog.js';
 import type { Transport } from './transports/types.js';
+import type { QueueAdapter, JobEnvelope } from './queue/types.js';
 
 /** @experimental Layer 5 queue worker — not yet implemented; ships in v0.3. */
 export type Worker = {
@@ -13,9 +14,9 @@ export type Worker = {
 export type CreateWorkerOptions<R extends AnyCatalog, Ctx> = {
   catalog: R;
   transport: Transport;
-  queue: unknown;
+  queue: QueueAdapter;
   concurrency?: number;
-  context?: (params: { job: { id: string; attemptsMade: number } }) => Ctx;
+  context?: (params: { job: JobEnvelope }) => Ctx;
 };
 
 /** @experimental Layer 5 queue worker — not yet implemented; ships in v0.3. */

--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -71,9 +71,7 @@ export const createWorker = <R extends AnyCatalog, Ctx = {}>(
 
     const ctx = context?.({ job }) ?? ({} as Ctx);
 
-    const [renderErr, rendered] = await handlePromise(
-      channel.render(def as never, { input }, ctx),
-    );
+    const [renderErr, rendered] = await handlePromise(channel.render(def as never, { input }, ctx));
     if (renderErr) {
       throw new NotifyRpcError({
         message: `Render failed for route "${payload.route}": ${renderErr.message}`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ catalogs:
     '@vitest/coverage-v8':
       specifier: 2.1.9
       version: 2.1.9
+    bullmq:
+      specifier: 5.0.0
+      version: 5.0.0
     fumadocs-core:
       specifier: 16.8.5
       version: 16.8.5
@@ -54,6 +57,9 @@ catalogs:
     fumadocs-ui:
       specifier: 16.8.5
       version: 16.8.5
+    ioredis:
+      specifier: 5.0.0
+      version: 5.0.0
     nodemailer:
       specifier: 8.0.6
       version: 8.0.6
@@ -298,9 +304,21 @@ importers:
       '@internal/tsconfig':
         specifier: workspace:*
         version: link:../../internal/tsconfig
+      bullmq:
+        specifier: 'catalog:'
+        version: 5.0.0
+      ioredis:
+        specifier: 'catalog:'
+        version: 5.0.0
+      ioredis-mock:
+        specifier: ^8.13.1
+        version: 8.13.1(ioredis@5.0.0)
       rolldown:
         specifier: 'catalog:'
         version: 1.0.0-rc.17
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -2068,6 +2086,15 @@ packages:
       '@types/node':
         optional: true
 
+  '@ioredis/as-callback@3.0.0':
+    resolution: {integrity: sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg==}
+
+  '@ioredis/commands@1.5.1':
+    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
+
+  '@ioredis/commands@1.7.0':
+    resolution: {integrity: sha512-5E3KP12g1Po3xMdaym6N3VBibWAH/vv7XxGl8M20KQyPfZWB7sAhLb90+9IX/WJWFHuRFai5caz+DXKQbLI51g==}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -2097,6 +2124,36 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -3579,6 +3636,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  bullmq@5.0.0:
+    resolution: {integrity: sha512-/GhvAB/nUKJMy2NzPCBKvq6yic6wlgaWW1gRCcFpjxP2LWB5TiCOSpsAx2i/9fUuMMa53/ZIKNK+vLO2DT+ZVQ==}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -3665,6 +3725,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
@@ -3744,6 +3808,10 @@ packages:
       typescript:
         optional: true
 
+  cron-parser@4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -3793,6 +3861,10 @@ packages:
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -4006,6 +4078,14 @@ packages:
       picomatch:
         optional: true
 
+  fengari-interop@0.1.4:
+    resolution: {integrity: sha512-4/CW/3PJUo3ebD4ACgE1g/3NGEYSq7OQAyETyypsAl/WeySDBbxExikkayNkZzbpgyC9GyJp8v1DU2VOXxNq7Q==}
+    peerDependencies:
+      fengari: ^0.1.0
+
+  fengari@0.1.5:
+    resolution: {integrity: sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -4031,6 +4111,9 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -4189,6 +4272,11 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
+  glob@8.1.0:
+    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
+    engines: {node: '>=12'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
     engines: {node: '>=18'}
@@ -4285,12 +4373,34 @@ packages:
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   ini@4.1.1:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  ioredis-mock@8.13.1:
+    resolution: {integrity: sha512-Wsi50AU+cMiI32nAgfwpUaJVBtb4iQdVsOHl9M6R3tePCO/8vGsToCVIG82XWAxN4Se55TZoOzVseu+QngFLyw==}
+    engines: {node: '>=12.22'}
+    peerDependencies:
+      '@types/ioredis-mock': ^8
+      ioredis: ^5
+
+  ioredis@5.0.0:
+    resolution: {integrity: sha512-pnHk1RMuyyyOGq5fe8evNuaZG4QMFj9sW9Mdx5EAbK5kJl5ENf1V0MsX5Wc5Cvfzs1kWK4NfECLY+0gC0FQTYQ==}
+    engines: {node: '>=12.22.0'}
+
+  ioredis@5.10.1:
+    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
+    engines: {node: '>=12.22.0'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -4518,6 +4628,12 @@ packages:
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
 
@@ -4541,6 +4657,9 @@ packages:
 
   lodash.upperfirst@4.3.1:
     resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
@@ -4570,6 +4689,10 @@ packages:
     resolution: {integrity: sha512-UOhjdztXCgdBReRcIhsvz2siIBogfv/lhJEIViCpLt924dO+GDms9T7DNoucI23s6kEPpe988m5N0D2ajnzb2g==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -4789,6 +4912,10 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -4823,6 +4950,13 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+
+  msgpackr@1.11.10:
+    resolution: {integrity: sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA==}
+
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -4841,6 +4975,13 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+
+  node-abort-controller@3.1.1:
+    resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
@@ -4875,6 +5016,9 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -5062,6 +5206,10 @@ packages:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
 
+  readline-sync@1.4.10:
+    resolution: {integrity: sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==}
+    engines: {node: '>= 0.8.0'}
+
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
 
@@ -5075,6 +5223,14 @@ packages:
 
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
 
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
@@ -5250,6 +5406,9 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
   srvx@0.11.15:
     resolution: {integrity: sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg==}
     engines: {node: '>=20.16.0'}
@@ -5257,6 +5416,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -5370,6 +5532,10 @@ packages:
   tinyspy@3.0.2:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
+
+  tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -5494,6 +5660,10 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -5679,6 +5849,9 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
@@ -6782,6 +6955,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.17
 
+  '@ioredis/as-callback@3.0.0': {}
+
+  '@ioredis/commands@1.5.1': {}
+
+  '@ioredis/commands@1.7.0': {}
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -6846,6 +7025,24 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    optional: true
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -8055,7 +8252,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.2
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.27.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -8097,6 +8294,20 @@ snapshots:
       electron-to-chromium: 1.5.344
       node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  bullmq@5.0.0:
+    dependencies:
+      cron-parser: 4.9.0
+      glob: 8.1.0
+      ioredis: 5.10.1
+      lodash: 4.18.1
+      msgpackr: 1.11.10
+      node-abort-controller: 3.1.1
+      semver: 7.7.4
+      tslib: 2.8.1
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   cac@6.7.14: {}
 
@@ -8193,6 +8404,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   collapse-white-space@2.1.0: {}
 
   color-convert@2.0.1:
@@ -8270,6 +8483,10 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  cron-parser@4.9.0:
+    dependencies:
+      luxon: 3.7.2
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -8312,6 +8529,8 @@ snapshots:
   deep-eql@5.0.2: {}
 
   deepmerge@4.3.1: {}
+
+  denque@2.1.0: {}
 
   dequal@2.0.3: {}
 
@@ -8671,6 +8890,16 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fengari-interop@0.1.4(fengari@0.1.5):
+    dependencies:
+      fengari: 0.1.5
+
+  fengari@0.1.5:
+    dependencies:
+      readline-sync: 1.4.10
+      sprintf-js: 1.1.3
+      tmp: 0.2.5
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -8694,6 +8923,8 @@ snapshots:
     optionalDependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
+
+  fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -8835,6 +9066,14 @@ snapshots:
       minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
+
+  glob@8.1.0:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 5.1.9
+      once: 1.4.0
 
   global-directory@4.0.1:
     dependencies:
@@ -9006,9 +9245,53 @@ snapshots:
 
   import-meta-resolve@4.2.0: {}
 
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
   ini@4.1.1: {}
 
   inline-style-parser@0.2.7: {}
+
+  ioredis-mock@8.13.1(ioredis@5.0.0):
+    dependencies:
+      '@ioredis/as-callback': 3.0.0
+      '@ioredis/commands': 1.7.0
+      fengari: 0.1.5
+      fengari-interop: 0.1.4(fengari@0.1.5)
+      ioredis: 5.0.0
+      semver: 7.7.4
+
+  ioredis@5.0.0:
+    dependencies:
+      '@ioredis/commands': 1.7.0
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  ioredis@5.10.1:
+    dependencies:
+      '@ioredis/commands': 1.5.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   is-alphabetical@2.0.1: {}
 
@@ -9171,6 +9454,10 @@ snapshots:
 
   lodash.camelcase@4.3.0: {}
 
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
+
   lodash.isplainobject@4.0.6: {}
 
   lodash.kebabcase@4.1.1: {}
@@ -9186,6 +9473,8 @@ snapshots:
   lodash.uniq@4.5.0: {}
 
   lodash.upperfirst@4.3.1: {}
+
+  lodash@4.18.1: {}
 
   log-symbols@6.0.0:
     dependencies:
@@ -9212,6 +9501,8 @@ snapshots:
   lucide-react@1.11.0(react@19.2.5):
     dependencies:
       react: 19.2.5
+
+  luxon@3.7.2: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -9698,6 +9989,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.5
 
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.0
@@ -9722,6 +10017,22 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msgpackr-extract@3.0.3:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    optional: true
+
+  msgpackr@1.11.10:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
+
   mute-stream@2.0.0: {}
 
   nanoid@3.3.11: {}
@@ -9732,6 +10043,13 @@ snapshots:
     dependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
+
+  node-abort-controller@3.1.1: {}
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   node-releases@2.0.38: {}
 
@@ -9758,6 +10076,10 @@ snapshots:
   object-treeify@1.1.33: {}
 
   obug@2.1.1: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@5.1.2:
     dependencies:
@@ -10002,6 +10324,8 @@ snapshots:
 
   readdirp@5.0.0: {}
 
+  readline-sync@1.4.10: {}
+
   recma-build-jsx@1.0.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -10030,6 +10354,12 @@ snapshots:
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
+
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
 
   regex-recursion@6.0.2:
     dependencies:
@@ -10307,9 +10637,13 @@ snapshots:
 
   split2@4.2.0: {}
 
+  sprintf-js@1.1.3: {}
+
   srvx@0.11.15: {}
 
   stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
 
   std-env@3.10.0: {}
 
@@ -10406,6 +10740,8 @@ snapshots:
   tinyrainbow@1.2.0: {}
 
   tinyspy@3.0.2: {}
+
+  tmp@0.2.5: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -10535,6 +10871,8 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.5):
     dependencies:
       react: 19.2.5
+
+  uuid@9.0.1: {}
 
   vary@1.1.2: {}
 
@@ -10700,6 +11038,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.2.0
+
+  wrappy@1.0.2: {}
 
   ws@8.18.0: {}
 


### PR DESCRIPTION
## Summary

Implements the full queue layer across two commits:

**Commit 1 — Queue contract & types (BET-15)**
- `packages/core/src/queue/types.ts`: `QueueAdapter`, `EmailJobPayload` (versioned `_v:1`), `EnqueueOptions`, `EnqueueResult`, `JobEnvelope`, `JobHandler`
- `@betternotify/core/queue` subpath export (package.json + rolldown entry)
- `createClient().queue()`: validates, builds payload, calls `adapter.enqueue()`
- `createWorker` typed against `QueueAdapter` / `JobEnvelope`

**Commit 2 — BullMQ adapter + createWorker runtime (BET-49)**
- `@betternotify/bullmq`: replaces stub with real `Queue.add()` / `BullWorker` implementation; connection accepts `{ url }`, `{ host, port, password }`, or raw `ConnectionOptions`
- `createWorker` runtime: validates `_v === 1`, resolves catalog route, validates input against schema, renders, and sends via transport; schema mismatches and validation failures throw to trigger adapter DLQ
- 12 BullMQ unit tests (vi.mock) + 22 `createWorker` tests via in-memory queue adapter covering happy path, all DLQ paths, and lifecycle events

## Design rationale

`QueueAdapter` is intentionally minimal — three methods (`enqueue`, `subscribe`, `close`). Adapters own retry/DLQ policy; core owns payload validation and route resolution. The `_v` discriminator on `EmailJobPayload` lets workers reject payloads from mismatched schema versions rather than crashing silently.

## Test plan

- [x] `pnpm build` — all packages build cleanly
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm test` — 442/442 pass (60 test files)
- [x] Rebased onto main (`37af0f5`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-class queue support: per-route .queue API, typed queue contracts, worker lifecycle (start/close), and runtime enqueue/processing validation.
  * BullMQ-backed adapter: enqueue/subscribe with delay/priority/jobId, returns job acknowledgements, and supports URL or connection-object configs.
  * Package exports/build updated to expose the queue module.

* **Tests**
  * Comprehensive tests for adapter enqueue/subscribe/close and worker processing, retries, DLQ and error scenarios.

* **Chore**
  * Prettier ignore rule added for generated route files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->