### PR TITLE
feat(resend): implement Resend transport

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Better-Notify is an end-to-end typed email infrastructure for Node.js (ESM-only, Node ≥ 22). A single `EmailCatalog` type drives the typed sender, queue worker, and webhook router — analogous to tRPC/oRPC, but for email. The canonical design spec lives at `plan/betternotify-spec.md` (gitignored, kept locally); the active per-feature design and execution docs live under `docs/superpowers/{specs,plans}/` (also gitignored). Treat the spec as the source of truth when behavior is ambiguous.
 
-Status: v0.1.0-alpha. Layer 1 (typed contracts in `@betternotify/core`) plus build/release tooling are real. Adapter packages (`react-email`, `mjml`, `handlebars`, `ses`, `resend`, `bullmq`) and Layers 5–6 are stubs filled in over the v0.2+ roadmap.
+Status: v0.1.0-alpha. Layer 1 (typed contracts in `@betternotify/core`) plus build/release tooling are real. Adapter packages (`react-email`, `mjml`, `handlebars`, `ses`, `bullmq`) and Layers 5–6 are stubs filled in over the v0.2+ roadmap.
 
 ## Commands
 

--- a/apps/web/content/docs/transports/third-party/resend.mdx
+++ b/apps/web/content/docs/transports/third-party/resend.mdx
@@ -1,7 +1,143 @@
 ---
 title: Resend
 icon: PaperPlane
-description: Send emails via Resend
+description: Send emails via the Resend HTTP API
 ---
 
