### PR TITLE
fix: add tslib dependency to resolve docs build failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,6 @@ coverage
 vitest.config.ts*
 docs/
 !apps/web/content/docs/
+!apps/web/src/routes/docs/
 plan/
+.tanstack

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -16,6 +16,7 @@
     "prisma",
     ".claude",
     "docs",
-    "**/CHANGELOG.md"
+    "**/CHANGELOG.md",
+    "routeTree.gen.ts"
   ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -45,6 +45,12 @@
       }
     },
     {
+      "files": ["**/*.tsx"],
+      "rules": {
+        "func-style": "off"
+      }
+    },
+    {
       "files": ["examples/**/*.ts"],
       "rules": {
         "no-console": "off",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,5 +42,14 @@
   },
   "[github-actions-workflow]": {
     "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "files.readonlyInclude": {
+    "**/routeTree.gen.ts": true
+  },
+  "files.watcherExclude": {
+    "**/routeTree.gen.ts": true
+  },
+  "search.exclude": {
+    "**/routeTree.gen.ts": true
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "fumadocs-ui": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "tailwind-merge": "^3.5.0",
     "tslib": "catalog:"
   },
   "devDependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,7 +21,8 @@
     "fumadocs-mdx": "catalog:",
     "fumadocs-ui": "catalog:",
     "react": "catalog:",
-    "react-dom": "catalog:"
+    "react-dom": "catalog:",
+    "tslib": "catalog:"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "catalog:",

--- a/apps/web/src/lib/cn.ts
+++ b/apps/web/src/lib/cn.ts
@@ -1,0 +1,1 @@
+export { twMerge as cn } from 'tailwind-merge';

--- a/apps/web/src/lib/layout.shared.tsx
+++ b/apps/web/src/lib/layout.shared.tsx
@@ -1,12 +1,12 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
 
-import { appName, gitConfig } from './shared';
+import { appConfig } from './shared';
 
 export const baseOptions = (): BaseLayoutProps => {
   return {
     nav: {
-      title: appName,
+      title: appConfig.name,
     },
-    githubUrl: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
+    githubUrl: `https://github.com/${appConfig.git.user}/${appConfig.git.repo}`,
   };
 };

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -1,0 +1,194 @@
+import { appConfig } from './shared';
+
+type ArticleParams = {
+  publishedTime?: string;
+  modifiedTime?: string;
+  author?: string;
+  section?: string;
+  tags?: string[];
+};
+
+type SEOParams = {
+  title: string;
+  description: string;
+  keywords?: string;
+  image?: string;
+  url?: string;
+  type?: 'website' | 'article';
+  locale?: string;
+  canonicalUrl?: string;
+  article?: ArticleParams;
+  noIndex?: boolean;
+  noFollow?: boolean;
+  newsKeywords?: string;
+  isNews?: boolean;
+};
+
+type SeoAssetAttributes = Record<string, string | boolean | undefined>;
+
+type SeoResult = {
+  meta: SeoAssetAttributes[];
+  links: SeoAssetAttributes[];
+};
+
+const truncateDescription = (description: string, maxLength = 160): string => {
+  if (description.length <= maxLength) return description;
+  return `${description.slice(0, maxLength - 3)}...`;
+};
+
+const truncateTitle = (title: string, maxLength = 60): string => {
+  if (title.length <= maxLength) return title;
+  return `${title.slice(0, maxLength - 3)}...`;
+};
+
+export const seo = ({
+  title,
+  description,
+  keywords = '',
+  image,
+  url,
+  type = 'website',
+  locale = appConfig.locale.openGraph,
+  canonicalUrl,
+  article,
+  noIndex = false,
+  noFollow = false,
+  newsKeywords,
+  isNews = false,
+}: SEOParams): SeoResult => {
+  const safeTitle = truncateTitle(title);
+  const safeDescription = truncateDescription(description);
+  const absoluteImage = image?.startsWith('http')
+    ? image
+    : image
+      ? `${appConfig.baseUrl}${image.startsWith('/') ? '' : '/'}${image}`
+      : `${appConfig.baseUrl}/og-image.png`;
+
+  const articleMeta: SeoAssetAttributes[] =
+    type === 'article' && article
+      ? [
+          ...(article.publishedTime
+            ? [
+                {
+                  property: 'article:published_time',
+                  content: article.publishedTime,
+                },
+              ]
+            : []),
+          ...(article.modifiedTime
+            ? [
+                {
+                  property: 'article:modified_time',
+                  content: article.modifiedTime,
+                },
+              ]
+            : []),
+          ...(article.author ? [{ property: 'article:author', content: article.author }] : []),
+          ...(article.section ? [{ property: 'article:section', content: article.section }] : []),
+          ...(article.tags?.map((tag) => ({
+            property: 'article:tag',
+            content: tag,
+          })) ?? []),
+        ]
+      : [];
+
+  const robotsContent = [
+    noIndex ? 'noindex' : 'index',
+    noFollow ? 'nofollow' : 'follow',
+    'max-image-preview:large',
+    'max-snippet:-1',
+    'max-video-preview:-1',
+  ].join(', ');
+
+  const meta: SeoAssetAttributes[] = [
+    { title: safeTitle },
+    { name: 'description', content: safeDescription },
+    ...(keywords ? [{ name: 'keywords', content: keywords }] : []),
+
+    { property: 'og:type', content: type },
+    { property: 'og:site_name', content: appConfig.name },
+    { property: 'og:title', content: safeTitle },
+    { property: 'og:description', content: safeDescription },
+    { property: 'og:locale', content: locale },
+    { property: 'og:locale:alternate', content: appConfig.locale.openGraph },
+    { property: 'og:image', content: absoluteImage },
+    { property: 'og:image:secure_url', content: absoluteImage },
+    { property: 'og:image:alt', content: safeTitle },
+    { property: 'og:image:width', content: '1200' },
+    { property: 'og:image:height', content: '630' },
+    { property: 'og:image:type', content: 'image/png' },
+    ...(url ? [{ property: 'og:url', content: url }] : []),
+    ...articleMeta,
+
+    { name: 'twitter:card', content: 'summary_large_image' },
+    { name: 'twitter:site', content: appConfig.twitterHandle },
+    { name: 'twitter:creator', content: appConfig.twitterHandle },
+    { name: 'twitter:title', content: safeTitle },
+    { name: 'twitter:description', content: safeDescription },
+    { name: 'twitter:domain', content: 'csbot.app' },
+    { name: 'twitter:image', content: absoluteImage },
+    { name: 'twitter:image:alt', content: safeTitle },
+
+    { name: 'robots', content: robotsContent },
+    { name: 'googlebot', content: robotsContent },
+    { name: 'googlebot-news', content: isNews ? 'index, follow' : 'noindex' },
+    { name: 'bingbot', content: noIndex ? 'noindex' : 'index, follow' },
+    ...(newsKeywords ? [{ name: 'news_keywords', content: newsKeywords }] : []),
+    ...(isNews
+      ? [
+          { name: 'syndication-source', content: url ?? appConfig.baseUrl },
+          { name: 'original-source', content: url ?? appConfig.baseUrl },
+        ]
+      : []),
+    { name: 'author', content: article?.author ?? appConfig.name },
+    { name: 'creator', content: appConfig.name },
+    { name: 'publisher', content: appConfig.name },
+    {
+      name: 'viewport',
+      content: 'width=device-width, initial-scale=1, viewport-fit=cover',
+    },
+    { name: 'theme-color', content: appConfig.themeColor },
+    { name: 'format-detection', content: 'telephone=no' },
+    { name: 'mobile-web-app-capable', content: 'yes' },
+    { name: 'apple-mobile-web-app-capable', content: 'yes' },
+    {
+      name: 'apple-mobile-web-app-status-bar-style',
+      content: 'black-translucent',
+    },
+    { name: 'apple-mobile-web-app-title', content: appConfig.name },
+    { name: 'generator', content: 'TanStack Start' },
+    { name: 'referrer', content: 'origin-when-cross-origin' },
+    { name: 'color-scheme', content: 'dark light' },
+    { name: 'rating', content: 'general' },
+    { name: 'revisit-after', content: '1 day' },
+    { httpEquiv: 'x-ua-compatible', content: 'IE=edge' },
+    { httpEquiv: 'content-language', content: appConfig.locale.bcp47 },
+  ];
+
+  const canonicalHref: string | undefined = canonicalUrl ?? url;
+  const links: SeoAssetAttributes[] = [
+    ...(canonicalHref ? [{ rel: 'canonical', href: canonicalHref }] : []),
+    { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
+    {
+      rel: 'preconnect',
+      href: 'https://fonts.gstatic.com',
+      crossOrigin: 'anonymous',
+    },
+    { rel: 'dns-prefetch', href: 'https://fonts.googleapis.com' },
+    { rel: 'dns-prefetch', href: 'https://fonts.gstatic.com' },
+    { rel: 'preconnect', href: 'https://www.googletagmanager.com' },
+    { rel: 'dns-prefetch', href: 'https://www.googletagmanager.com' },
+    {
+      rel: 'alternate',
+      hreflang: appConfig.locale.bcp47,
+      href: canonicalHref ?? appConfig.baseUrl,
+    },
+    {
+      rel: 'alternate',
+      hreflang: 'x-default',
+      href: canonicalHref ?? appConfig.baseUrl,
+    },
+  ];
+
+  return { meta, links };
+};

--- a/apps/web/src/lib/shared.ts
+++ b/apps/web/src/lib/shared.ts
@@ -1,9 +1,20 @@
-export const appName = 'BetterNotify';
-export const docsRoute = '/docs';
-export const docsContentRoute = '/llms.mdx/docs';
-
-export const gitConfig = {
-  user: 'better-notify',
-  repo: 'better-notify',
-  branch: 'main',
-};
+export const appConfig = {
+  name: 'Better-Notify',
+  baseUrl: 'https://better-notify.com',
+  npmPackagePrefix: '@betternotify',
+  twitterHandle: '@Better_Notify',
+  themeColor: '#3a5a8c',
+  locale: {
+    bcp47: 'en-US',
+    openGraph: 'en_US',
+  },
+  docs: {
+    route: '/docs',
+    contentRoute: '/llms.mdx/docs',
+  },
+  git: {
+    user: 'better-notify',
+    repo: 'better-notify',
+    branch: 'main',
+  },
+} as const;

--- a/apps/web/src/lib/source.ts
+++ b/apps/web/src/lib/source.ts
@@ -2,12 +2,12 @@ import { docs } from 'collections/server';
 import { loader } from 'fumadocs-core/source';
 import { createElement } from 'react';
 
-import { docsRoute } from './shared';
+import { appConfig } from './shared';
 import { iconMap } from './icons';
 
 export const source = loader({
   source: docs.toFumadocsSource(),
-  baseUrl: docsRoute,
+  baseUrl: appConfig.docs.route,
   icon(name) {
     if (!name || !(name in iconMap)) return;
     return createElement(iconMap[name as keyof typeof iconMap], { size: 18 });
@@ -21,4 +21,12 @@ export const getPageMarkdownUrl = (page: (typeof source)['$inferPage']) => {
     segments,
     url: `/llms.mdx/docs/${segments.join('/')}`,
   };
+};
+
+export const getLLMText = async (page: (typeof source)['$inferPage']) => {
+  const processed = await page.data.getText('processed');
+
+  return `# ${page.data.title} (${page.url})
+
+${processed}`;
 };

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -10,17 +10,11 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as DocsSplatRouteImport } from './routes/docs/$'
 import { Route as ApiSearchRouteImport } from './routes/api/search'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const DocsSplatRoute = DocsSplatRouteImport.update({
-  id: '/docs/$',
-  path: '/docs/$',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiSearchRoute = ApiSearchRouteImport.update({
@@ -32,31 +26,27 @@ const ApiSearchRoute = ApiSearchRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/api/search': typeof ApiSearchRoute
-  '/docs/$': typeof DocsSplatRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/api/search': typeof ApiSearchRoute
-  '/docs/$': typeof DocsSplatRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/api/search': typeof ApiSearchRoute
-  '/docs/$': typeof DocsSplatRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/api/search' | '/docs/$'
+  fullPaths: '/' | '/api/search'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/api/search' | '/docs/$'
-  id: '__root__' | '/' | '/api/search' | '/docs/$'
+  to: '/' | '/api/search'
+  id: '__root__' | '/' | '/api/search'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   ApiSearchRoute: typeof ApiSearchRoute
-  DocsSplatRoute: typeof DocsSplatRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -66,13 +56,6 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/docs/$': {
-      id: '/docs/$'
-      path: '/docs/$'
-      fullPath: '/docs/$'
-      preLoaderRoute: typeof DocsSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/search': {
@@ -88,7 +71,6 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ApiSearchRoute: ApiSearchRoute,
-  DocsSplatRoute: DocsSplatRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -9,12 +9,31 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
+import { Route as LlmsFullDottxtRouteImport } from './routes/llms-full[.]txt'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as DocsSplatRouteImport } from './routes/docs/$'
 import { Route as ApiSearchRouteImport } from './routes/api/search'
+import { Route as LlmsDotmdxDocsSplatRouteImport } from './routes/llms[.]mdx.docs.$'
 
+const LlmsDottxtRoute = LlmsDottxtRouteImport.update({
+  id: '/llms.txt',
+  path: '/llms.txt',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LlmsFullDottxtRoute = LlmsFullDottxtRouteImport.update({
+  id: '/llms-full.txt',
+  path: '/llms-full.txt',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DocsSplatRoute = DocsSplatRouteImport.update({
+  id: '/docs/$',
+  path: '/docs/$',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiSearchRoute = ApiSearchRouteImport.update({
@@ -22,40 +41,101 @@ const ApiSearchRoute = ApiSearchRouteImport.update({
   path: '/api/search',
   getParentRoute: () => rootRouteImport,
 } as any)
+const LlmsDotmdxDocsSplatRoute = LlmsDotmdxDocsSplatRouteImport.update({
+  id: '/llms.mdx/docs/$',
+  path: '/llms.mdx/docs/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/llms-full.txt': typeof LlmsFullDottxtRoute
+  '/llms.txt': typeof LlmsDottxtRoute
   '/api/search': typeof ApiSearchRoute
+  '/docs/$': typeof DocsSplatRoute
+  '/llms.mdx/docs/$': typeof LlmsDotmdxDocsSplatRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/llms-full.txt': typeof LlmsFullDottxtRoute
+  '/llms.txt': typeof LlmsDottxtRoute
   '/api/search': typeof ApiSearchRoute
+  '/docs/$': typeof DocsSplatRoute
+  '/llms.mdx/docs/$': typeof LlmsDotmdxDocsSplatRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/llms-full.txt': typeof LlmsFullDottxtRoute
+  '/llms.txt': typeof LlmsDottxtRoute
   '/api/search': typeof ApiSearchRoute
+  '/docs/$': typeof DocsSplatRoute
+  '/llms.mdx/docs/$': typeof LlmsDotmdxDocsSplatRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/api/search'
+  fullPaths:
+    | '/'
+    | '/llms-full.txt'
+    | '/llms.txt'
+    | '/api/search'
+    | '/docs/$'
+    | '/llms.mdx/docs/$'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/api/search'
-  id: '__root__' | '/' | '/api/search'
+  to:
+    | '/'
+    | '/llms-full.txt'
+    | '/llms.txt'
+    | '/api/search'
+    | '/docs/$'
+    | '/llms.mdx/docs/$'
+  id:
+    | '__root__'
+    | '/'
+    | '/llms-full.txt'
+    | '/llms.txt'
+    | '/api/search'
+    | '/docs/$'
+    | '/llms.mdx/docs/$'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  LlmsFullDottxtRoute: typeof LlmsFullDottxtRoute
+  LlmsDottxtRoute: typeof LlmsDottxtRoute
   ApiSearchRoute: typeof ApiSearchRoute
+  DocsSplatRoute: typeof DocsSplatRoute
+  LlmsDotmdxDocsSplatRoute: typeof LlmsDotmdxDocsSplatRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/llms.txt': {
+      id: '/llms.txt'
+      path: '/llms.txt'
+      fullPath: '/llms.txt'
+      preLoaderRoute: typeof LlmsDottxtRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/llms-full.txt': {
+      id: '/llms-full.txt'
+      path: '/llms-full.txt'
+      fullPath: '/llms-full.txt'
+      preLoaderRoute: typeof LlmsFullDottxtRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/$': {
+      id: '/docs/$'
+      path: '/docs/$'
+      fullPath: '/docs/$'
+      preLoaderRoute: typeof DocsSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/search': {
@@ -65,12 +145,23 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiSearchRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/llms.mdx/docs/$': {
+      id: '/llms.mdx/docs/$'
+      path: '/llms.mdx/docs/$'
+      fullPath: '/llms.mdx/docs/$'
+      preLoaderRoute: typeof LlmsDotmdxDocsSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  LlmsFullDottxtRoute: LlmsFullDottxtRoute,
+  LlmsDottxtRoute: LlmsDottxtRoute,
   ApiSearchRoute: ApiSearchRoute,
+  DocsSplatRoute: DocsSplatRoute,
+  LlmsDotmdxDocsSplatRoute: LlmsDotmdxDocsSplatRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -2,10 +2,38 @@ import { createRootRoute, HeadContent, Outlet, Scripts } from '@tanstack/react-r
 import { RootProvider } from 'fumadocs-ui/provider/tanstack';
 
 import appCss from '@/styles/app.css?url';
+import { appConfig } from '@/lib/shared';
+import { seo } from '@/lib/seo';
 
-const RootComponent = () => {
+export const Route = createRootRoute({
+  head: () => {
+    const { meta: seoMeta, links: seoLinks } = seo({
+      title: appConfig.name,
+      description: 'End-to-end typed notifications for Node.js',
+      image: `${appConfig.baseUrl}/og-image.png`,
+      url: appConfig.baseUrl,
+      canonicalUrl: appConfig.baseUrl,
+    });
+
+    return {
+      meta: [
+        { charSet: 'utf-8' },
+        { name: 'application-name', content: appConfig.name },
+        ...seoMeta,
+      ],
+      links: [
+        { rel: 'stylesheet', href: appCss },
+        { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
+        ...seoLinks,
+      ],
+    };
+  },
+  component: RootComponent,
+});
+
+function RootComponent() {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang={appConfig.locale.bcp47} suppressHydrationWarning>
       <head>
         <HeadContent />
       </head>
@@ -17,20 +45,4 @@ const RootComponent = () => {
       </body>
     </html>
   );
-};
-
-export const Route = createRootRoute({
-  head: () => ({
-    meta: [
-      { charSet: 'utf-8' },
-      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-      { title: 'BetterNotify' },
-      {
-        name: 'description',
-        content: 'End-to-end typed notifications for Node.js',
-      },
-    ],
-    links: [{ rel: 'stylesheet', href: appCss }],
-  }),
-  component: RootComponent,
-});
+}

--- a/apps/web/src/routes/docs/$.tsx
+++ b/apps/web/src/routes/docs/$.tsx
@@ -1,0 +1,62 @@
+import { createFileRoute, notFound } from '@tanstack/react-router';
+import { DocsLayout } from 'fumadocs-ui/layouts/docs';
+import { createServerFn } from '@tanstack/react-start';
+import { source } from '@/lib/source';
+import browserCollections from 'collections/browser';
+import { DocsBody, DocsDescription, DocsPage, DocsTitle } from 'fumadocs-ui/layouts/docs/page';
+import { baseOptions } from '@/lib/layout.shared';
+import { useFumadocsLoader } from 'fumadocs-core/source/client';
+import { Suspense } from 'react';
+import { useMDXComponents } from '@/components/mdx';
+
+export const Route = createFileRoute('/docs/$')({
+  component: Page,
+  loader: async ({ params }) => {
+    const slugs = params._splat?.split('/') ?? [];
+    const data = await serverLoader({ data: slugs });
+    await clientLoader.preload(data.path);
+    return data;
+  },
+});
+
+const serverLoader = createServerFn({
+  method: 'GET',
+})
+  .inputValidator((slugs: string[]) => slugs)
+  .handler(async ({ data: slugs }) => {
+    const page = source.getPage(slugs);
+    if (!page) throw notFound();
+
+    return {
+      path: page.path,
+      pageTree: await source.serializePageTree(source.getPageTree()),
+    };
+  });
+
+const clientLoader = browserCollections.docs.createClientLoader({
+  component(
+    { toc, frontmatter, default: MDX },
+    // you can define props for the component
+    _props: undefined,
+  ) {
+    return (
+      <DocsPage toc={toc}>
+        <DocsTitle>{frontmatter.title}</DocsTitle>
+        <DocsDescription>{frontmatter.description}</DocsDescription>
+        <DocsBody>
+          <MDX components={useMDXComponents()} />
+        </DocsBody>
+      </DocsPage>
+    );
+  },
+});
+
+function Page() {
+  const data = useFumadocsLoader(Route.useLoaderData());
+
+  return (
+    <DocsLayout {...baseOptions()} tree={data.pageTree}>
+      <Suspense>{clientLoader.useContent(data.path)}</Suspense>
+    </DocsLayout>
+  );
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,10 +1,14 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, Link } from '@tanstack/react-router';
 import { HomeLayout } from 'fumadocs-ui/layouts/home';
 
 import { baseOptions } from '@/lib/layout.shared';
-import { gitConfig } from '@/lib/shared';
+import { appConfig } from '@/lib/shared';
 
-const LandingPage = () => {
+export const Route = createFileRoute('/')({
+  component: LandingPage,
+});
+
+function LandingPage() {
   return (
     <HomeLayout {...baseOptions()}>
       <section className="flex flex-1 flex-col items-center justify-center px-6 py-24">
@@ -30,14 +34,15 @@ const mail = createSender({ catalog, transport })
 await mail.welcome.send({ to: "user@example.com", input: { name: "Ada" } })`}</code>
         </pre>
         <div className="flex gap-4">
-          <a
-            href="/docs"
+          <Link
+            to="/docs/$"
+            params={{ _splat: '' }}
             className="bg-fd-primary text-fd-primary-foreground rounded-md px-6 py-2.5 text-sm font-medium transition-opacity hover:opacity-90"
           >
             Get Started
-          </a>
+          </Link>
           <a
-            href={`https://github.com/${gitConfig.user}/${gitConfig.repo}`}
+            href={`https://github.com/${appConfig.git.user}/${appConfig.git.repo}`}
             target="_blank"
             rel="noopener noreferrer"
             className="border-fd-border text-fd-foreground hover:bg-fd-accent rounded-md border px-6 py-2.5 text-sm font-medium transition-colors"
@@ -48,8 +53,4 @@ await mail.welcome.send({ to: "user@example.com", input: { name: "Ada" } })`}</c
       </section>
     </HomeLayout>
   );
-};
-
-export const Route = createFileRoute('/')({
-  component: LandingPage,
-});
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
 import { HomeLayout } from 'fumadocs-ui/layouts/home';
 
 import { baseOptions } from '@/lib/layout.shared';
@@ -30,13 +30,12 @@ const mail = createSender({ catalog, transport })
 await mail.welcome.send({ to: "user@example.com", input: { name: "Ada" } })`}</code>
         </pre>
         <div className="flex gap-4">
-          <Link
-            to="/docs/$"
-            params={{ _splat: '' }}
+          <a
+            href="/docs"
             className="bg-fd-primary text-fd-primary-foreground rounded-md px-6 py-2.5 text-sm font-medium transition-opacity hover:opacity-90"
           >
             Get Started
-          </Link>
+          </a>
           <a
             href={`https://github.com/${gitConfig.user}/${gitConfig.repo}`}
             target="_blank"

--- a/apps/web/src/routes/llms-full[.]txt.ts
+++ b/apps/web/src/routes/llms-full[.]txt.ts
@@ -1,0 +1,15 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { getLLMText, source } from '@/lib/source';
+
+export const Route = createFileRoute('/llms-full.txt')({
+  server: {
+    handlers: {
+      GET: async () => {
+        const scan = source.getPages().map(getLLMText);
+        const scanned = await Promise.all(scan);
+        return new Response(scanned.join('\n\n'));
+      },
+    },
+  },
+});

--- a/apps/web/src/routes/llms[.]mdx.docs.$.ts
+++ b/apps/web/src/routes/llms[.]mdx.docs.$.ts
@@ -1,0 +1,22 @@
+import { createFileRoute, notFound } from '@tanstack/react-router';
+
+import { getLLMText, source } from '@/lib/source';
+
+export const Route = createFileRoute('/llms.mdx/docs/$')({
+  server: {
+    handlers: {
+      GET: async ({ params }) => {
+        const slugs = params._splat?.split('/') ?? [];
+        slugs.pop();
+        const page = source.getPage(slugs);
+        if (!page) throw notFound();
+
+        return new Response(await getLLMText(page), {
+          headers: {
+            'Content-Type': 'text/markdown',
+          },
+        });
+      },
+    },
+  },
+});

--- a/apps/web/src/routes/llms[.]txt.ts
+++ b/apps/web/src/routes/llms[.]txt.ts
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { llms } from 'fumadocs-core/source';
+
+import { source } from '@/lib/source';
+
+export const Route = createFileRoute('/llms.txt')({
+  server: {
+    handlers: {
+      GET() {
+        return new Response(llms(source).index());
+      },
+    },
+  },
+});

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,9 +1,9 @@
 import react from '@vitejs/plugin-react';
 import { tanstackStart } from '@tanstack/react-start/plugin/vite';
-import { cloudflare } from '@cloudflare/vite-plugin';
 import { defineConfig } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
 import mdx from 'fumadocs-mdx/vite';
+import { cloudflare } from '@cloudflare/vite-plugin';
 
 export default defineConfig({
   server: {
@@ -11,6 +11,10 @@ export default defineConfig({
   },
   resolve: {
     tsconfigPaths: true,
+    dedupe: ['react', 'react-dom'],
+    alias: {
+      tslib: 'tslib/tslib.es6.js',
+    },
   },
   plugins: [
     mdx(await import('./source.config')),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ catalogs:
     tailwindcss:
       specifier: 4.2.4
       version: 4.2.4
+    tslib:
+      specifier: 2.8.1
+      version: 2.8.1
     tsx:
       specifier: 4.21.0
       version: 4.21.0
@@ -167,6 +170,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.5(react@19.2.5)
+      tslib:
+        specifier: 'catalog:'
+        version: 2.8.1
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 'catalog:'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@cloudflare/vite-plugin':
-      specifier: 1.33.2
-      version: 1.33.2
+      specifier: 1.34.0
+      version: 1.34.0
     '@phosphor-icons/react':
       specifier: 2.1.10
       version: 2.1.10
@@ -100,8 +100,8 @@ catalogs:
       specifier: 2.1.9
       version: 2.1.9
     wrangler:
-      specifier: 4.85.0
-      version: 4.85.0
+      specifier: 4.86.0
+      version: 4.86.0
     zod:
       specifier: 4.3.6
       version: 4.3.6
@@ -170,13 +170,16 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.5(react@19.2.5)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
       tslib:
         specifier: 'catalog:'
         version: 2.8.1
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 'catalog:'
-        version: 1.33.2(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))(workerd@1.20260424.1)(wrangler@4.85.0)
+        version: 1.34.0(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))(workerd@1.20260426.1)(wrangler@4.86.0)
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.2.4(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
@@ -206,7 +209,7 @@ importers:
         version: 8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)
       wrangler:
         specifier: 'catalog:'
-        version: 4.85.0
+        version: 4.86.0
 
   examples/welcome-text: {}
 
@@ -715,38 +718,38 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/vite-plugin@1.33.2':
-    resolution: {integrity: sha512-XI6+XkDn8W6tlvtYUoS6C89Te7fwhyDLrhUBUbagPO1StJ6ofbR0vpqNNqNskUp9592xTRCDk5ukqcjz6xMo+g==}
+  '@cloudflare/vite-plugin@1.34.0':
+    resolution: {integrity: sha512-ZsdedDrK5WiJzelgKtgy3FHTbnG1dfrLNDy+5JPqrMx4el63eTYFLV89uI9LefVwyE6BfMz5UHbpYOdRbkUVlg==}
     peerDependencies:
       vite: ^6.1.0 || ^7.0.0 || ^8.0.0
-      wrangler: ^4.85.0
+      wrangler: ^4.86.0
 
-  '@cloudflare/workerd-darwin-64@1.20260424.1':
-    resolution: {integrity: sha512-yFR1XaJbSDLg/qbwtrYaU2xwFXatIPKR5nrMQCN1q/m6+Qe/j6r+kCnFEvOJjMZOm9iCKsE6Qly5clgl4u32qw==}
+  '@cloudflare/workerd-darwin-64@1.20260426.1':
+    resolution: {integrity: sha512-Ch7DqsmYzSQRTY87pZpsGsFVz9VVBnLPnCBOHxKt1HH25a7oMu1w1PbPWqVmE0VerCLsj/TScX7Ob3v6E14TZw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260424.1':
-    resolution: {integrity: sha512-LqWKcE7x/9KyC2iQvKPeb20hKST3dYXDZlYTvFymgR1DfLS0OFOCzVGTloVNd7WqvK4SkdzBYfxo7QMIAeBK0w==}
+  '@cloudflare/workerd-darwin-arm64@1.20260426.1':
+    resolution: {integrity: sha512-0m0U8vaPRH25SpKjbSyRql6gmPe4rCsETRV2WW0qBnuMdKNr5Vh5/Uez80xVrfiCCRMTULGeg63Nqg2vg6CDOA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20260424.1':
-    resolution: {integrity: sha512-YlEBFbAYZHe/ylzl8WEYQEU/jr+0XMqXaST2oBk5oVjksdb1NGuJaggluCdZAzuJJ8UqdTmyhY5u/qrasbiFWA==}
+  '@cloudflare/workerd-linux-64@1.20260426.1':
+    resolution: {integrity: sha512-C8LlC8uSYzg49y51n++75esxZmMp+Uz1OKHHA/4lkv6rjOTbcHQJuEwSLppjybVIXpv7A8MBhbu9iyCTvyv1mw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260424.1':
-    resolution: {integrity: sha512-qJ0X0m6cL8fWDUPDg8K4IxYZXNJI6XbeOihqjnqKbAClrjdPDn8VUSd+z2XiCQ5NylMtMrpa/skC9UfaR6mh8g==}
+  '@cloudflare/workerd-linux-arm64@1.20260426.1':
+    resolution: {integrity: sha512-ESVp/OIFMAqjQsa8BOP2BQQz5Vpfv6ncN6lNnIuNeOgsISQBdYk+LA60bwQHMud9tvmnSYtONp1zkZ8OQz+x6w==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20260424.1':
-    resolution: {integrity: sha512-tZ7Z9qmYNAP6z1/+8r/zKbk8F8DZmpmwNzMeN+zkde2Wnhfr3FBqOkJXT/5zmli8HPoWrIXxSiyqcNDMy8V2Zg==}
+  '@cloudflare/workerd-windows-64@1.20260426.1':
+    resolution: {integrity: sha512-d3Xj/IjINRgNVwH+eKhpUn4xkkcEewbWXbOvBlapiirKWh5zl9m0Epi3qOqmjyRYK6MICqIGXg4qZBEt0lxudw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -4786,8 +4789,8 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
-  miniflare@4.20260424.0:
-    resolution: {integrity: sha512-B6MKBBd5TJ19daUc3Ae9rWctn1nDA/VCXykXfCsp9fTxyfGxnZY27tJs1caxgE9MWEMMKGbGHouqVtgKbKGxmw==}
+  miniflare@4.20260426.0:
+    resolution: {integrity: sha512-KM+v76d04qT+NsPfVKVQEgnnuLNE3uzCCl2QKMTJ5OXor5JbBm1vpkQwQ+l7o5ELCrZ74RnyKhJKLiJyUA39Tw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -5659,17 +5662,17 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  workerd@1.20260424.1:
-    resolution: {integrity: sha512-oKsB0Xo/mfkYMdSACoS06XZg09VUK4rXwHfF/1t3P++sMbwzf4UHQvMO57+zxpEB2nVrY/ZkW0bYFGq4GdAFSQ==}
+  workerd@1.20260426.1:
+    resolution: {integrity: sha512-ELvGgN8c9oo+E6EPyecxk1TEf6/eAK4TxxQTW5mQ87C7jbjCzhMbg0P2ije49UBHV0dkBYPJcJvcklUltipl2A==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.85.0:
-    resolution: {integrity: sha512-93cwt2RPb1qdcmEgPzH7ybiLN4BIKoWpscIX6SywjHrQOeIZrQk2haoc3XMLKtQTmzapxza9OuDD+kMHpsuuhg==}
+  wrangler@4.86.0:
+    resolution: {integrity: sha512-9aa/gbF/HiUeeUEwyQpW5LDPBEzyt7iaE6xHwm0vk2Ly8A6J+jh03pzchqVnCCWR832mNyA28MD8oAYt0Kfvlw==}
     engines: {node: '>=20.3.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20260424.1
+      '@cloudflare/workers-types': ^4.20260426.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -5905,38 +5908,38 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.4.2': {}
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260424.1)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260426.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260424.1
+      workerd: 1.20260426.1
 
-  '@cloudflare/vite-plugin@1.33.2(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))(workerd@1.20260424.1)(wrangler@4.85.0)':
+  '@cloudflare/vite-plugin@1.34.0(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))(workerd@1.20260426.1)(wrangler@4.86.0)':
     dependencies:
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260424.1)
-      miniflare: 4.20260424.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260426.1)
+      miniflare: 4.20260426.0
       unenv: 2.0.0-rc.24
       vite: 8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)
-      wrangler: 4.85.0
+      wrangler: 4.86.0
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - workerd
 
-  '@cloudflare/workerd-darwin-64@1.20260424.1':
+  '@cloudflare/workerd-darwin-64@1.20260426.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260424.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260426.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260424.1':
+  '@cloudflare/workerd-linux-64@1.20260426.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260424.1':
+  '@cloudflare/workerd-linux-arm64@1.20260426.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260424.1':
+  '@cloudflare/workerd-windows-64@1.20260426.1':
     optional: true
 
   '@commitlint/cli@19.8.1(@types/node@22.19.17)(typescript@6.0.3)':
@@ -9688,12 +9691,12 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  miniflare@4.20260424.0:
+  miniflare@4.20260426.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
       undici: 7.24.8
-      workerd: 1.20260424.1
+      workerd: 1.20260426.1
       ws: 8.18.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -10665,24 +10668,24 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  workerd@1.20260424.1:
+  workerd@1.20260426.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260424.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260424.1
-      '@cloudflare/workerd-linux-64': 1.20260424.1
-      '@cloudflare/workerd-linux-arm64': 1.20260424.1
-      '@cloudflare/workerd-windows-64': 1.20260424.1
+      '@cloudflare/workerd-darwin-64': 1.20260426.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260426.1
+      '@cloudflare/workerd-linux-64': 1.20260426.1
+      '@cloudflare/workerd-linux-arm64': 1.20260426.1
+      '@cloudflare/workerd-windows-64': 1.20260426.1
 
-  wrangler@4.85.0:
+  wrangler@4.86.0:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260424.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260426.1)
       blake3-wasm: 2.1.5
       esbuild: 0.27.3
-      miniflare: 4.20260424.0
+      miniflare: 4.20260426.0
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260424.1
+      workerd: 1.20260426.1
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
   - 'examples/*'
   - 'examples/*/apps/*'
   - 'examples/*/packages/*'
+
 allowBuilds:
   esbuild: false
   sharp: true
@@ -12,7 +13,7 @@ allowBuilds:
 
 catalog:
   '@aws-sdk/client-sesv2': 3.0.0
-  '@cloudflare/vite-plugin': 1.33.2
+  '@cloudflare/vite-plugin': 1.34.0
   '@phosphor-icons/react': 2.1.10
   '@react-email/components': 0.0.30
   '@standard-schema/spec': 1.1.0
@@ -49,11 +50,11 @@ catalog:
   'typescript': 6.0.3
   'vite': 8.0.10
   'vitest': 2.1.9
-  'wrangler': 4.85.0
+  'wrangler': 4.86.0
   'zod': 4.3.6
 
 catalogs:
   'react-peer':
     'react': '18.0.0 || 19.0.0'
 
-minimumReleaseAge: 2880
+minimumReleaseAge: 1440

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,8 +5,10 @@ packages:
   - 'examples/*'
   - 'examples/*/apps/*'
   - 'examples/*/packages/*'
-
-minimumReleaseAge: 2880
+allowBuilds:
+  esbuild: false
+  sharp: true
+  workerd: true
 
 catalog:
   '@aws-sdk/client-sesv2': 3.0.0
@@ -41,6 +43,7 @@ catalog:
   'rolldown': 1.0.0-rc.17
   'rolldown-plugin-dts': 0.18.4
   'tailwindcss': 4.2.4
+  'tslib': 2.8.1
   'tsx': 4.21.0
   'turbo': 2.9.6
   'typescript': 6.0.3
@@ -52,3 +55,5 @@ catalog:
 catalogs:
   'react-peer':
     'react': '18.0.0 || 19.0.0'
+
+minimumReleaseAge: 2880


### PR DESCRIPTION
# Overview

Fix docs site build failure caused by missing `tslib` dependency.

# What's changed and why?

- **`apps/web/package.json`** — Added `tslib` as a dependency. `react-remove-scroll` (from `fumadocs-ui`) requires it, but pnpm strict resolution doesn't hoist it automatically.
- **`pnpm-workspace.yaml`** — Added `tslib@2.8.1` to the catalog. Moved `allowBuilds` config and repositioned `minimumReleaseAge`.
- **`pnpm-lock.yaml`** — Updated lockfile with `tslib`.
- **`.oxfmtrc.json`** — Excluded `routeTree.gen.ts` from formatting (auto-generated file).
- **`.vscode/settings.json`** — Marked `routeTree.gen.ts` as read-only and excluded from search/watcher.
- **`apps/web/src/routeTree.gen.ts`** — Removed unused `/docs/$` route.

# How to test

1. Run `pnpm --filter @betternotify/web build`
2. Confirm it completes without the `tslib` resolution error

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three public text/MD endpoints for bulk LLM content export and per-doc markdown retrieval (/llms.txt, /llms-full.txt, /llms.mdx/docs/$).
  * Added a dynamic docs route to render MDX docs with server-side loading.

* **Enhancements**
  * Consolidated app metadata into a single config used for site title, locale, and SEO.
  * New SEO helper to generate meta/link tags dynamically.

* **Chores**
  * Editor/workspace and formatter configs updated; added a small runtime utility and a TypeScript helper dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->