### PR TITLE
docs: add implementation status matrix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,43 @@ Each channel package re-exports these factories pre-parameterized for that chann
 | `@betternotify/resend`      | Resend transport (stub)                                                                                                                                                                                                                    |
 | `@betternotify/bullmq`      | BullMQ queue adapter (stub)                                                                                                                                                                                                                |
 
+## Implementation status
+
+✅ = ships and works today · 🚧 = package is published but throws `NotImplementedError` at runtime
+
+### Packages
+
+| Package                     | Status | Planned |
+| --------------------------- | ------ | ------- |
+| `@betternotify/core`        | ✅     | —       |
+| `@betternotify/email`       | ✅     | —       |
+| `@betternotify/sms`         | ✅     | —       |
+| `@betternotify/push`        | ✅     | —       |
+| `@betternotify/smtp`        | ✅     | —       |
+| `@betternotify/react-email` | ✅     | —       |
+| `@betternotify/ses`         | 🚧     | v0.3    |
+| `@betternotify/resend`      | 🚧     | v0.3    |
+| `@betternotify/bullmq`      | 🚧     | v0.3    |
+| `@betternotify/mjml`        | 🚧     | v0.4    |
+| `@betternotify/handlebars`  | 🚧     | v0.4    |
+
+### Core APIs
+
+| Feature                                                                                                          | Subpath export                   | Status | Planned |
+| ---------------------------------------------------------------------------------------------------------------- | -------------------------------- | ------ | ------- |
+| Channel contracts (`Channel<>`, `defineChannel`, `slot`)                                                         | `@betternotify/core`             | ✅     | —       |
+| Catalog builder (`createNotify`, `createCatalog`)                                                                | `@betternotify/core`             | ✅     | —       |
+| Typed client (`createClient`, `.send()`, `.batch()`)                                                             | `@betternotify/core`             | ✅     | —       |
+| Middleware (`withDryRun`, `withRateLimit`, `withIdempotency`, `withEventLogger`, `withTagInject`, `withTracing`) | `@betternotify/core/middlewares` | ✅     | —       |
+| Suppression-list middleware (`withSuppressionList`)                                                              | `@betternotify/email`            | ✅     | —       |
+| Stores (idempotency, rate-limit, suppression)                                                                    | `@betternotify/core/stores`      | ✅     | —       |
+| Event sinks (`inMemoryEventSink`, `consoleEventSink`)                                                            | `@betternotify/core/sinks`       | ✅     | —       |
+| Tracing (`inMemoryTracer`)                                                                                       | `@betternotify/core/tracers`     | ✅     | —       |
+| Logger (`consoleLogger`, `fromPino`)                                                                             | `@betternotify/core/logger`      | ✅     | —       |
+| Config (`defineConfig`)                                                                                          | `@betternotify/core/config`      | ✅     | —       |
+| Queue worker (`createWorker`)                                                                                    | `@betternotify/core/worker`      | 🚧     | v0.3    |
+| Webhook router (`toNodeHandler`, `toFetchHandler`)                                                               | `@betternotify/core/webhook`     | 🚧     | v0.3    |
+
 ## Development
 
 ```sh

--- a/packages/bullmq/CHANGELOG.md
+++ b/packages/bullmq/CHANGELOG.md
@@ -2,22 +2,19 @@
 
 ## [0.0.3-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/bullmq-v0.0.2-alpha.0...@betternotify/bullmq-v0.0.3-alpha.0) (2026-04-27)
 
-
 ### Bug Fixes
 
-* add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
+- add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
 
 ## [0.0.2-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/bullmq-v0.0.1-alpha.0...@betternotify/bullmq-v0.0.2-alpha.0) (2026-04-27)
 
-
 ### Features
 
-* add configuration files for oxlint and oxfmt, and introduce CLAUDE.md for project guidance ([7ecbb27](https://github.com/better-notify/better-notify/commit/7ecbb27a1a9c22a007d8dee89c0f3326c151795c))
-* bootstrap emailRpc monorepo with Layer 1 contracts ([4976d61](https://github.com/better-notify/better-notify/commit/4976d61fbf569c0882b4d9d7b3c0419623d7a03b))
-* **core:** add LoggerLike, consoleLogger, and fromPino ([e5e88bc](https://github.com/better-notify/better-notify/commit/e5e88bc685a288d13e13336bf6ad3792765c19b4))
-* **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
-
+- add configuration files for oxlint and oxfmt, and introduce CLAUDE.md for project guidance ([7ecbb27](https://github.com/better-notify/better-notify/commit/7ecbb27a1a9c22a007d8dee89c0f3326c151795c))
+- bootstrap emailRpc monorepo with Layer 1 contracts ([4976d61](https://github.com/better-notify/better-notify/commit/4976d61fbf569c0882b4d9d7b3c0419623d7a03b))
+- **core:** add LoggerLike, consoleLogger, and fromPino ([e5e88bc](https://github.com/better-notify/better-notify/commit/e5e88bc685a288d13e13336bf6ad3792765c19b4))
+- **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
 
 ### Bug Fixes
 
-* use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))
+- use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,27 +2,24 @@
 
 ## [0.0.3-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/core-v0.0.2-alpha.0...@betternotify/core-v0.0.3-alpha.0) (2026-04-27)
 
-
 ### Bug Fixes
 
-* add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
+- add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
 
 ## [0.0.2-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/core-v0.0.1-alpha.0...@betternotify/core-v0.0.2-alpha.0) (2026-04-27)
 
-
 ### Features
 
-* add configuration files for oxlint and oxfmt, and introduce CLAUDE.md for project guidance ([7ecbb27](https://github.com/better-notify/better-notify/commit/7ecbb27a1a9c22a007d8dee89c0f3326c151795c))
-* bootstrap emailRpc monorepo with Layer 1 contracts ([4976d61](https://github.com/better-notify/better-notify/commit/4976d61fbf569c0882b4d9d7b3c0419623d7a03b))
-* **core:** add client types and handlePromise utility ([19a5226](https://github.com/better-notify/better-notify/commit/19a5226355d3d6cd65aab9306f8da8a35e948117))
-* **core:** add LoggerLike, consoleLogger, and fromPino ([e5e88bc](https://github.com/better-notify/better-notify/commit/e5e88bc685a288d13e13336bf6ad3792765c19b4))
-* **core:** add memoryLogger test helper ([07c37af](https://github.com/better-notify/better-notify/commit/07c37af5cef5824bf99248ebd47548a6469edc31))
-* **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
-* **core:** implement createClient with executeRender and executeSend ([a7a5108](https://github.com/better-notify/better-notify/commit/a7a51083945662ec97032f1dbd75e9433d9ab8f6))
-* **core:** wire built-in logger through createClient send pipeline ([ba79e59](https://github.com/better-notify/better-notify/commit/ba79e594286ee7434ad6f0adec12a4e7d55ecf3e))
-* wip ([075e566](https://github.com/better-notify/better-notify/commit/075e566817bab3ac5a83d5928c833188ba446ec7))
-
+- add configuration files for oxlint and oxfmt, and introduce CLAUDE.md for project guidance ([7ecbb27](https://github.com/better-notify/better-notify/commit/7ecbb27a1a9c22a007d8dee89c0f3326c151795c))
+- bootstrap emailRpc monorepo with Layer 1 contracts ([4976d61](https://github.com/better-notify/better-notify/commit/4976d61fbf569c0882b4d9d7b3c0419623d7a03b))
+- **core:** add client types and handlePromise utility ([19a5226](https://github.com/better-notify/better-notify/commit/19a5226355d3d6cd65aab9306f8da8a35e948117))
+- **core:** add LoggerLike, consoleLogger, and fromPino ([e5e88bc](https://github.com/better-notify/better-notify/commit/e5e88bc685a288d13e13336bf6ad3792765c19b4))
+- **core:** add memoryLogger test helper ([07c37af](https://github.com/better-notify/better-notify/commit/07c37af5cef5824bf99248ebd47548a6469edc31))
+- **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
+- **core:** implement createClient with executeRender and executeSend ([a7a5108](https://github.com/better-notify/better-notify/commit/a7a51083945662ec97032f1dbd75e9433d9ab8f6))
+- **core:** wire built-in logger through createClient send pipeline ([ba79e59](https://github.com/better-notify/better-notify/commit/ba79e594286ee7434ad6f0adec12a4e7d55ecf3e))
+- wip ([075e566](https://github.com/better-notify/better-notify/commit/075e566817bab3ac5a83d5928c833188ba446ec7))
 
 ### Bug Fixes
 
-* use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))
+- use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))

--- a/packages/core/src/channel/define-channel.ts
+++ b/packages/core/src/channel/define-channel.ts
@@ -121,7 +121,7 @@ const buildBuilder = <
     buildBuilder<TInput, TSlotValues, TSlotConfig, TArgsBase, TRendered>(channelName, slots, {
       ...state,
       ...patch,
-      runtime: { ...state.runtime, ...(patch.runtime ?? {}) },
+      runtime: { ...state.runtime, ...patch.runtime },
     });
 
   const builder: Record<string | symbol, unknown> = {

--- a/packages/email/CHANGELOG.md
+++ b/packages/email/CHANGELOG.md
@@ -2,19 +2,16 @@
 
 ## [0.0.3-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/email-v0.0.2-alpha.0...@betternotify/email-v0.0.3-alpha.0) (2026-04-27)
 
-
 ### Bug Fixes
 
-* add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
+- add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
 
 ## [0.0.2-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/email-v0.0.1-alpha.0...@betternotify/email-v0.0.2-alpha.0) (2026-04-27)
 
-
 ### Features
 
-* **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
-
+- **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
 
 ### Bug Fixes
 
-* use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))
+- use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))

--- a/packages/email/src/channel.ts
+++ b/packages/email/src/channel.ts
@@ -65,8 +65,8 @@ export const emailChannel = (options: EmailChannelOptions = {}) =>
       const from = resolveFrom(args.from ?? runtime.from, options.defaults?.from);
       const replyTo = args.replyTo ?? runtime.replyTo ?? options.defaults?.replyTo;
       const mergedHeaders = {
-        ...(options.defaults?.headers ?? {}),
-        ...(args.headers ?? {}),
+        ...options.defaults?.headers,
+        ...args.headers,
       };
 
       const message: RenderedMessage = {

--- a/packages/handlebars/CHANGELOG.md
+++ b/packages/handlebars/CHANGELOG.md
@@ -2,23 +2,20 @@
 
 ## [0.0.3-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/handlebars-v0.0.2-alpha.0...@betternotify/handlebars-v0.0.3-alpha.0) (2026-04-27)
 
-
 ### Bug Fixes
 
-* add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
+- add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
 
 ## [0.0.2-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/handlebars-v0.0.1-alpha.0...@betternotify/handlebars-v0.0.2-alpha.0) (2026-04-27)
 
-
 ### Features
 
-* add configuration files for oxlint and oxfmt, and introduce CLAUDE.md for project guidance ([7ecbb27](https://github.com/better-notify/better-notify/commit/7ecbb27a1a9c22a007d8dee89c0f3326c151795c))
-* bootstrap emailRpc monorepo with Layer 1 contracts ([4976d61](https://github.com/better-notify/better-notify/commit/4976d61fbf569c0882b4d9d7b3c0419623d7a03b))
-* **core:** add LoggerLike, consoleLogger, and fromPino ([e5e88bc](https://github.com/better-notify/better-notify/commit/e5e88bc685a288d13e13336bf6ad3792765c19b4))
-* **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
-* wip ([075e566](https://github.com/better-notify/better-notify/commit/075e566817bab3ac5a83d5928c833188ba446ec7))
-
+- add configuration files for oxlint and oxfmt, and introduce CLAUDE.md for project guidance ([7ecbb27](https://github.com/better-notify/better-notify/commit/7ecbb27a1a9c22a007d8dee89c0f3326c151795c))
+- bootstrap emailRpc monorepo with Layer 1 contracts ([4976d61](https://github.com/better-notify/better-notify/commit/4976d61fbf569c0882b4d9d7b3c0419623d7a03b))
+- **core:** add LoggerLike, consoleLogger, and fromPino ([e5e88bc](https://github.com/better-notify/better-notify/commit/e5e88bc685a288d13e13336bf6ad3792765c19b4))
+- **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
+- wip ([075e566](https://github.com/better-notify/better-notify/commit/075e566817bab3ac5a83d5928c833188ba446ec7))
 
 ### Bug Fixes
 
-* use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))
+- use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))

--- a/packages/mjml/CHANGELOG.md
+++ b/packages/mjml/CHANGELOG.md
@@ -2,23 +2,20 @@
 
 ## [0.0.3-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/mjml-v0.0.2-alpha.0...@betternotify/mjml-v0.0.3-alpha.0) (2026-04-27)
 
-
 ### Bug Fixes
 
-* add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
+- add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
 
 ## [0.0.2-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/mjml-v0.0.1-alpha.0...@betternotify/mjml-v0.0.2-alpha.0) (2026-04-27)
 
-
 ### Features
 
-* add configuration files for oxlint and oxfmt, and introduce CLAUDE.md for project guidance ([7ecbb27](https://github.com/better-notify/better-notify/commit/7ecbb27a1a9c22a007d8dee89c0f3326c151795c))
-* bootstrap emailRpc monorepo with Layer 1 contracts ([4976d61](https://github.com/better-notify/better-notify/commit/4976d61fbf569c0882b4d9d7b3c0419623d7a03b))
-* **core:** add LoggerLike, consoleLogger, and fromPino ([e5e88bc](https://github.com/better-notify/better-notify/commit/e5e88bc685a288d13e13336bf6ad3792765c19b4))
-* **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
-* wip ([075e566](https://github.com/better-notify/better-notify/commit/075e566817bab3ac5a83d5928c833188ba446ec7))
-
+- add configuration files for oxlint and oxfmt, and introduce CLAUDE.md for project guidance ([7ecbb27](https://github.com/better-notify/better-notify/commit/7ecbb27a1a9c22a007d8dee89c0f3326c151795c))
+- bootstrap emailRpc monorepo with Layer 1 contracts ([4976d61](https://github.com/better-notify/better-notify/commit/4976d61fbf569c0882b4d9d7b3c0419623d7a03b))
+- **core:** add LoggerLike, consoleLogger, and fromPino ([e5e88bc](https://github.com/better-notify/better-notify/commit/e5e88bc685a288d13e13336bf6ad3792765c19b4))
+- **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
+- wip ([075e566](https://github.com/better-notify/better-notify/commit/075e566817bab3ac5a83d5928c833188ba446ec7))
 
 ### Bug Fixes
 
-* use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))
+- use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))

--- a/packages/push/CHANGELOG.md
+++ b/packages/push/CHANGELOG.md
@@ -2,19 +2,16 @@
 
 ## [0.0.3-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/push-v0.0.2-alpha.0...@betternotify/push-v0.0.3-alpha.0) (2026-04-27)
 
-
 ### Bug Fixes
 
-* add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
+- add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
 
 ## [0.0.2-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/push-v0.0.1-alpha.0...@betternotify/push-v0.0.2-alpha.0) (2026-04-27)
 
-
 ### Features
 
-* **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
-
+- **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
 
 ### Bug Fixes
 
-* use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))
+- use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))

--- a/packages/react-email/CHANGELOG.md
+++ b/packages/react-email/CHANGELOG.md
@@ -2,23 +2,20 @@
 
 ## [0.0.3-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/react-email-v0.0.2-alpha.0...@betternotify/react-email-v0.0.3-alpha.0) (2026-04-27)
 
-
 ### Bug Fixes
 
-* add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
+- add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
 
 ## [0.0.2-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/react-email-v0.0.1-alpha.0...@betternotify/react-email-v0.0.2-alpha.0) (2026-04-27)
 
-
 ### Features
 
-* add configuration files for oxlint and oxfmt, and introduce CLAUDE.md for project guidance ([7ecbb27](https://github.com/better-notify/better-notify/commit/7ecbb27a1a9c22a007d8dee89c0f3326c151795c))
-* bootstrap emailRpc monorepo with Layer 1 contracts ([4976d61](https://github.com/better-notify/better-notify/commit/4976d61fbf569c0882b4d9d7b3c0419623d7a03b))
-* **core:** add LoggerLike, consoleLogger, and fromPino ([e5e88bc](https://github.com/better-notify/better-notify/commit/e5e88bc685a288d13e13336bf6ad3792765c19b4))
-* **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
-* wip ([075e566](https://github.com/better-notify/better-notify/commit/075e566817bab3ac5a83d5928c833188ba446ec7))
-
+- add configuration files for oxlint and oxfmt, and introduce CLAUDE.md for project guidance ([7ecbb27](https://github.com/better-notify/better-notify/commit/7ecbb27a1a9c22a007d8dee89c0f3326c151795c))
+- bootstrap emailRpc monorepo with Layer 1 contracts ([4976d61](https://github.com/better-notify/better-notify/commit/4976d61fbf569c0882b4d9d7b3c0419623d7a03b))
+- **core:** add LoggerLike, consoleLogger, and fromPino ([e5e88bc](https://github.com/better-notify/better-notify/commit/e5e88bc685a288d13e13336bf6ad3792765c19b4))
+- **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
+- wip ([075e566](https://github.com/better-notify/better-notify/commit/075e566817bab3ac5a83d5928c833188ba446ec7))
 
 ### Bug Fixes
 
-* use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))
+- use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))

--- a/packages/resend/CHANGELOG.md
+++ b/packages/resend/CHANGELOG.md
@@ -2,23 +2,20 @@
 
 ## [0.0.3-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/resend-v0.0.2-alpha.0...@betternotify/resend-v0.0.3-alpha.0) (2026-04-27)
 
-
 ### Bug Fixes
 
-* add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
+- add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
 
 ## [0.0.2-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/resend-v0.0.1-alpha.0...@betternotify/resend-v0.0.2-alpha.0) (2026-04-27)
 
-
 ### Features
 
-* add configuration files for oxlint and oxfmt, and introduce CLAUDE.md for project guidance ([7ecbb27](https://github.com/better-notify/better-notify/commit/7ecbb27a1a9c22a007d8dee89c0f3326c151795c))
-* bootstrap emailRpc monorepo with Layer 1 contracts ([4976d61](https://github.com/better-notify/better-notify/commit/4976d61fbf569c0882b4d9d7b3c0419623d7a03b))
-* **core:** add LoggerLike, consoleLogger, and fromPino ([e5e88bc](https://github.com/better-notify/better-notify/commit/e5e88bc685a288d13e13336bf6ad3792765c19b4))
-* **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
-* wip ([075e566](https://github.com/better-notify/better-notify/commit/075e566817bab3ac5a83d5928c833188ba446ec7))
-
+- add configuration files for oxlint and oxfmt, and introduce CLAUDE.md for project guidance ([7ecbb27](https://github.com/better-notify/better-notify/commit/7ecbb27a1a9c22a007d8dee89c0f3326c151795c))
+- bootstrap emailRpc monorepo with Layer 1 contracts ([4976d61](https://github.com/better-notify/better-notify/commit/4976d61fbf569c0882b4d9d7b3c0419623d7a03b))
+- **core:** add LoggerLike, consoleLogger, and fromPino ([e5e88bc](https://github.com/better-notify/better-notify/commit/e5e88bc685a288d13e13336bf6ad3792765c19b4))
+- **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
+- wip ([075e566](https://github.com/better-notify/better-notify/commit/075e566817bab3ac5a83d5928c833188ba446ec7))
 
 ### Bug Fixes
 
-* use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))
+- use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))

--- a/packages/ses/CHANGELOG.md
+++ b/packages/ses/CHANGELOG.md
@@ -2,23 +2,20 @@
 
 ## [0.0.3-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/ses-v0.0.2-alpha.0...@betternotify/ses-v0.0.3-alpha.0) (2026-04-27)
 
-
 ### Bug Fixes
 
-* add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
+- add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
 
 ## [0.0.2-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/ses-v0.0.1-alpha.0...@betternotify/ses-v0.0.2-alpha.0) (2026-04-27)
 
-
 ### Features
 
-* add configuration files for oxlint and oxfmt, and introduce CLAUDE.md for project guidance ([7ecbb27](https://github.com/better-notify/better-notify/commit/7ecbb27a1a9c22a007d8dee89c0f3326c151795c))
-* bootstrap emailRpc monorepo with Layer 1 contracts ([4976d61](https://github.com/better-notify/better-notify/commit/4976d61fbf569c0882b4d9d7b3c0419623d7a03b))
-* **core:** add LoggerLike, consoleLogger, and fromPino ([e5e88bc](https://github.com/better-notify/better-notify/commit/e5e88bc685a288d13e13336bf6ad3792765c19b4))
-* **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
-* wip ([075e566](https://github.com/better-notify/better-notify/commit/075e566817bab3ac5a83d5928c833188ba446ec7))
-
+- add configuration files for oxlint and oxfmt, and introduce CLAUDE.md for project guidance ([7ecbb27](https://github.com/better-notify/better-notify/commit/7ecbb27a1a9c22a007d8dee89c0f3326c151795c))
+- bootstrap emailRpc monorepo with Layer 1 contracts ([4976d61](https://github.com/better-notify/better-notify/commit/4976d61fbf569c0882b4d9d7b3c0419623d7a03b))
+- **core:** add LoggerLike, consoleLogger, and fromPino ([e5e88bc](https://github.com/better-notify/better-notify/commit/e5e88bc685a288d13e13336bf6ad3792765c19b4))
+- **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
+- wip ([075e566](https://github.com/better-notify/better-notify/commit/075e566817bab3ac5a83d5928c833188ba446ec7))
 
 ### Bug Fixes
 
-* use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))
+- use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))

--- a/packages/sms/CHANGELOG.md
+++ b/packages/sms/CHANGELOG.md
@@ -2,19 +2,16 @@
 
 ## [0.0.3-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/sms-v0.0.2-alpha.0...@betternotify/sms-v0.0.3-alpha.0) (2026-04-27)
 
-
 ### Bug Fixes
 
-* add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
+- add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
 
 ## [0.0.2-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/sms-v0.0.1-alpha.0...@betternotify/sms-v0.0.2-alpha.0) (2026-04-27)
 
-
 ### Features
 
-* **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
-
+- **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
 
 ### Bug Fixes
 
-* use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))
+- use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))

--- a/packages/smtp/CHANGELOG.md
+++ b/packages/smtp/CHANGELOG.md
@@ -2,20 +2,17 @@
 
 ## [0.0.3-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/smtp-v0.0.2-alpha.0...@betternotify/smtp-v0.0.3-alpha.0) (2026-04-27)
 
-
 ### Bug Fixes
 
-* add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
+- add repository field and ci improvements ([#7](https://github.com/better-notify/better-notify/issues/7)) ([b3212f0](https://github.com/better-notify/better-notify/commit/b3212f03e4ca49a15fb602748d2f38a8237c3f21))
 
 ## [0.0.2-alpha.0](https://github.com/better-notify/better-notify/compare/@betternotify/smtp-v0.0.1-alpha.0...@betternotify/smtp-v0.0.2-alpha.0) (2026-04-27)
 
-
 ### Features
 
-* **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
-* wip ([075e566](https://github.com/better-notify/better-notify/commit/075e566817bab3ac5a83d5928c833188ba446ec7))
-
+- **core:** add race, parallel, and mirrored strategies to multiTransport ([f9fdd59](https://github.com/better-notify/better-notify/commit/f9fdd595b3cdbbfce9a89d2ae65522dab6a863df))
+- wip ([075e566](https://github.com/better-notify/better-notify/commit/075e566817bab3ac5a83d5928c833188ba446ec7))
 
 ### Bug Fixes
 
-* use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))
+- use alpha prerelease versions for release-please ([#6](https://github.com/better-notify/better-notify/issues/6)) ([b0364cb](https://github.com/better-notify/better-notify/commit/b0364cbbb030e79a376bf523e88c043a444323a1))


### PR DESCRIPTION
## Summary

- Adds an `## Implementation status` section to the README with two tables: one for packages and one for core APIs
- Clearly separates what ships and works today (✅) from what is published-but-stub-at-runtime (🚧), with planned target versions for each stub entry
- Incidentally applies oxlint auto-fix corrections (`?? {}` spreads) and oxfmt CHANGELOG formatting surfaced by the quality gate run

Closes BET-43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)