-Documentation coming soon.
+import { TypeTable } from 'fumadocs-ui/components/type-table';
+
+The Resend transport is an official Better-Notify package that sends email through the [Resend](https://resend.com) HTTP API. It uses plain `fetch()` with zero external dependencies, so it works in Node.js, Cloudflare Workers, and any runtime with a global `fetch`.
+
+## Install
+
+```package-install
+@betternotify/resend @betternotify/core @betternotify/email
+```
+
+## Getting your API key
+
+1. Sign up or log in at [resend.com](https://resend.com).
+2. Go to **API Keys** in the sidebar.
+3. Click **Create API Key**, give it a name, and select **Sending access** with the domain(s) you want to send from.
+4. Copy the key — it starts with `re_` and is only shown once.
+
+Store it as an environment variable:
+
+```sh
+RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+<Callout type="info">
+  You must [verify your domain](https://resend.com/docs/dashboard/domains/introduction) before sending to addresses outside of `delivered@resend.dev`.
+</Callout>
+
+## Usage
+
+```ts
+import { createNotify, createClient } from '@betternotify/core';
+import { emailChannel } from '@betternotify/email';
+import { resendTransport } from '@betternotify/resend';
+
+const email = emailChannel({
+  defaults: { from: { name: 'My App', email: 'noreply@example.com' } },
+});
+
+const rpc = createNotify({ channels: { email } });
+const catalog = rpc.catalog({
+  /* routes */
+});
+
+const mail = createClient({
+  catalog,
+  channels: { email },
+  transportsByChannel: {
+    email: resendTransport({
+      apiKey: process.env.RESEND_API_KEY!,
+    }),
+  },
+});
+```
+
+## Options
+
+<TypeTable
+  type={{
+    apiKey: {
+      description: 'Resend API key (starts with re_). Required.',
+      type: 'string',
+    },
+    baseUrl: {
+      description: 'Override the Resend API base URL. Useful for testing.',
+      type: 'string',
+      default: '"https://api.resend.com"',
+    },
+    timeoutMs: {
+      description: 'Request timeout in milliseconds.',
+      type: 'number',
+      default: '30000',
+    },
+    logger: {
+      description: 'Override the default logger.',
+      type: 'LoggerLike',
+    },
+  }}
+/>
+
+## Error handling
+
+The transport maps Resend HTTP status codes to Better-Notify error codes:
+
+| HTTP status | Resend error | Better-Notify code |
+| --- | --- | --- |
+| 422 | `missing_required_field`, `invalid_from_address`, `invalid_attachment` | `VALIDATION` |
+| 401 | `missing_api_key` | `CONFIG` |
+| 403 | `invalid_api_key`, `restricted_api_key` | `CONFIG` |
+| 429 | `rate_limit_exceeded`, `daily_quota_exceeded` | `PROVIDER` |
+| 500 | `internal_server_error` | `PROVIDER` |
+
+When a 429 response includes a `Retry-After` header, the value is included in the error message.
+
+Network failures and unparseable responses are wrapped as `PROVIDER` errors. Timeouts are wrapped as `TIMEOUT` errors.
+
+## Tags
+
+Resend supports email tags for tracking and analytics. Better-Notify's `tags` field (a `Record<string, string | number | boolean>`) is converted to Resend's `Array<{ name, value }>` format automatically:
+
+```ts
+await mail.welcome.send({
+  to: 'user@example.com',
+  input: { name: 'Alice' },
+  tags: { campaign: 'onboarding', version: 2 },
+});
+// Sent as: [{ name: "campaign", value: "onboarding" }, { name: "version", value: "2" }]
+```
+
+Tag names and values must be ASCII alphanumeric, underscores, or dashes (max 256 characters each). Invalid tags are rejected by Resend with a 422 error.
+
+## Attachments
+
+The transport base64-encodes attachment content before sending:
+
+- `contentType` maps to Resend's `content_type` field (optional — Resend infers it when omitted).
+- `cid` maps to `content_id` for inline images.
+
+```ts
+await mail.invoice.send({
+  to: 'user@example.com',
+  input: { orderId: '12345' },
+  attachments: [
+    { filename: 'invoice.pdf', content: pdfBuffer, contentType: 'application/pdf' },
+  ],
+});
+```
+
+## Limits
+
+These limits are enforced by Resend, not by the transport:
+
+- **50 recipients** per email (to + cc + bcc combined)
+- **40 MB** total attachment size per email
+- Daily and monthly sending limits depend on your [Resend plan](https://resend.com/pricing)
+- Tag names and values: ASCII alphanumeric, underscores, dashes, max 256 characters
+
+If you need throttling or provider fallback, add `withRateLimit` middleware or wrap the transport in `multiTransport({ strategy: 'failover' })`.

--- a/examples/welcome-text/apps/cli/.env.example
+++ b/examples/welcome-text/apps/cli/.env.example
@@ -13,3 +13,7 @@ CF_ACCOUNT_ID=account-id
 CF_API_TOKEN=api-token
 CF_FROM_EMAIL=noreply@example.com
 CF_DESTINATION_EMAIL=example@email.com
+
+RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxxx
+RESEND_FROM_EMAIL=noreply@example.com
+RESEND_DESTINATION_EMAIL=example@email.com

--- a/examples/welcome-text/apps/cli/package.json
+++ b/examples/welcome-text/apps/cli/package.json
@@ -10,12 +10,13 @@
     "dotenvx": "dotenvx"
   },
   "dependencies": {
+    "@betternotify/cloudflare-email": "workspace:*",
     "@betternotify/core": "workspace:*",
     "@betternotify/email": "workspace:*",
     "@betternotify/push": "workspace:*",
     "@betternotify/react-email": "workspace:*",
+    "@betternotify/resend": "workspace:*",
     "@betternotify/sms": "workspace:*",
-    "@betternotify/cloudflare-email": "workspace:*",
     "@betternotify/smtp": "workspace:*",
     "@betternotify/telegram": "workspace:*",
     "@t3-oss/env-core": "0.13.11",

--- a/examples/welcome-text/apps/cli/src/env.ts
+++ b/examples/welcome-text/apps/cli/src/env.ts
@@ -30,6 +30,18 @@ export const env = createEnv({
       .optional()
       .default('example@email.com')
       .describe('Cloudflare destination email'),
+
+    RESEND_API_KEY: z.string().optional().default('re_test_123').describe('Resend API key'),
+    RESEND_FROM_EMAIL: z
+      .string()
+      .optional()
+      .default('noreply@example.com')
+      .describe('Resend from email'),
+    RESEND_DESTINATION_EMAIL: z
+      .string()
+      .optional()
+      .default('example@email.com')
+      .describe('Resend destination email'),
   },
   runtimeEnv: process.env,
 });

--- a/examples/welcome-text/apps/cli/src/examples/resend-attachment.ts
+++ b/examples/welcome-text/apps/cli/src/examples/resend-attachment.ts
@@ -1,6 +1,6 @@
 import { createNotify, createClient, consoleLogger } from '@betternotify/core';
 import { emailChannel } from '@betternotify/email';
-import { cloudflareEmailTransport } from '@betternotify/cloudflare-email';
+import { resendTransport } from '@betternotify/resend';
 import { z } from 'zod';
 import { env } from '../env';
 import { readFile } from 'node:fs/promises';
@@ -9,7 +9,7 @@ import path from 'node:path';
 const pdfBuffer = await readFile(path.join(import.meta.dirname, '../test-utils/example-pdf.pdf'));
 
 const ch = emailChannel({
-  defaults: { from: { name: 'Better-Notify', email: env.CF_FROM_EMAIL } },
+  defaults: { from: { name: 'Better-Notify', email: env.RESEND_FROM_EMAIL } },
 });
 
 const rpc = createNotify({ channels: { email: ch } });
@@ -27,21 +27,20 @@ const catalog = rpc.catalog({
     }),
 });
 
-export const runCloudflareEmailAttachment = async (): Promise<void> => {
+export const runResendAttachment = async (): Promise<void> => {
   const mail = createClient({
     catalog,
     channels: { email: ch },
     transportsByChannel: {
-      email: cloudflareEmailTransport({
-        accountId: env.CF_ACCOUNT_ID,
-        apiToken: env.CF_API_TOKEN,
+      email: resendTransport({
+        apiKey: env.RESEND_API_KEY,
       }),
     },
     logger: consoleLogger({ level: 'debug' }),
   });
 
   const result = await mail.invoice.send({
-    to: env.CF_DESTINATION_EMAIL,
+    to: env.RESEND_DESTINATION_EMAIL,
     input: { orderId: '12345', customerName: 'John Doe' },
     attachments: [
       {

--- a/examples/welcome-text/apps/cli/src/examples/resend.ts
+++ b/examples/welcome-text/apps/cli/src/examples/resend.ts
@@ -1,0 +1,48 @@
+import { createNotify, createClient, consoleLogger } from '@betternotify/core';
+import { emailChannel } from '@betternotify/email';
+import { resendTransport } from '@betternotify/resend';
+import { z } from 'zod';
+import { env } from '../env';
+
+const ch = emailChannel({
+  defaults: { from: { name: 'Better-Notify', email: env.RESEND_FROM_EMAIL } },
+});
+
+const rpc = createNotify({ channels: { email: ch } });
+
+const catalog = rpc.catalog({
+  welcome: rpc
+    .email()
+    .input(z.object({ name: z.string(), verifyUrl: z.string().url() }))
+    .subject(({ input }) => `Welcome, ${input.name}!`)
+    .template({
+      render: async ({ input }) => ({
+        text: `Welcome, ${input.name}! Verify here: ${input.verifyUrl}`,
+        html: `<p>Welcome, ${input.name}! <a href="${input.verifyUrl}">Verify</a></p>`,
+      }),
+    }),
+});
+
+export const runResend = async (): Promise<void> => {
+  const mail = createClient({
+    catalog,
+    channels: { email: ch },
+    transportsByChannel: {
+      email: resendTransport({
+        apiKey: env.RESEND_API_KEY,
+      }),
+    },
+    logger: consoleLogger({ level: 'debug' }),
+  });
+
+  const result = await mail.welcome.send({
+    to: env.RESEND_DESTINATION_EMAIL,
+    input: { name: 'John Doe', verifyUrl: 'https://example.com/verify?token=abc123' },
+  });
+
+  console.log('Message ID:', result.messageId);
+  console.log('From:      ', result.envelope?.from);
+  console.log('To:        ', result.envelope?.to.join(', '));
+  console.log('Render:    ', `${result.timing.renderMs.toFixed(1)}ms`);
+  console.log('Send:      ', `${result.timing.sendMs.toFixed(1)}ms`);
+};

--- a/examples/welcome-text/apps/cli/src/index.ts
+++ b/examples/welcome-text/apps/cli/src/index.ts
@@ -22,6 +22,8 @@ import { runTelegram } from './examples/telegram';
 import { runTelegramCrossTransport } from './examples/telegram-cross-transport';
 import { runCloudflareEmail } from './examples/cloudflare-email';
 import { runCloudflareEmailAttachment } from './examples/cloudflare-email-attachment';
+import { runResend } from './examples/resend';
+import { runResendAttachment } from './examples/resend-attachment';
 
 const examples: Record<string, () => Promise<void>> = {
   single: runSingle,
@@ -48,6 +50,8 @@ const examples: Record<string, () => Promise<void>> = {
   'telegram-cross-transport': runTelegramCrossTransport,
   'cloudflare-email': runCloudflareEmail,
   'cloudflare-email-attachment': runCloudflareEmailAttachment,
+  resend: runResend,
+  'resend-attachment': runResendAttachment,
 };
 
 const main = async (): Promise<void> => {

--- a/packages/cloudflare-email/src/index.test.ts
+++ b/packages/cloudflare-email/src/index.test.ts
@@ -43,9 +43,7 @@ describe('cloudflareEmailTransport', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0]!;
-    expect(url).toBe(
-      'https://api.cloudflare.com/client/v4/accounts/acc123/email/sending/send',
-    );
+    expect(url).toBe('https://api.cloudflare.com/client/v4/accounts/acc123/email/sending/send');
     expect(init.method).toBe('POST');
     expect(init.headers['Authorization']).toBe('Bearer tok456');
     expect(init.headers['Content-Type']).toBe('application/json');
@@ -379,9 +377,7 @@ describe('cloudflareEmailTransport — network errors', () => {
 
   it('returns PROVIDER when response is valid JSON but missing errors/result fields', async () => {
     const { cloudflareEmailTransport } = await import('./index.js');
-    fetchMock.mockResolvedValue(
-      new Response(JSON.stringify({ success: false }), { status: 400 }),
-    );
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ success: false }), { status: 400 }));
     const t = cloudflareEmailTransport({ accountId: 'acc123', apiToken: 'tok456' });
     const result = await t.send(baseMessage, baseCtx);
 

--- a/packages/resend/package.json
+++ b/packages/resend/package.json
@@ -37,9 +37,6 @@
     "typescript": "catalog:",
     "vitest": "catalog:"
   },
-  "peerDependencies": {
-    "resend": "catalog:"
-  },
   "engines": {
     "node": ">=22"
   }

--- a/packages/resend/rolldown.config.ts
+++ b/packages/resend/rolldown.config.ts
@@ -2,5 +2,4 @@ import { baseConfig } from '@internal/rolldown-config';
 
 export default baseConfig({
   entries: { index: 'src/index.ts' },
-  external: ['resend'],
 });

--- a/packages/resend/src/index.test.ts
+++ b/packages/resend/src/index.test.ts
@@ -1,12 +1,447 @@
-import { describe, expect, it } from 'vitest';
-import { resendTransport, resendAdapter } from './index.js';
+import { describe, expect, it, vi, beforeEach, type Mock } from 'vitest';
+import type { RenderedMessage } from '@betternotify/email';
+import type { SendContext } from '@betternotify/core';
+import { NotifyRpcError } from '@betternotify/core';
 
-describe('@betternotify/resend (stub)', () => {
-  it('resendTransport() throws not-implemented', () => {
-    expect(() => resendTransport({ apiKey: 'fake' })).toThrow(/not implemented/);
+let fetchMock: Mock;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+const baseMessage: RenderedMessage = {
+  from: { name: 'App', email: 'noreply@example.com' },
+  to: [{ email: 'user@example.com' }],
+  subject: 'Hello',
+  html: '<p>hi</p>',
+  text: 'hi',
+};
+
+const baseCtx: SendContext = { route: 'welcome', messageId: 'm1', attempt: 1 };
+
+const okResponse = { id: '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794' };
+
+const mockFetchOk = () =>
+  fetchMock.mockResolvedValue(new Response(JSON.stringify(okResponse), { status: 200 }));
+
+describe('resendTransport', () => {
+  it('sends a POST to the Resend API with correct URL and auth header', async () => {
+    const { resendTransport } = await import('./index.js');
+    mockFetchOk();
+    const t = resendTransport({ apiKey: 're_test_123' });
+    await t.send(baseMessage, baseCtx);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.resend.com/emails');
+    expect(init.method).toBe('POST');
+    expect(init.headers['Authorization']).toBe('Bearer re_test_123');
+    expect(init.headers['Content-Type']).toBe('application/json');
   });
 
-  it('resendAdapter() throws not-implemented', () => {
+  it('maps RenderedMessage fields to the Resend request body', async () => {
+    const { resendTransport } = await import('./index.js');
+    mockFetchOk();
+    const t = resendTransport({ apiKey: 're_test_123' });
+    await t.send(
+      {
+        ...baseMessage,
+        cc: [{ name: 'CC User', email: 'cc@example.com' }],
+        bcc: ['bcc@example.com'],
+        replyTo: { name: 'Reply', email: 'reply@example.com' },
+        headers: { 'X-Campaign': 'launch' },
+      },
+      baseCtx,
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.from).toBe('"App" <noreply@example.com>');
+    expect(body.to).toEqual(['user@example.com']);
+    expect(body.cc).toEqual(['"CC User" <cc@example.com>']);
+    expect(body.bcc).toEqual(['bcc@example.com']);
+    expect(body.reply_to).toEqual(['"Reply" <reply@example.com>']);
+    expect(body.subject).toBe('Hello');
+    expect(body.html).toBe('<p>hi</p>');
+    expect(body.text).toBe('hi');
+    expect(body.headers).toEqual({ 'X-Campaign': 'launch' });
+  });
+
+  it('returns EmailTransportData with transportMessageId from Resend response', async () => {
+    const { resendTransport } = await import('./index.js');
+    mockFetchOk();
+    const t = resendTransport({ apiKey: 're_test_123' });
+    const result = await t.send(baseMessage, baseCtx);
+
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.data.transportMessageId).toBe('49a3999c-0ce1-4ea6-ab68-afcd6dc2e794');
+    expect(result.data.accepted).toEqual(['user@example.com']);
+    expect(result.data.rejected).toEqual([]);
+    expect(result.data.raw).toMatchObject({ id: '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794' });
+  });
+
+  it('uses custom baseUrl when provided', async () => {
+    const { resendTransport } = await import('./index.js');
+    mockFetchOk();
+    const t = resendTransport({ apiKey: 're_test_123', baseUrl: 'https://mock.local' });
+    await t.send(baseMessage, baseCtx);
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://mock.local/emails');
+  });
+
+  it('omits optional fields from request body when not in RenderedMessage', async () => {
+    const { resendTransport } = await import('./index.js');
+    mockFetchOk();
+    const t = resendTransport({ apiKey: 're_test_123' });
+    await t.send({ from: 'a@x.com', to: ['b@x.com'], subject: 's', html: '<p>h</p>' }, baseCtx);
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.cc).toBeUndefined();
+    expect(body.bcc).toBeUndefined();
+    expect(body.reply_to).toBeUndefined();
+    expect(body.text).toBeUndefined();
+    expect(body.attachments).toBeUndefined();
+    expect(body.headers).toBeUndefined();
+    expect(body.tags).toBeUndefined();
+  });
+
+  it('has name "resend"', async () => {
+    const { resendTransport } = await import('./index.js');
+    const t = resendTransport({ apiKey: 're_test_123' });
+    expect(t.name).toBe('resend');
+  });
+
+  it('maps string from address directly', async () => {
+    const { resendTransport } = await import('./index.js');
+    mockFetchOk();
+    const t = resendTransport({ apiKey: 're_test_123' });
+    await t.send({ ...baseMessage, from: 'plain@example.com' }, baseCtx);
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.from).toBe('plain@example.com');
+  });
+
+  it('maps tags from Record to array of { name, value } pairs', async () => {
+    const { resendTransport } = await import('./index.js');
+    mockFetchOk();
+    const t = resendTransport({ apiKey: 're_test_123' });
+    await t.send(
+      { ...baseMessage, tags: { campaign: 'launch', version: 2, active: true } },
+      baseCtx,
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.tags).toEqual([
+      { name: 'campaign', value: 'launch' },
+      { name: 'version', value: '2' },
+      { name: 'active', value: 'true' },
+    ]);
+  });
+
+  it('drops unsupported fields (priority, inlineAssets) without error', async () => {
+    const { resendTransport } = await import('./index.js');
+    mockFetchOk();
+    const t = resendTransport({ apiKey: 're_test_123' });
+    const result = await t.send(
+      {
+        ...baseMessage,
+        priority: 'high',
+        inlineAssets: { logo: { path: '/logo.png' } },
+      },
+      baseCtx,
+    );
+
+    expect(result.ok).toBe(true);
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.priority).toBeUndefined();
+    expect(body.inlineAssets).toBeUndefined();
+  });
+
+  it('populates accepted from all to recipients', async () => {
+    const { resendTransport } = await import('./index.js');
+    mockFetchOk();
+    const t = resendTransport({ apiKey: 're_test_123' });
+    const result = await t.send(
+      {
+        ...baseMessage,
+        to: [{ email: 'a@x.com' }, { email: 'b@x.com' }, 'c@x.com'],
+      },
+      baseCtx,
+    );
+
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.data.accepted).toEqual(['a@x.com', 'b@x.com', 'c@x.com']);
+  });
+});
+
+describe('resendTransport — from validation', () => {
+  it('throws CONFIG error when from is missing', async () => {
+    const { resendTransport } = await import('./index.js');
+    const t = resendTransport({ apiKey: 're_test_123' });
+    const msg = { ...baseMessage } as Record<string, unknown>;
+    delete msg.from;
+    await expect(t.send(msg as never, baseCtx)).rejects.toThrow(/no "from"/);
+  });
+});
+
+describe('resendTransport — Resend API errors', () => {
+  it('returns VALIDATION for 422 status', async () => {
+    const { resendTransport } = await import('./index.js');
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          statusCode: 422,
+          message: 'Missing `to` field.',
+          name: 'missing_required_field',
+        }),
+        { status: 422 },
+      ),
+    );
+    const t = resendTransport({ apiKey: 're_test_123' });
+    const result = await t.send(baseMessage, baseCtx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    expect(result.error).toBeInstanceOf(NotifyRpcError);
+    expect((result.error as NotifyRpcError).code).toBe('VALIDATION');
+    expect(result.error.message).toContain('missing_required_field');
+  });
+
+  it('returns CONFIG for 401 status', async () => {
+    const { resendTransport } = await import('./index.js');
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          statusCode: 401,
+          message: 'Missing API key in the authorization header.',
+          name: 'missing_api_key',
+        }),
+        { status: 401 },
+      ),
+    );
+    const t = resendTransport({ apiKey: '' });
+    const result = await t.send(baseMessage, baseCtx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    expect((result.error as NotifyRpcError).code).toBe('CONFIG');
+  });
+
+  it('returns CONFIG for 403 status', async () => {
+    const { resendTransport } = await import('./index.js');
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          statusCode: 403,
+          message: 'API key is invalid.',
+          name: 'invalid_api_key',
+        }),
+        { status: 403 },
+      ),
+    );
+    const t = resendTransport({ apiKey: 're_bad_key' });
+    const result = await t.send(baseMessage, baseCtx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    expect((result.error as NotifyRpcError).code).toBe('CONFIG');
+  });
+
+  it('returns PROVIDER for 429 rate limit', async () => {
+    const { resendTransport } = await import('./index.js');
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          statusCode: 429,
+          message: 'Too many requests.',
+          name: 'rate_limit_exceeded',
+        }),
+        { status: 429, headers: { 'Retry-After': '30' } },
+      ),
+    );
+    const t = resendTransport({ apiKey: 're_test_123' });
+    const result = await t.send(baseMessage, baseCtx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
+    expect(result.error.message).toContain('retry after 30s');
+  });
+
+  it('returns PROVIDER for 500 server error', async () => {
+    const { resendTransport } = await import('./index.js');
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          statusCode: 500,
+          message: 'Internal server error.',
+          name: 'internal_server_error',
+        }),
+        { status: 500 },
+      ),
+    );
+    const t = resendTransport({ apiKey: 're_test_123' });
+    const result = await t.send(baseMessage, baseCtx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
+  });
+
+  it('includes error name and message in the error string', async () => {
+    const { resendTransport } = await import('./index.js');
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          statusCode: 422,
+          message: 'Invalid `from` field.',
+          name: 'invalid_from_address',
+        }),
+        { status: 422 },
+      ),
+    );
+    const t = resendTransport({ apiKey: 're_test_123' });
+    const result = await t.send(baseMessage, baseCtx);
+
+    if (result.ok) throw new Error('expected not ok');
+    expect(result.error.message).toContain('invalid_from_address');
+    expect(result.error.message).toContain('Invalid `from` field.');
+  });
+});
+
+describe('resendTransport — network errors', () => {
+  it('returns PROVIDER when fetch throws (network failure)', async () => {
+    const { resendTransport } = await import('./index.js');
+    fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+    const t = resendTransport({ apiKey: 're_test_123' });
+    const result = await t.send(baseMessage, baseCtx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
+    expect(result.error.message).toContain('network error');
+  });
+
+  it('returns TIMEOUT when fetch throws TimeoutError', async () => {
+    const { resendTransport } = await import('./index.js');
+    const err = new DOMException('signal timed out', 'TimeoutError');
+    fetchMock.mockRejectedValue(err);
+    const t = resendTransport({ apiKey: 're_test_123' });
+    const result = await t.send(baseMessage, baseCtx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    expect((result.error as NotifyRpcError).code).toBe('TIMEOUT');
+    expect(result.error.message).toContain('request timed out');
+  });
+
+  it('returns PROVIDER when response body is not valid JSON', async () => {
+    const { resendTransport } = await import('./index.js');
+    fetchMock.mockResolvedValue(new Response('not json', { status: 200 }));
+    const t = resendTransport({ apiKey: 're_test_123' });
+    const result = await t.send(baseMessage, baseCtx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
+  });
+});
+
+describe('resendTransport — attachments', () => {
+  it('base64-encodes Buffer attachment content', async () => {
+    const { resendTransport } = await import('./index.js');
+    mockFetchOk();
+    const t = resendTransport({ apiKey: 're_test_123' });
+    await t.send(
+      {
+        ...baseMessage,
+        attachments: [
+          {
+            filename: 'invoice.pdf',
+            content: Buffer.from('pdf-bytes'),
+            contentType: 'application/pdf',
+          },
+        ],
+      },
+      baseCtx,
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.attachments).toEqual([
+      {
+        content: Buffer.from('pdf-bytes').toString('base64'),
+        filename: 'invoice.pdf',
+        content_type: 'application/pdf',
+      },
+    ]);
+  });
+
+  it('base64-encodes string attachment content', async () => {
+    const { resendTransport } = await import('./index.js');
+    mockFetchOk();
+    const t = resendTransport({ apiKey: 're_test_123' });
+    await t.send(
+      {
+        ...baseMessage,
+        attachments: [
+          {
+            filename: 'note.txt',
+            content: 'hello world',
+            contentType: 'text/plain',
+          },
+        ],
+      },
+      baseCtx,
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.attachments[0].content).toBe(Buffer.from('hello world').toString('base64'));
+  });
+
+  it('maps cid to content_id', async () => {
+    const { resendTransport } = await import('./index.js');
+    mockFetchOk();
+    const t = resendTransport({ apiKey: 're_test_123' });
+    await t.send(
+      {
+        ...baseMessage,
+        attachments: [
+          {
+            filename: 'logo.png',
+            content: Buffer.from('png-bytes'),
+            contentType: 'image/png',
+            cid: 'logo@inline',
+          },
+        ],
+      },
+      baseCtx,
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.attachments[0].content_id).toBe('logo@inline');
+  });
+
+  it('omits content_type when not provided', async () => {
+    const { resendTransport } = await import('./index.js');
+    mockFetchOk();
+    const t = resendTransport({ apiKey: 're_test_123' });
+    await t.send(
+      {
+        ...baseMessage,
+        attachments: [{ filename: 'data.bin', content: Buffer.from('bytes') }],
+      },
+      baseCtx,
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(body.attachments[0].content_type).toBeUndefined();
+  });
+});
+
+describe('resendAdapter (stub)', () => {
+  it('throws not-implemented', async () => {
+    const { resendAdapter } = await import('./index.js');
     expect(() => resendAdapter()).toThrow(/not implemented/);
   });
 });

--- a/packages/resend/src/index.ts
+++ b/packages/resend/src/index.ts
@@ -1,24 +1,182 @@
-import { NotifyRpcNotImplementedError } from '@betternotify/core';
-import type { Transport } from '@betternotify/email/transports';
+import type { RenderedMessage } from '@betternotify/email';
+import { createTransport, formatAddress, normalizeAddress } from '@betternotify/email/transports';
+import { consoleLogger, handlePromise, NotifyRpcError } from '@betternotify/core';
 import type { WebhookAdapter } from '@betternotify/core/webhook';
+import { NotifyRpcNotImplementedError } from '@betternotify/core';
+import type {
+  ResendTransportOptions,
+  ResendAttachment,
+  ResendRequest,
+  ResendSuccessResponse,
+  ResendErrorResponse,
+} from './types.js';
 
-/** @experimental Resend transport — not yet implemented; ships in v0.3. */
-export type ResendTransportOptions = {
-  apiKey: string;
-  baseUrl?: string;
+export type {
+  ResendTransportOptions,
+  ResendAttachment,
+  ResendRequest,
+  ResendSuccessResponse,
+  ResendErrorResponse,
+  ResendTag,
+} from './types.js';
+
+const DEFAULT_BASE_URL = 'https://api.resend.com';
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+const toBase64 = (content: Buffer | string): string => {
+  if (Buffer.isBuffer(content)) return content.toString('base64');
+  return Buffer.from(content).toString('base64');
 };
 
-/** @experimental Resend transport — not yet implemented; ships in v0.3. */
-export const resendTransport = (_opts: ResendTransportOptions): Transport => {
-  throw new NotifyRpcNotImplementedError('@betternotify/resend transport (v0.3)');
+const toAttachments = (
+  attachments: NonNullable<RenderedMessage['attachments']>,
+): ResendAttachment[] =>
+  attachments.map((att) => ({
+    content: toBase64(att.content),
+    filename: att.filename,
+    ...(att.contentType ? { content_type: att.contentType } : {}),
+    ...(att.cid ? { content_id: att.cid } : {}),
+  }));
+
+const buildRequestBody = (message: RenderedMessage, from: string): ResendRequest => {
+  const body: ResendRequest = {
+    from,
+    to: message.to.map(formatAddress),
+    subject: message.subject,
+  };
+
+  if (message.html) body.html = message.html;
+  if (message.text) body.text = message.text;
+  if (message.cc?.length) body.cc = message.cc.map(formatAddress);
+  if (message.bcc?.length) body.bcc = message.bcc.map(formatAddress);
+  if (message.replyTo) body.reply_to = [formatAddress(message.replyTo)];
+  if (message.headers && Object.keys(message.headers).length > 0) body.headers = message.headers;
+  if (message.attachments?.length) body.attachments = toAttachments(message.attachments);
+  if (message.tags && Object.keys(message.tags).length > 0) {
+    body.tags = Object.entries(message.tags).map(([name, value]) => ({
+      name,
+      value: String(value),
+    }));
+  }
+
+  return body;
 };
 
-/** @experimental Resend webhook adapter — not yet implemented; ships in v0.3. */
+const mapErrorCode = (status: number): 'VALIDATION' | 'CONFIG' | 'PROVIDER' => {
+  if (status === 422) return 'VALIDATION';
+  if (status === 401 || status === 403) return 'CONFIG';
+  return 'PROVIDER';
+};
+
+/** @experimental Resend transport using the Resend HTTP API. */
+export const resendTransport = (opts: ResendTransportOptions) => {
+  const baseUrl = (opts.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+  const url = `${baseUrl}/emails`;
+  const log = (opts.logger ?? consoleLogger()).child({ component: 'resend' });
+
+  return createTransport({
+    name: 'resend',
+    async send(message, ctx) {
+      if (!message.from) {
+        throw new NotifyRpcError({
+          message:
+            'Resend transport: no "from" address. Set it on the channel default, route `.from()` resolver, or per-call args.',
+          code: 'CONFIG',
+          route: ctx.route,
+          messageId: ctx.messageId,
+        });
+      }
+
+      const body = buildRequestBody(message, formatAddress(message.from));
+
+      const [fetchErr, response] = await handlePromise(
+        fetch(url, {
+          method: 'POST',
+          signal: AbortSignal.timeout(opts.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+          headers: {
+            Authorization: `Bearer ${opts.apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(body),
+        }),
+      );
+
+      if (fetchErr) {
+        const isTimeout = fetchErr.name === 'TimeoutError' || fetchErr.name === 'AbortError';
+        log.error('Resend fetch failed', { err: fetchErr, route: ctx.route });
+        return {
+          ok: false,
+          error: new NotifyRpcError({
+            message: `Resend transport: ${isTimeout ? 'request timed out' : `network error: ${fetchErr.message}`}`,
+            code: isTimeout ? 'TIMEOUT' : 'PROVIDER',
+            route: ctx.route,
+            messageId: ctx.messageId,
+            cause: fetchErr,
+          }),
+        };
+      }
+
+      const [parseErr, data] = await handlePromise(
+        response.json() as Promise<ResendSuccessResponse | ResendErrorResponse>,
+      );
+
+      if (parseErr) {
+        log.error('Resend response parse failed', { err: parseErr, route: ctx.route });
+        return {
+          ok: false,
+          error: new NotifyRpcError({
+            message: 'Resend transport: failed to parse response',
+            code: 'PROVIDER',
+            route: ctx.route,
+            messageId: ctx.messageId,
+            cause: parseErr,
+          }),
+        };
+      }
+
+      if (!response.ok) {
+        const errData = data as ResendErrorResponse;
+        const code = mapErrorCode(response.status);
+        const retryAfter = response.headers.get('retry-after');
+        const suffix = retryAfter ? ` (retry after ${retryAfter}s)` : '';
+
+        const errorMessage = `Resend transport: [${errData.name}] ${errData.message}${suffix}`;
+        log.error(errorMessage, {
+          err: { status: response.status, name: errData.name, message: errData.message },
+          route: ctx.route,
+        });
+
+        return {
+          ok: false,
+          error: new NotifyRpcError({
+            message: errorMessage,
+            code,
+            route: ctx.route,
+            messageId: ctx.messageId,
+          }),
+        };
+      }
+
+      const successData = data as ResendSuccessResponse;
+      return {
+        ok: true,
+        data: {
+          transportMessageId: successData.id,
+          accepted: message.to.map(normalizeAddress),
+          rejected: [],
+          raw: successData,
+        },
+      };
+    },
+  });
+};
+
+/** @experimental Resend webhook adapter — not yet implemented; ships in a later release. */
 export type ResendAdapterOptions = {
   webhookSecret?: string;
 };
 
