### PR TITLE
feat(ci): add preview docs deployment for PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,3 +18,6 @@
 
 <!-- start Preview packages update -->
 <!-- end Preview packages update -->
+
+<!-- start Preview docs URL -->
+<!-- end Preview docs URL -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,12 @@ jobs:
       - uses: ./.github/actions/prepare
       - run: pnpm run ci
 
+  preview-gate:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.fork == false
+    steps:
+      - run: echo "Preview gate passed"
+
   bundle-projects:
     name: Bundle and analyze affected projects
     runs-on: ubuntu-latest
@@ -65,7 +71,7 @@ jobs:
   publish-preview:
     name: Preview ${{ matrix.project.name }}
     runs-on: ubuntu-latest
-    needs: [bundle-projects]
+    needs: [bundle-projects, preview-gate]
     if: needs.bundle-projects.outputs.has-projects == 'true'
     environment: preview
     permissions:
@@ -137,6 +143,62 @@ jobs:
         with:
           content: ${{ steps.content.outputs.body }}
           regex: '<!-- start Preview packages update -->.*?<!-- end Preview packages update -->'
+          regexFlags: ims
+          appendContentOnMatchOnly: 'true'
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy-preview-web:
+    name: Deploy preview docs
+    runs-on: ubuntu-latest
+    needs: [ci, preview-gate]
+    environment: preview
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/prepare
+
+      - name: Build docs site
+        run: pnpm exec turbo run build --filter=@betternotify/web...
+
+      - name: Upload preview version
+        id: preview
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/web
+          command: versions upload --preview-alias "pr-${{ github.event.pull_request.number }}"
+
+      - name: Parse preview URL
+        id: url
+        shell: bash
+        run: |
+          url=$(echo "${{ steps.preview.outputs.command-output }}" | grep -oP 'https://pr-\d+-[^\s]+\.workers\.dev' | head -1)
+
+          if [[ -z "$url" ]]; then
+            echo "::error::Could not parse preview URL from wrangler output"
+            exit 1
+          fi
+
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Update PR description with preview URL
+        uses: nefrob/pr-description@4dcc9f3ad5ec06b2a197c5f8f93db5e69d2fdca7 # v1.2.0
+        with:
+          content: |
+            <!-- start Preview docs URL -->
+            <details>
+            <summary>Preview docs</summary>
+
+            | Site | URL |
+            | --- | --- |
+            | Docs | [${{ steps.url.outputs.url }}](${{ steps.url.outputs.url }}) |
+
+            </details>
+            <!-- end Preview docs URL -->
+          regex: '<!-- start Preview docs URL -->.*?<!-- end Preview docs URL -->'
           regexFlags: ims
           appendContentOnMatchOnly: 'true'
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Overview

Add preview docs deployment gated on the `preview` environment, so reviewers can test docs changes live before merging.

# What's changed and why?

- `.github/workflows/ci.yml` — Added `preview-gate` job that skips fork PRs in one place. Added `deploy-preview-web` job that builds the docs site and uploads a preview version via `cloudflare/wrangler-action`. Parses the preview URL and posts it to the PR description. Existing `publish-preview` now also depends on `preview-gate`.
- `.github/pull_request_template.md` — Added preview docs URL markers so the preview URL gets injected into PR descriptions.

# How to test

1. Open this PR and check the CI tab
2. Approve the `preview` environment when prompted
3. Verify the preview URL appears in the PR description
4. Visit the preview URL and confirm the docs site loads

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<details>
<summary>Preview docs</summary>

| Site | URL |
| --- | --- |
| Docs | [https://pr-30-better-notify.reis.workers.dev](https://pr-30-better-notify.reis.workers.dev) |

</details>
<!-- end Preview docs URL -->
