### PR TITLE
ci: fix release-please CI and add prepare action

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -1,23 +1,15 @@
 name: Prepare pipeline
-description: Checkout, install pnpm + Node 22, and run pnpm install
+description: Install pnpm + Node 22 and run pnpm install
 
 inputs:
   registry-url:
     description: npm registry URL (set when publishing)
     required: false
     default: ''
-  fetch-depth:
-    description: Git fetch depth for checkout
-    required: false
-    default: '1'
 
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: ${{ inputs.fetch-depth }}
-
     - uses: pnpm/action-setup@v6
 
     - uses: actions/setup-node@v6

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -1,0 +1,30 @@
+name: Prepare pipeline
+description: Checkout, install pnpm + Node 22, and run pnpm install
+
+inputs:
+  registry-url:
+    description: npm registry URL (set when publishing)
+    required: false
+    default: ''
+  fetch-depth:
+    description: Git fetch depth for checkout
+    required: false
+    default: '1'
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: ${{ inputs.fetch-depth }}
+
+    - uses: pnpm/action-setup@v6
+
+    - uses: actions/setup-node@v6
+      with:
+        node-version: 22
+        registry-url: ${{ inputs.registry-url }}
+        cache: pnpm
+
+    - run: pnpm install --frozen-lockfile
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/prepare
       - run: pnpm run ci
 
   bundle-projects:
@@ -41,18 +35,9 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: ./.github/actions/prepare
         with:
           fetch-depth: 0
-
-      - uses: pnpm/action-setup@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
 
       - id: projects
         uses: ./.github/actions/affected-projects
@@ -90,17 +75,9 @@ jobs:
       matrix:
         project: ${{ fromJSON(needs.bundle-projects.outputs.projects) }}
     steps:
-      - uses: actions/checkout@v6
-
-      - uses: pnpm/action-setup@v6
-
-      - uses: actions/setup-node@v6
+      - uses: ./.github/actions/prepare
         with:
-          node-version: 22
           registry-url: https://registry.npmjs.org
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
 
       - run: pnpm exec turbo run build --filter="${{ matrix.project.name }}..."
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/prepare
       - run: pnpm run ci
 
@@ -35,9 +36,10 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: ./.github/actions/prepare
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - uses: ./.github/actions/prepare
 
       - id: projects
         uses: ./.github/actions/affected-projects
@@ -75,6 +77,7 @@ jobs:
       matrix:
         project: ${{ fromJSON(needs.bundle-projects.outputs.projects) }}
     steps:
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/prepare
         with:
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,18 @@ jobs:
       paths_released: ${{ steps.release.outputs.paths_released }}
       web_releases_created: ${{ steps.release-web.outputs.releases_created }}
     steps:
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.BETTER_NOTIFY_APP_ID }}
+          private-key: ${{ secrets.BETTER_NOTIFY_APP_PRIVATE_KEY }}
+
       - name: Release Please (packages)
         uses: googleapis/release-please-action@v5.0.0
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
@@ -30,7 +37,7 @@ jobs:
         uses: googleapis/release-please-action@v5.0.0
         id: release-web
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config-web.json
           manifest-file: .release-please-manifest-web.json
 
@@ -44,21 +51,9 @@ jobs:
       matrix:
         path: ${{ fromJSON(needs.release-please.outputs.paths_released) }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - uses: ./.github/actions/prepare
         with:
-          node-version: 22
           registry-url: https://registry.npmjs.org
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build
@@ -80,20 +75,7 @@ jobs:
       group: deploy-web
       cancel-in-progress: true
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/prepare
 
       - name: Deploy
         run: pnpm web:deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
       matrix:
         path: ${{ fromJSON(needs.release-please.outputs.paths_released) }}
     steps:
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/prepare
         with:
           registry-url: https://registry.npmjs.org
@@ -75,6 +76,7 @@ jobs:
       group: deploy-web
       cancel-in-progress: true
     steps:
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/prepare
 
       - name: Deploy


### PR DESCRIPTION
# Overview

Release-please PRs were not triggering CI because `GITHUB_TOKEN` PRs don't fire `pull_request` workflows. This uses a GitHub App token instead, and extracts repeated setup steps into a reusable action.

# What's changed and why?

- **`.github/actions/prepare/action.yml`** — new reusable composite action (checkout + pnpm + Node 22 + install). Accepts optional `registry-url` and `fetch-depth` inputs.
- **`.github/workflows/release.yml`** — uses `create-github-app-token` so release-please PRs trigger CI. Replaced setup boilerplate with `prepare` action.
- **`.github/workflows/ci.yml`** — replaced setup boilerplate in all jobs with `prepare` action.

# How to test

1. Add `BETTER_NOTIFY_APP_ID` and `BETTER_NOTIFY_APP_PRIVATE_KEY` secrets to the repo
2. Merge and wait for release-please to open a PR
3. Confirm CI runs automatically on the release-please PR

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized Node/pnpm preparation into a shared reusable step across CI, build and release pipelines.
  * Consolidated dependency installation into the shared preparation step to reduce duplication.
  * Switched release automation to use an app-generated token for authentication during release operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->