-/** @experimental Resend webhook adapter — not yet implemented; ships in v0.3. */
+/** @experimental Resend webhook adapter — not yet implemented; ships in a later release. */
 export const resendAdapter = (_opts: ResendAdapterOptions = {}): WebhookAdapter => {
-  throw new NotifyRpcNotImplementedError('@betternotify/resend webhook adapter (v0.3)');
+  throw new NotifyRpcNotImplementedError('@betternotify/resend webhook adapter');
 };

--- a/packages/resend/src/types.ts
+++ b/packages/resend/src/types.ts
@@ -1,0 +1,44 @@
+import type { LoggerLike } from '@betternotify/core';
+
+export type ResendTransportOptions = {
+  apiKey: string;
+  baseUrl?: string;
+  timeoutMs?: number;
+  logger?: LoggerLike;
+};
+
+export type ResendAttachment = {
+  filename: string;
+  content: string;
+  content_type?: string;
+  content_id?: string;
+};
+
+export type ResendTag = {
+  name: string;
+  value: string;
+};
+
+export type ResendRequest = {
+  from: string;
+  to: string[];
+  subject: string;
+  html?: string;
+  text?: string;
+  cc?: string[];
+  bcc?: string[];
+  reply_to?: string[];
+  headers?: Record<string, string>;
+  attachments?: ResendAttachment[];
+  tags?: ResendTag[];
+};
+
+export type ResendSuccessResponse = {
+  id: string;
+};
+
+export type ResendErrorResponse = {
+  statusCode: number;
+  message: string;
+  name: string;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,9 @@ importers:
       '@betternotify/react-email':
         specifier: workspace:*
         version: link:../../../../packages/react-email
+      '@betternotify/resend':
+        specifier: workspace:*
+        version: link:../../../../packages/resend
       '@betternotify/sms':
         specifier: workspace:*
         version: link:../../../../packages/sms

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,7 +40,6 @@ catalog:
   'react': 19.2.5
   'react-dom': 19.2.5
   'react-email': 6.0.0
-  'resend': 4.0.0
   'rolldown': 1.0.0-rc.17
   'rolldown-plugin-dts': 0.18.4
   'tailwindcss': 4.2.4


### PR DESCRIPTION
# Overview

Implements the `@betternotify/resend` transport (BET-50), replacing the stub with a working Resend HTTP API integration.

# What's changed and why?

- `packages/resend/src/index.ts` — Real `resendTransport()` using fetch against the Resend API, with error normalization and tag/attachment mapping
- `packages/resend/src/types.ts` — Resend API request/response types
- `packages/resend/src/index.test.ts` — 25 tests covering API calls, field mapping, error codes, network failures, attachments, and tags
- `packages/resend/package.json` — Removed unused `resend` SDK peer dependency (fetch-only)
- `packages/resend/rolldown.config.ts` — Removed `resend` from externals
- `apps/web/content/docs/transports/third-party/resend.mdx` — Full documentation (install, credentials, usage, options, error handling, tags, attachments, limits)
- `examples/welcome-text/apps/cli/src/examples/resend.ts` — Basic send example
- `examples/welcome-text/apps/cli/src/examples/resend-attachment.ts` — Attachment example
- `examples/welcome-text/apps/cli/src/index.ts` — Registered both examples
- `examples/welcome-text/apps/cli/src/env.ts` — Added Resend env vars
- `pnpm-workspace.yaml` — Removed dead `resend` catalog entry
- `CLAUDE.md` — Removed `resend` from stubs list

# How to test

1. `pnpm install && pnpm run ci` — all 43 tasks pass
2. `pnpm --filter @betternotify/resend test` — 25 tests pass
3. Set `RESEND_API_KEY` and run `pnpm --filter @welcome-text/cli start resend`

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented Resend email transport with full functionality including attachment support.
  * Added CLI examples demonstrating Resend integration.

* **Documentation**
  * Published comprehensive Resend transport documentation with installation, setup, usage examples, options, and error mapping.
  * Updated status documentation to reflect Resend transport completion.

* **Tests**
  * Added extensive test coverage for Resend transport functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->