### PR TITLE
docs: audit and fix README accuracy against current API

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ const slackChannel = defineChannel({
   validateArgs: z.object({ channel: z.string(), threadTs: z.string().optional() }),
   render: ({ runtime, args }) => ({
     channel: args.channel,
-    text: typeof runtime.text === 'function' ? runtime.text({ input: args.input }) : runtime.text,
+    text: runtime.text,
   }),
 });
 ```


### PR DESCRIPTION
## Summary

Audited README against the actual codebase (packages, exports, API surface) and fixed three inaccuracies:

- **Version**: Updated status badge from `v0.0.1` to `v0.0.3-alpha` (matches `packages/core/package.json`)
- **Custom channel render example**: Removed incorrect `typeof runtime.text === 'function'` guard. `defineChannel` resolves slot values via `resolveRuntime` before invoking the user's `render` callback, so resolver slots are always pre-resolved plain values at render time. The actual working example in `examples/welcome-text/.../custom-channel.ts` confirms this.
- **Release instructions**: Replaced the stale `pnpm changeset` block with a note about release-please and conventional commits (changesets were removed in #4).

Also includes auto-fixes from `pnpm lint:fix` and `pnpm fmt` (pre-existing lint warnings in `define-channel.ts` and `channel.ts`, plus CHANGELOG reformatting).

## Test plan

- [x] All 54 test files / 408 tests pass (`pnpm test:coverage`)
- [x] `pnpm lint:fix` — 0 errors
- [x] `pnpm fmt` — clean
- [x] README examples verified against exported API surface of `@betternotify/core`, `@betternotify/email`, `@betternotify/sms`, `@betternotify/push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Slack custom channel example code snippet in README for clarity and simplification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->