### PR TITLE
feat(ci): gate preview publish on environment approval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,8 @@ jobs:
     name: Preview ${{ matrix.project.name }}
     runs-on: ubuntu-latest
     needs: [bundle-projects]
-    if: >-
-      needs.bundle-projects.outputs.has-projects == 'true'
-      && github.event.pull_request.head.repo.full_name == github.repository
+    if: needs.bundle-projects.outputs.has-projects == 'true'
+    environment: preview
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -16,7 +16,7 @@ jobs:
   cleanup:
     name: Unpublish preview packages
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: always()
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
# Overview

Prevent unauthorized preview package publishing by gating it behind a GitHub Environment approval step.

# What's changed and why?

- `.github/workflows/ci.yml` — replaced the fork-only guard (`head.repo.full_name == github.repository`) with `environment: preview`, which requires a maintainer to approve before preview packages are published to npm
- `.github/workflows/preview-cleanup.yml` — changed cleanup condition to `always()` so preview packages are cleaned up for all closed PRs, not just same-repo ones

**Also configured in GitHub Settings (not in code):**
- Created `preview` environment with required reviewer (`thereis`)
- Updated `main` branch ruleset: restrict creations/updates/deletions, require PR, require status checks (`ci` + `semantic-title`), block force pushes

# How to test

1. Open a PR from a fork — CI runs but preview publish pauses waiting for approval
2. Approve the environment in the Actions tab — preview publishes
3. Close the PR — preview packages get cleaned up

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to improve preview build handling. Simplified job execution conditions and removed repository origin restrictions, enabling more consistent preview build publishing and cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->