### PR TITLE
docs: mark unstable API surfaces with @experimental

### DIFF
--- a/packages/bullmq/src/index.ts
+++ b/packages/bullmq/src/index.ts
@@ -1,5 +1,6 @@
 import { NotifyRpcNotImplementedError } from '@betternotify/core';
 
+/** @experimental BullMQ queue adapter — not yet implemented; ships in v0.3. */
 export type BullmqOptions = {
   connection: { url: string } | { host: string; port: number; password?: string };
   prefix?: string;
@@ -11,6 +12,7 @@ export type BullmqOptions = {
   };
 };
 
+/** @experimental BullMQ queue adapter — not yet implemented; ships in v0.3. */
 export const bullmq = (_opts: BullmqOptions): never => {
   throw new NotifyRpcNotImplementedError('@betternotify/bullmq queue adapter (v0.3)');
 };

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,3 +1,4 @@
+/** @experimental Config-file-driven setup — not yet implemented; ships in a future release. */
 export type NotifyRpcConfig = {
   router: string;
   transport: string;
@@ -11,6 +12,7 @@ export type NotifyRpcConfig = {
   };
 };
 
+/** @experimental Config-file-driven setup — not yet implemented; ships in a future release. */
 export const defineConfig = (config: NotifyRpcConfig): NotifyRpcConfig => {
   return config;
 };

--- a/packages/core/src/webhook.ts
+++ b/packages/core/src/webhook.ts
@@ -1,20 +1,24 @@
 import { NotifyRpcNotImplementedError } from './errors.js';
 import type { AnyStandardSchema, InferOutput } from './schema.js';
 
+/** @experimental Layer 6 webhook router — not yet implemented; ships in v0.3. */
 export type WebhookHandler<TSchema extends AnyStandardSchema, TCtx> = {
   (params: { input: InferOutput<TSchema>; ctx: TCtx }): Promise<void> | void;
 };
 
+/** @experimental Layer 6 webhook router — not yet implemented; ships in v0.3. */
 export type WebhookDefinition<TSchema extends AnyStandardSchema, TCtx> = {
   schema: TSchema;
   handler: WebhookHandler<TSchema, TCtx>;
 };
 
+/** @experimental Layer 6 webhook router — not yet implemented; ships in v0.3. */
 export type WebhookRouter = {
   readonly _brand: 'WebhookRouter';
   readonly handlers: Record<string, WebhookDefinition<AnyStandardSchema, unknown>>;
 };
 
