### PR TITLE
test(smtp,react-email): verify beta-readiness with edge case coverage

### DIFF
--- a/examples/welcome-text/apps/cli/package.json
+++ b/examples/welcome-text/apps/cli/package.json
@@ -23,9 +23,9 @@
     "@betternotify/sms": "workspace:*",
     "@betternotify/smtp": "workspace:*",
     "@betternotify/telegram": "workspace:*",
+    "@t3-oss/env-core": "0.13.11",
     "handlebars": "catalog:",
     "mjml": "catalog:",
-    "@t3-oss/env-core": "0.13.11",
     "react": "19.2.5",
     "react-email": "6.0.0",
     "zod": "4.3.6"

--- a/examples/welcome-text/apps/cli/package.json
+++ b/examples/welcome-text/apps/cli/package.json
@@ -23,7 +23,7 @@
     "@betternotify/sms": "workspace:*",
     "@betternotify/smtp": "workspace:*",
     "@betternotify/telegram": "workspace:*",
-    "@t3-oss/env-core": "0.13.11",
+    "@t3-oss/env-core": "catalog:",
     "handlebars": "catalog:",
     "mjml": "catalog:",
     "react": "19.2.5",

--- a/packages/handlebars/README.md
+++ b/packages/handlebars/README.md
@@ -23,15 +23,20 @@ export const catalog = rpc.catalog({
   welcome: rpc
     .email()
     .input(z.object({ name: z.string(), items: z.array(z.string()) }))
-    .template(handlebarsTemplate(`
+    .template(
+      handlebarsTemplate(
+        `
       <h1>Hello {{name}}</h1>
       <ul>
         {{#each items}}<li>{{this}}</li>{{/each}}
       </ul>
-    `, {
-      subject: 'Welcome, {{name}}!',
-      text: 'Hello {{name}}. Items: {{#each items}}{{this}} {{/each}}',
-    })),
+    `,
+        {
+          subject: 'Welcome, {{name}}!',
+          text: 'Hello {{name}}. Items: {{#each items}}{{this}} {{/each}}',
+        },
+      ),
+    ),
 });
 ```
 
@@ -39,13 +44,13 @@ export const catalog = rpc.catalog({
 
 ### `handlebarsTemplate(source, opts?)`
 
-| Arg            | Type                                      | Notes                                                      |
-| -------------- | ----------------------------------------- | ---------------------------------------------------------- |
-| `source`       | `string`                                  | Handlebars HTML template. Compiled eagerly at creation.    |
-| `opts.text`    | `string`                                  | Handlebars template for the plain-text alternative.        |
-| `opts.subject` | `string`                                  | Handlebars template for the subject line.                  |
-| `opts.helpers` | `Record<string, Handlebars.HelperDelegate>` | Custom Handlebars helpers available in all templates.      |
-| `opts.partials`| `Record<string, string>`                  | Named partials available via `{{> partialName}}`.          |
+| Arg             | Type                                        | Notes                                                   |
+| --------------- | ------------------------------------------- | ------------------------------------------------------- |
+| `source`        | `string`                                    | Handlebars HTML template. Compiled eagerly at creation. |
+| `opts.text`     | `string`                                    | Handlebars template for the plain-text alternative.     |
+| `opts.subject`  | `string`                                    | Handlebars template for the subject line.               |
+| `opts.helpers`  | `Record<string, Handlebars.HelperDelegate>` | Custom Handlebars helpers available in all templates.   |
+| `opts.partials` | `Record<string, string>`                    | Named partials available via `{{> partialName}}`.       |
 
 Returns a `TemplateAdapter<TInput>`. Each `render({ input })` call executes the pre-compiled template with `input` as the Handlebars data context.
 

--- a/packages/handlebars/src/index.test.ts
+++ b/packages/handlebars/src/index.test.ts
@@ -28,9 +28,7 @@ describe('handlebarsTemplate', () => {
   });
 
   it('supports nested object paths', async () => {
-    const adapter = handlebarsTemplate<{ user: { name: string } }>(
-      '<p>Hi {{user.name}}</p>',
-    );
+    const adapter = handlebarsTemplate<{ user: { name: string } }>('<p>Hi {{user.name}}</p>');
     const result = await adapter.render({ input: { user: { name: 'Bob' } }, ctx: {} });
     expect(result.html).toBe('<p>Hi Bob</p>');
   });
@@ -60,9 +58,7 @@ describe('handlebarsTemplate', () => {
   });
 
   it('supports conditional blocks', async () => {
-    const adapter = handlebarsTemplate<{ show: boolean }>(
-      '{{#if show}}<p>visible</p>{{/if}}',
-    );
+    const adapter = handlebarsTemplate<{ show: boolean }>('{{#if show}}<p>visible</p>{{/if}}');
     const shown = await adapter.render({ input: { show: true }, ctx: {} });
     expect(shown.html).toBe('<p>visible</p>');
     const hidden = await adapter.render({ input: { show: false }, ctx: {} });

--- a/packages/mjml/README.md
+++ b/packages/mjml/README.md
@@ -25,7 +25,9 @@ export const catalog = rpc.catalog({
   welcome: rpc
     .email()
     .input(z.object({ name: z.string(), code: z.string() }))
-    .template(mjmlTemplate(`
+    .template(
+      mjmlTemplate(
+        `
       <mjml>
         <mj-body>
           <mj-section>
@@ -36,10 +38,13 @@ export const catalog = rpc.catalog({
           </mj-section>
         </mj-body>
       </mjml>
-    `, {
-      subject: 'Welcome, {{name}}!',
-      text: 'Hello {{name}}. Your code: {{code}}',
-    })),
+    `,
+        {
+          subject: 'Welcome, {{name}}!',
+          text: 'Hello {{name}}. Your code: {{code}}',
+        },
+      ),
+    ),
 });
 ```
 
@@ -47,14 +52,14 @@ export const catalog = rpc.catalog({
 
 ### `mjmlTemplate(source, opts?)`
 
-| Arg            | Type                                      | Notes                                                                     |
-| -------------- | ----------------------------------------- | ------------------------------------------------------------------------- |
-| `source`       | `string`                                  | MJML markup with optional `{{}}` placeholders. Compiled eagerly.          |
-| `opts.text`    | `string`                                  | Handlebars template for the plain-text alternative.                       |
-| `opts.subject` | `string`                                  | Handlebars template for the subject line.                                 |
-| `opts.helpers` | `Record<string, Handlebars.HelperDelegate>` | Custom Handlebars helpers available in all templates.                     |
-| `opts.partials`| `Record<string, string>`                  | Named partials available via `{{> partialName}}`.                         |
-| `opts.mjml`    | `MjmlOptions`                             | Options passed to `mjml2html` (validation level, beautify, minify, etc.). |
+| Arg             | Type                                        | Notes                                                                     |
+| --------------- | ------------------------------------------- | ------------------------------------------------------------------------- |
+| `source`        | `string`                                    | MJML markup with optional `{{}}` placeholders. Compiled eagerly.          |
+| `opts.text`     | `string`                                    | Handlebars template for the plain-text alternative.                       |
+| `opts.subject`  | `string`                                    | Handlebars template for the subject line.                                 |
+| `opts.helpers`  | `Record<string, Handlebars.HelperDelegate>` | Custom Handlebars helpers available in all templates.                     |
+| `opts.partials` | `Record<string, string>`                    | Named partials available via `{{> partialName}}`.                         |
+| `opts.mjml`     | `MjmlOptions`                               | Options passed to `mjml2html` (validation level, beautify, minify, etc.). |
 
 Returns a `TemplateAdapter<TInput>`. Two-phase rendering:
 

--- a/packages/mjml/src/index.test.ts
+++ b/packages/mjml/src/index.test.ts
@@ -73,9 +73,7 @@ describe('mjmlTemplate', () => {
   });
 
   it('throws on malformed MJML source', () => {
-    expect(() => mjmlTemplate('<invalid>not mjml</invalid>')).toThrow(
-      /Malformed MJML/,
-    );
+    expect(() => mjmlTemplate('<invalid>not mjml</invalid>')).toThrow(/Malformed MJML/);
   });
 
   it('throws on MJML with validation errors by default', () => {

--- a/packages/react-email/README.md
+++ b/packages/react-email/README.md
@@ -63,6 +63,28 @@ Returns `Promise<RenderedOutput>` (`{ html, text? }`) ready to return from your 
 
 `.template()` itself is the inference site — it gives the lambda fully-typed `{ input, ctx }`. Inside the lambda you compute props however you want (rename, format dates, build URLs) and hand them to `reactEmail`. No factory, no schema duplication, no explicit generics.
 
+## Plain-text alternatives
+
+Setting `plainText: true` generates a text version alongside HTML using `react-email`'s `toPlainText()`. Many email providers factor plain-text presence into spam scoring — messages with both HTML and text alternatives score better than HTML-only. Recommended for transactional email.
+
+Heading elements (`h1`–`h6`) are rendered without uppercase coercion in the plain-text output. By default, `toPlainText()` uppercases headings for emphasis; this adapter disables that to preserve the original casing from your component.
+
 ## JSX setup
 
 Templates are `.tsx` files. Add `/** @jsxImportSource react */` at the top of each, or set `"jsx": "react-jsx"` in your tsconfig. With the new automatic JSX runtime, you don't need `import React`.
+
+## Tests & development
+
+```sh
+pnpm --filter @betternotify/react-email test
+pnpm --filter @betternotify/react-email build
+```
+
+## Manual verification checklist
+
+These scenarios go beyond unit tests and need visual inspection:
+
+- **Email client rendering**: send a React Email template through a real transport and open in Gmail, Outlook, and Apple Mail. Check layout, images, and button styling.
+- **Dark mode**: verify the template renders correctly in dark-mode email clients (Outlook dark, Gmail dark).
+- **Mobile responsiveness**: check the rendered email on a mobile viewport — React Email components should be responsive by default, but custom styles may break.
+- **Plain-text quality**: enable `plainText: true` and review the generated text for readability — check that links are visible, headings are clear, and no HTML artifacts leak through.

--- a/packages/react-email/src/index.test.ts
+++ b/packages/react-email/src/index.test.ts
@@ -40,4 +40,29 @@ describe('reactEmail', () => {
     const result = await reactEmail(Welcome, { name: 'John' }, { pretty: true });
     expect(result.html).toContain('\n');
   });
+
+  it('handles UTF-8 props with accents and emoji', async () => {
+    const result = await reactEmail(Welcome, { name: 'José García 🌍' });
+    expect(result.html).toContain('José García 🌍');
+  });
+
+  it('wraps output with XHTML 1.0 Transitional DOCTYPE', async () => {
+    const result = await reactEmail(Welcome, { name: 'John' });
+    expect(result.html).toMatch(
+      /^<!DOCTYPE html PUBLIC "-\/\/W3C\/\/DTD XHTML 1\.0 Transitional\/\/EN"/,
+    );
+  });
+
+  it('preserves heading case in plain-text output (NO_UPPERCASE_SELECTORS)', async () => {
+    const result = await reactEmail(Welcome, { name: 'World' }, { plainText: true });
+    expect(result.text).toContain('Hello, World!');
+    expect(result.text).not.toContain('HELLO, WORLD!');
+  });
+
+  it('pretty and plainText together produce formatted html and text', async () => {
+    const result = await reactEmail(Welcome, { name: 'John' }, { pretty: true, plainText: true });
+    expect(result.html).toContain('\n');
+    expect(result.text).toBeDefined();
+    expect(result.text).toContain('Hello, John!');
+  });
 });

--- a/packages/smtp/README.md
+++ b/packages/smtp/README.md
@@ -82,6 +82,38 @@ If you see this and want the original address to stick, switch to a provider tha
 defaults: { from: { name: 'My App', email: process.env.SMTP_USER! } }
 ```
 
+## Attachments
+
+Pass attachments through the `attachments` field on send args. Each entry needs `filename` and `content` (Buffer or string); `contentType` defaults to `application/octet-stream`. Use `cid` for inline images referenced via `<img src="cid:logo@inline">` in your HTML.
+
+```ts
+await mail.welcome.send({
+  to: 'user@example.com',
+  input: { name: 'Alice' },
+  attachments: [
+    {
+      filename: 'invoice.pdf',
+      content: await readFile('./invoice.pdf'),
+      contentType: 'application/pdf',
+    },
+    {
+      filename: 'logo.png',
+      content: logoPngBuffer,
+      contentType: 'image/png',
+      cid: 'logo@inline',
+    },
+  ],
+});
+```
+
+## UTF-8 and special characters
+
+Nodemailer handles UTF-8 encoding for subjects, display names, and body content automatically. Non-ASCII characters (accented names, CJK, emoji) work without extra configuration in subjects, From/To display names, and HTML/text bodies.
+
+## Known limitations
+
+The SMTP transport maps `from`, `to`, `cc`, `bcc`, `replyTo`, `subject`, `html`, `text`, `headers`, and `attachments` from `RenderedMessage`. The `inlineAssets`, `tags`, and `priority` fields are **not forwarded** to nodemailer — SMTP has no standard mechanism for metadata tags or priority hints beyond custom headers. If you need these, map them to `X-` headers via middleware before they reach the transport.
+
 ## Tests & development
 
 ```sh
@@ -89,4 +121,25 @@ pnpm --filter @betternotify/smtp test
 pnpm --filter @betternotify/smtp build
 ```
 
-Tests use a mocked nodemailer — no real SMTP server needed. To exercise against a local catcher, point at [Mailpit](https://github.com/axllent/mailpit) or [maildev](https://github.com/maildev/maildev).
+Unit tests use a mocked nodemailer — no real SMTP server needed. To exercise against a local catcher, point at [Mailpit](https://github.com/axllent/mailpit) or [maildev](https://github.com/maildev/maildev).
+
+### Integration tests (Ethereal)
+
+The `integration.test.ts` suite sends real email through [Ethereal](https://ethereal.email/) (a free throwaway SMTP service from the nodemailer team). It's skipped by default and requires network access:
+
+```sh
+SMTP_INTEGRATION=1 pnpm --filter @betternotify/smtp test
+```
+
+The test prints an Ethereal preview URL so you can inspect the delivered message in a browser.
+
+## Manual verification checklist
+
+These scenarios need live credentials and cannot be fully automated:
+
+- **Deliverability**: send to a real inbox (Gmail, Outlook) and confirm the message arrives in the primary tab, not spam.
+- **DKIM signature**: configure `dkim` and verify the signature using a mail header analyzer (e.g. Google Admin Toolbox).
+- **From-address rewriting**: send with a `from` different from `auth.user` and check whether the provider rewrites it. Observe the one-time warning in logs.
+- **Large attachments**: send a message with a 10 MB+ attachment; confirm the provider doesn't silently truncate or reject.
+- **Connection pool reconnect**: enable `pool: true`, send a message, wait 10+ minutes (beyond server idle timeout), then send another. Verify the pool recovers without error.
+- **TLS modes**: test both `secure: false` (STARTTLS on 587) and `secure: true` (implicit TLS on 465) against your provider.

--- a/packages/smtp/README.md
+++ b/packages/smtp/README.md
@@ -87,6 +87,10 @@ defaults: { from: { name: 'My App', email: process.env.SMTP_USER! } }
 Pass attachments through the `attachments` field on send args. Each entry needs `filename` and `content` (Buffer or string); `contentType` defaults to `application/octet-stream`. Use `cid` for inline images referenced via `<img src="cid:logo@inline">` in your HTML.
 
 ```ts
+import { readFile } from 'node:fs/promises';
+
+const logoPngBuffer = await readFile('./logo.png');
+
 await mail.welcome.send({
   to: 'user@example.com',
   input: { name: 'Alice' },

--- a/packages/smtp/src/index.test.ts
+++ b/packages/smtp/src/index.test.ts
@@ -196,4 +196,80 @@ describe('smtpTransport', () => {
     delete msg.from;
     await expect(t.send(msg as never, baseCtx)).rejects.toThrow(/no "from"/);
   });
+
+  it('handles UTF-8 subject, display name, and body', async () => {
+    sendMailMock.mockResolvedValue({ messageId: 'x', accepted: [], rejected: [] });
+    const t = smtpTransport({ host: 'smtp.x.com', port: 587 });
+    await t.send(
+      {
+        ...baseMessage,
+        from: { name: 'José García', email: 'jose@example.com' },
+        to: [{ name: 'Müller', email: 'muller@example.com' }],
+        subject: 'Welcome — José! 📧',
+        html: '<p>Héllo wörld 🌍</p>',
+        text: 'Héllo wörld 🌍',
+      },
+      baseCtx,
+    );
+    const arg = sendMailMock.mock.calls[0]?.[0];
+    expect(arg.from).toBe('"José García" <jose@example.com>');
+    expect(arg.to).toEqual(['"Müller" <muller@example.com>']);
+    expect(arg.subject).toBe('Welcome — José! 📧');
+    expect(arg.html).toBe('<p>Héllo wörld 🌍</p>');
+    expect(arg.text).toBe('Héllo wörld 🌍');
+  });
+
+  it('passes custom headers through to nodemailer', async () => {
+    sendMailMock.mockResolvedValue({ messageId: 'x', accepted: [], rejected: [] });
+    const t = smtpTransport({ host: 'smtp.x.com', port: 587 });
+    const headers = { 'X-Custom-Id': 'abc-123', 'X-Campaign': 'onboarding' };
+    await t.send({ ...baseMessage, headers }, baseCtx);
+    const arg = sendMailMock.mock.calls[0]?.[0];
+    expect(arg.headers).toEqual(headers);
+  });
+
+  it('verify() rejects when nodemailer rejects', async () => {
+    verifyMock.mockRejectedValue(new Error('ECONNREFUSED'));
+    const t = smtpTransport({ host: 'smtp.x.com', port: 587 });
+    if (!t.verify) throw new Error('verify expected');
+    await expect(t.verify()).rejects.toThrow('ECONNREFUSED');
+  });
+
+  it('sends HTML-only when text is omitted', async () => {
+    sendMailMock.mockResolvedValue({ messageId: 'x', accepted: [], rejected: [] });
+    const t = smtpTransport({ host: 'smtp.x.com', port: 587 });
+    const { text: _text, ...htmlOnly } = baseMessage;
+    await t.send(htmlOnly as never, baseCtx);
+    const arg = sendMailMock.mock.calls[0]?.[0];
+    expect(arg.html).toBe('<p>hi</p>');
+    expect(arg.text).toBeUndefined();
+  });
+
+  it('sends text-only when html is omitted', async () => {
+    sendMailMock.mockResolvedValue({ messageId: 'x', accepted: [], rejected: [] });
+    const t = smtpTransport({ host: 'smtp.x.com', port: 587 });
+    const { html: _html, ...textOnly } = baseMessage;
+    await t.send(textOnly as never, baseCtx);
+    const arg = sendMailMock.mock.calls[0]?.[0];
+    expect(arg.text).toBe('hi');
+    expect(arg.html).toBeUndefined();
+  });
+
+  it('silently drops inlineAssets, tags, and priority (not mapped to nodemailer)', async () => {
+    sendMailMock.mockResolvedValue({ messageId: 'x', accepted: [], rejected: [] });
+    const t = smtpTransport({ host: 'smtp.x.com', port: 587 });
+    await t.send(
+      {
+        ...baseMessage,
+        inlineAssets: { logo: { content: Buffer.from('png'), contentType: 'image/png' } },
+        tags: { campaign: 'onboarding' },
+        priority: 'high',
+      } as never,
+      baseCtx,
+    );
+    const arg = sendMailMock.mock.calls[0]?.[0];
+    expect(arg.inlineAssets).toBeUndefined();
+    expect(arg.tags).toBeUndefined();
+    expect(arg.priority).toBeUndefined();
+  });
 });

--- a/packages/smtp/src/integration.test.ts
+++ b/packages/smtp/src/integration.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import nodemailer from 'nodemailer';
+import { smtpTransport } from './index.js';
+
+describe.skipIf(!process.env.SMTP_INTEGRATION)('integration (Ethereal)', () => {
+  it('sends a real email through Ethereal SMTP', async () => {
+    const account = await nodemailer.createTestAccount();
+    const t = smtpTransport({
+      host: account.smtp.host,
+      port: account.smtp.port,
+      secure: account.smtp.secure,
+      auth: { user: account.user, pass: account.pass },
+    });
+
+    const result = await t.send(
+      {
+        from: account.user,
+        to: ['recipient@example.com'],
+        subject: 'BetterNotify SMTP integration test — José 📧',
+        html: '<h1>Hello, Wörld! 🌍</h1><p>This is a test from <code>@betternotify/smtp</code>.</p>',
+        text: 'Hello, Wörld! 🌍\n\nThis is a test from @betternotify/smtp.',
+        headers: { 'X-BetterNotify-Test': 'true' },
+        attachments: [
+          {
+            filename: 'hello.txt',
+            content: Buffer.from('Hello from BetterNotify!'),
+            contentType: 'text/plain',
+          },
+        ],
+      },
+      { route: 'integration-test', messageId: 'int-1', attempt: 1 },
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.transportMessageId).toBeDefined();
+    expect(result.data.accepted).toContain('recipient@example.com');
+
+    const previewUrl = nodemailer.getTestMessageUrl(
+      result.data.raw as Parameters<typeof nodemailer.getTestMessageUrl>[0],
+    );
+    if (previewUrl) {
+      console.log('Ethereal preview:', previewUrl);
+    }
+
+    if (t.close) await t.close();
+  });
+
+  it('verify() succeeds against Ethereal', async () => {
+    const account = await nodemailer.createTestAccount();
+    const t = smtpTransport({
+      host: account.smtp.host,
+      port: account.smtp.port,
+      secure: account.smtp.secure,
+      auth: { user: account.user, pass: account.pass },
+    });
+
+    if (!t.verify) throw new Error('verify expected');
+    const r = await t.verify();
+    expect(r).toEqual({ ok: true });
+
+    if (t.close) await t.close();
+  });
+});

--- a/packages/smtp/src/integration.test.ts
+++ b/packages/smtp/src/integration.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import nodemailer from 'nodemailer';
 import { smtpTransport } from './index.js';
 
-describe.skipIf(!process.env.SMTP_INTEGRATION)('integration (Ethereal)', () => {
+describe.skipIf(process.env.SMTP_INTEGRATION !== '1')('integration (Ethereal)', () => {
   it('sends a real email through Ethereal SMTP', async () => {
     const account = await nodemailer.createTestAccount();
     const t = smtpTransport({
@@ -12,38 +12,40 @@ describe.skipIf(!process.env.SMTP_INTEGRATION)('integration (Ethereal)', () => {
       auth: { user: account.user, pass: account.pass },
     });
 
-    const result = await t.send(
-      {
-        from: account.user,
-        to: ['recipient@example.com'],
-        subject: 'BetterNotify SMTP integration test — José 📧',
-        html: '<h1>Hello, Wörld! 🌍</h1><p>This is a test from <code>@betternotify/smtp</code>.</p>',
-        text: 'Hello, Wörld! 🌍\n\nThis is a test from @betternotify/smtp.',
-        headers: { 'X-BetterNotify-Test': 'true' },
-        attachments: [
-          {
-            filename: 'hello.txt',
-            content: Buffer.from('Hello from BetterNotify!'),
-            contentType: 'text/plain',
-          },
-        ],
-      },
-      { route: 'integration-test', messageId: 'int-1', attempt: 1 },
-    );
+    try {
+      const result = await t.send(
+        {
+          from: account.user,
+          to: ['recipient@example.com'],
+          subject: 'BetterNotify SMTP integration test — José 📧',
+          html: '<h1>Hello, Wörld! 🌍</h1><p>This is a test from <code>@betternotify/smtp</code>.</p>',
+          text: 'Hello, Wörld! 🌍\n\nThis is a test from @betternotify/smtp.',
+          headers: { 'X-BetterNotify-Test': 'true' },
+          attachments: [
+            {
+              filename: 'hello.txt',
+              content: Buffer.from('Hello from BetterNotify!'),
+              contentType: 'text/plain',
+            },
+          ],
+        },
+        { route: 'integration-test', messageId: 'int-1', attempt: 1 },
+      );
 
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.data.transportMessageId).toBeDefined();
-    expect(result.data.accepted).toContain('recipient@example.com');
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.transportMessageId).toBeDefined();
+      expect(result.data.accepted).toContain('recipient@example.com');
 
-    const previewUrl = nodemailer.getTestMessageUrl(
-      result.data.raw as Parameters<typeof nodemailer.getTestMessageUrl>[0],
-    );
-    if (previewUrl) {
-      console.log('Ethereal preview:', previewUrl);
+      const previewUrl = nodemailer.getTestMessageUrl(
+        result.data.raw as Parameters<typeof nodemailer.getTestMessageUrl>[0],
+      );
+      if (previewUrl) {
+        console.log('Ethereal preview:', previewUrl);
+      }
+    } finally {
+      if (t.close) await t.close();
     }
-
-    if (t.close) await t.close();
   });
 
   it('verify() succeeds against Ethereal', async () => {
@@ -55,10 +57,12 @@ describe.skipIf(!process.env.SMTP_INTEGRATION)('integration (Ethereal)', () => {
       auth: { user: account.user, pass: account.pass },
     });
 
-    if (!t.verify) throw new Error('verify expected');
-    const r = await t.verify();
-    expect(r).toEqual({ ok: true });
-
-    if (t.close) await t.close();
+    try {
+      if (!t.verify) throw new Error('verify expected');
+      const r = await t.verify();
+      expect(r).toEqual({ ok: true });
+    } finally {
+      if (t.close) await t.close();
+    }
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@standard-schema/spec':
       specifier: 1.1.0
       version: 1.1.0
+    '@t3-oss/env-core':
+      specifier: 0.13.11
+      version: 0.13.11
     '@tailwindcss/vite':
       specifier: 4.2.4
       version: 4.2.4
@@ -285,7 +288,7 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/telegram
       '@t3-oss/env-core':
-        specifier: 0.13.11
+        specifier: 'catalog:'
         version: 0.13.11(typescript@5.9.3)(zod@4.3.6)
       handlebars:
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ catalog:
   '@phosphor-icons/react': 2.1.10
   '@react-email/components': 0.0.30
   '@standard-schema/spec': 1.1.0
+  '@t3-oss/env-core': 0.13.11
   '@tailwindcss/vite': 4.2.4
   '@tanstack/react-router': 1.168.25
   '@tanstack/react-start': 1.167.50


### PR DESCRIPTION
# Overview

Beta-readiness verification for `@betternotify/smtp` and `@betternotify/react-email` (BET-55).

# What's changed and why?

- **`packages/smtp/src/index.test.ts`** — Added 6 new unit tests: UTF-8 handling, custom headers pass-through, verify failure path, HTML-only send, text-only send, and a test documenting that `inlineAssets`/`tags`/`priority` are silently dropped.
- **`packages/smtp/src/integration.test.ts`** — New file. Ethereal-based integration tests (skipped by default, enable with `SMTP_INTEGRATION=1`).
- **`packages/smtp/README.md`** — Added attachments example, UTF-8 note, known limitations section, integration test instructions, and manual verification checklist.
- **`packages/react-email/src/index.test.ts`** — Added 4 new tests: UTF-8 props, DOCTYPE presence, heading case preservation, and `pretty + plainText` interaction.
- **`packages/react-email/README.md`** — Added plain-text alternatives section, test commands, and manual verification checklist.
- **`packages/handlebars/README.md`** and **`packages/mjml/README.md`** — Formatting fixes (table alignment, code block indentation).
- **`packages/handlebars/src/index.test.ts`** and **`packages/mjml/src/index.test.ts`** — Minor formatting cleanup.
- **`examples/welcome-text/apps/cli/package.json`** — Dependency sort order fix.

# How to test

```sh
pnpm build
pnpm --filter @betternotify/smtp test
pnpm --filter @betternotify/react-email test
SMTP_INTEGRATION=1 pnpm --filter @betternotify/smtp test  # optional, needs network
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * React Email: Added plain-text alternative docs preserving heading case with `plainText: true`.
  * SMTP: Documented attachments, UTF-8 handling, known limitations, and optional Ethereal integration steps.
  * Handlebars & MJML: Clarified and reformatted example templates and API tables for clearer usage.

* **Tests**
  * React Email: Added tests for UTF-8/emoji, DOCTYPE, plain-text output and pretty formatting.
  * SMTP: Expanded unit and conditional integration tests for UTF-8, headers, failure paths, send behavior, and attachments.
  * Handlebars & MJML: Adjusted test formatting/assertion styles (no logic changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->