+/** @experimental Layer 6 webhook router — not yet implemented; ships in v0.3. */
 export type WebhookAdapter = {
   name: string;
   parse(
@@ -24,6 +28,7 @@ export type WebhookAdapter = {
   verify?(payload: unknown, headers: Record<string, string>): Promise<boolean>;
 };
 
+/** @experimental Layer 6 webhook router — not yet implemented; ships in v0.3. */
 export const toNodeHandler = (
   _router: WebhookRouter,
   _opts: { adapter: WebhookAdapter },
@@ -31,6 +36,7 @@ export const toNodeHandler = (
   throw new NotifyRpcNotImplementedError('toNodeHandler() (Layer 6)');
 };
 
+/** @experimental Layer 6 webhook router — not yet implemented; ships in v0.3. */
 export const toFetchHandler = (
   _router: WebhookRouter,
   _opts: { adapter: WebhookAdapter },

--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -2,12 +2,14 @@ import { NotifyRpcNotImplementedError } from './errors.js';
 import type { AnyCatalog } from './catalog.js';
 import type { Transport } from './transports/types.js';
 
+/** @experimental Layer 5 queue worker — not yet implemented; ships in v0.3. */
 export type Worker = {
   on(event: 'completed' | 'failed', handler: (...args: any[]) => void): void;
   start(): Promise<void>;
   close(): Promise<void>;
 };
 
+/** @experimental Layer 5 queue worker — not yet implemented; ships in v0.3. */
 export type CreateWorkerOptions<R extends AnyCatalog, Ctx> = {
   catalog: R;
   transport: Transport;
@@ -16,6 +18,7 @@ export type CreateWorkerOptions<R extends AnyCatalog, Ctx> = {
   context?: (params: { job: { id: string; attemptsMade: number } }) => Ctx;
 };
 
+/** @experimental Layer 5 queue worker — not yet implemented; ships in v0.3. */
 export const createWorker = <R extends AnyCatalog, Ctx = {}>(
   _opts: CreateWorkerOptions<R, Ctx>,
 ): Worker => {

--- a/packages/handlebars/src/index.ts
+++ b/packages/handlebars/src/index.ts
@@ -1,6 +1,7 @@
 import { NotifyRpcNotImplementedError } from '@betternotify/core';
 import type { TemplateAdapter } from '@betternotify/email';
 
+/** @experimental Handlebars template adapter — not yet implemented; ships in v0.4. */
 export const handlebarsTemplate = <TInput>(_source: string): TemplateAdapter<TInput> => {
   return {
     render: async (_args) => {

--- a/packages/mjml/src/index.ts
+++ b/packages/mjml/src/index.ts
@@ -1,6 +1,7 @@
 import { NotifyRpcNotImplementedError } from '@betternotify/core';
 import type { TemplateAdapter } from '@betternotify/email';
 
+/** @experimental MJML template adapter — not yet implemented; ships in v0.4. */
 export const mjmlTemplate = <TInput>(_source: string): TemplateAdapter<TInput> => {
   return {
     render: async (_args) => {

--- a/packages/resend/src/index.ts
+++ b/packages/resend/src/index.ts
@@ -2,19 +2,23 @@ import { NotifyRpcNotImplementedError } from '@betternotify/core';
 import type { Transport } from '@betternotify/email/transports';
 import type { WebhookAdapter } from '@betternotify/core/webhook';
 
+/** @experimental Resend transport — not yet implemented; ships in v0.3. */
 export type ResendTransportOptions = {
   apiKey: string;
   baseUrl?: string;
 };
 
+/** @experimental Resend transport — not yet implemented; ships in v0.3. */
 export const resendTransport = (_opts: ResendTransportOptions): Transport => {
   throw new NotifyRpcNotImplementedError('@betternotify/resend transport (v0.3)');
 };
 
+/** @experimental Resend webhook adapter — not yet implemented; ships in v0.3. */
 export type ResendAdapterOptions = {
   webhookSecret?: string;
 };
 
+/** @experimental Resend webhook adapter — not yet implemented; ships in v0.3. */
 export const resendAdapter = (_opts: ResendAdapterOptions = {}): WebhookAdapter => {
   throw new NotifyRpcNotImplementedError('@betternotify/resend webhook adapter (v0.3)');
 };

--- a/packages/ses/src/index.ts
+++ b/packages/ses/src/index.ts
@@ -2,6 +2,7 @@ import { NotifyRpcNotImplementedError } from '@betternotify/core';
 import type { Transport } from '@betternotify/email/transports';
 import type { WebhookAdapter } from '@betternotify/core/webhook';
 
+/** @experimental AWS SES transport — not yet implemented; ships in v0.3. */
 export type SesTransportOptions = {
   region: string;
   configurationSetName?: string;
@@ -12,14 +13,17 @@ export type SesTransportOptions = {
   };
 };
 
+/** @experimental AWS SES transport — not yet implemented; ships in v0.3. */
 export const sesTransport = (_opts: SesTransportOptions): Transport => {
   throw new NotifyRpcNotImplementedError('@betternotify/ses transport (v0.3)');
 };
 
+/** @experimental AWS SES webhook adapter — not yet implemented; ships in v0.3. */
 export type SesAdapterOptions = {
   verifySnsSignature?: boolean;
 };
 
+/** @experimental AWS SES webhook adapter — not yet implemented; ships in v0.3. */
 export const sesAdapter = (_opts: SesAdapterOptions = {}): WebhookAdapter => {
   throw new NotifyRpcNotImplementedError('@betternotify/ses webhook adapter (v0.3)');
 };


### PR DESCRIPTION
## Summary

- Adds `@experimental` JSDoc tag to all stub/unimplemented API surfaces so consumers see instability signals in IDE tooltips and generated docs
- Surfaces covered: `createWorker`, `Worker`, `CreateWorkerOptions` (Layer 5); `toNodeHandler`, `toFetchHandler`, `WebhookRouter`, `WebhookAdapter`, `WebhookHandler`, `WebhookDefinition` (Layer 6); `defineConfig`/`NotifyRpcConfig` (config stub); and all stub adapters in `@betternotify/bullmq`, `handlebars`, `mjml`, `resend`, `ses`
- No runtime behaviour changed; pure documentation annotation

## Test plan

- [x] `pnpm lint:fix` — 0 errors
- [x] `pnpm fmt` — clean
- [x] `pnpm test:coverage` — 408 tests pass, coverage unchanged
- [x] `pnpm typecheck` — 18 packages pass

Closes BET-44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added experimental status labels to several features not yet implemented: config-file-driven setup, queue worker, webhook router, BullMQ adapter, Resend transport/adapter, SES transport/adapter, Handlebars template, and MJML template. These features will ship in upcoming releases (v0.3–v0.4).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->