### PR TITLE
feat(core): provider error normalization

### DIFF
--- a/packages/cloudflare-email/src/index.test.ts
+++ b/packages/cloudflare-email/src/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach, type Mock } from 'vitest';
 import type { RenderedMessage } from '@betternotify/email';
 import type { SendContext } from '@betternotify/core';
-import { NotifyRpcError } from '@betternotify/core';
+import { NotifyRpcProviderError } from '@betternotify/core';
 
 let fetchMock: Mock;
 
@@ -205,8 +205,12 @@ describe('cloudflareEmailTransport — CF API errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect(result.error).toBeInstanceOf(NotifyRpcError);
-    expect((result.error as NotifyRpcError).code).toBe('VALIDATION');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('VALIDATION');
+    expect(err.provider).toBe('cloudflare-email');
+    expect(err.retriable).toBe(false);
+    expect(err.providerCode).toBe(10001);
   });
 
   it('returns VALIDATION for CF error code 10200', async () => {
@@ -227,7 +231,12 @@ describe('cloudflareEmailTransport — CF API errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('VALIDATION');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('VALIDATION');
+    expect(err.provider).toBe('cloudflare-email');
+    expect(err.retriable).toBe(false);
+    expect(err.providerCode).toBe(10200);
   });
 
   it('returns VALIDATION for CF error code 10201 (no content length)', async () => {
@@ -248,7 +257,12 @@ describe('cloudflareEmailTransport — CF API errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('VALIDATION');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('VALIDATION');
+    expect(err.provider).toBe('cloudflare-email');
+    expect(err.retriable).toBe(false);
+    expect(err.providerCode).toBe(10201);
   });
 
   it('returns VALIDATION for CF error code 10202 (too big)', async () => {
@@ -269,7 +283,12 @@ describe('cloudflareEmailTransport — CF API errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('VALIDATION');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('VALIDATION');
+    expect(err.provider).toBe('cloudflare-email');
+    expect(err.retriable).toBe(false);
+    expect(err.providerCode).toBe(10202);
   });
 
   it('returns CONFIG for CF error code 10203 (sending disabled)', async () => {
@@ -290,10 +309,15 @@ describe('cloudflareEmailTransport — CF API errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('CONFIG');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('CONFIG');
+    expect(err.provider).toBe('cloudflare-email');
+    expect(err.retriable).toBe(false);
+    expect(err.providerCode).toBe(10203);
   });
 
-  it('returns PROVIDER for CF error code 10004 (rate limited)', async () => {
+  it('returns RATE_LIMITED for CF error code 10004 (rate limited)', async () => {
     const { cloudflareEmailTransport } = await import('./index.js');
     fetchMock.mockResolvedValue(
       new Response(
@@ -311,7 +335,12 @@ describe('cloudflareEmailTransport — CF API errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('RATE_LIMITED');
+    expect(err.provider).toBe('cloudflare-email');
+    expect(err.retriable).toBe(true);
+    expect(err.providerCode).toBe(10004);
   });
 
   it('returns PROVIDER for CF error code 10002 (internal server error)', async () => {
@@ -332,7 +361,13 @@ describe('cloudflareEmailTransport — CF API errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('PROVIDER');
+    expect(err.provider).toBe('cloudflare-email');
+    expect(err.retriable).toBe(true);
+    expect(err.httpStatus).toBe(500);
+    expect(err.providerCode).toBe(10002);
   });
 
   it('returns PROVIDER for unknown CF error codes', async () => {
@@ -353,11 +388,33 @@ describe('cloudflareEmailTransport — CF API errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('PROVIDER');
+    expect(err.provider).toBe('cloudflare-email');
+    expect(err.retriable).toBe(true);
+    expect(err.httpStatus).toBe(500);
+    expect(err.providerCode).toBe(99999);
   });
 });
 
 describe('cloudflareEmailTransport — network errors', () => {
+  it('returns TIMEOUT when fetch times out', async () => {
+    const { cloudflareEmailTransport } = await import('./index.js');
+    const abortError = new DOMException('The operation was aborted', 'AbortError');
+    fetchMock.mockRejectedValue(abortError);
+    const t = cloudflareEmailTransport({ accountId: 'acc123', apiToken: 'tok456' });
+    const result = await t.send(baseMessage, baseCtx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('TIMEOUT');
+    expect(err.provider).toBe('cloudflare-email');
+    expect(err.retriable).toBe(true);
+  });
+
   it('returns PROVIDER when fetch throws (network failure)', async () => {
     const { cloudflareEmailTransport } = await import('./index.js');
     fetchMock.mockRejectedValue(new TypeError('fetch failed'));
@@ -366,11 +423,15 @@ describe('cloudflareEmailTransport — network errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('PROVIDER');
+    expect(err.provider).toBe('cloudflare-email');
+    expect(err.retriable).toBe(true);
     expect(result.error.message).toContain('network error');
   });
 
-  it('returns PROVIDER when response body is not valid JSON', async () => {
+  it('returns PROVIDER when response body is empty (not valid JSON)', async () => {
     const { cloudflareEmailTransport } = await import('./index.js');
     fetchMock.mockResolvedValue(new Response('not json', { status: 200 }));
     const t = cloudflareEmailTransport({ accountId: 'acc123', apiToken: 'tok456' });
@@ -378,7 +439,11 @@ describe('cloudflareEmailTransport — network errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('PROVIDER');
+    expect(err.provider).toBe('cloudflare-email');
+    expect(err.retriable).toBe(true);
   });
 
   it('returns PROVIDER when response is valid JSON but missing errors/result fields', async () => {
@@ -389,7 +454,11 @@ describe('cloudflareEmailTransport — network errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('PROVIDER');
+    expect(err.provider).toBe('cloudflare-email');
+    expect(err.httpStatus).toBe(400);
     expect(result.error.message).toContain('unknown error');
   });
 });

--- a/packages/cloudflare-email/src/index.ts
+++ b/packages/cloudflare-email/src/index.ts
@@ -1,6 +1,6 @@
 import type { Address, RenderedMessage, Transport } from '@betternotify/email';
 import { normalizeAddress } from '@betternotify/email/transports';
-import { consoleLogger, NotifyRpcError } from '@betternotify/core';
+import { consoleLogger, NotifyRpcError, NotifyRpcProviderError } from '@betternotify/core';
 import { createHttpClient } from '@betternotify/core/transports';
 import type {
   CloudflareEmailTransportOptions,
@@ -20,14 +20,25 @@ export type {
   CloudflareEmailResult,
 } from './types.js';
 
+export { isCloudflareEmailRetriable } from './is-retriable.js';
+
 const DEFAULT_BASE_URL = 'https://api.cloudflare.com';
-/**
- * CF error codes mapped to VALIDATION:
- * 10001 — invalid request schema, 10200 — invalid email content,
- * 10201 — missing content length, 10202 — message too large.
- */
 const VALIDATION_CODES = [10001, 10200, 10201, 10202];
+const RATE_LIMITED_CODES = [10004];
 const DEFAULT_TIMEOUT_MS = 30_000;
+
+const mapCfError = (
+  errorCode: number | undefined,
+  httpStatus: number,
+): { code: 'VALIDATION' | 'CONFIG' | 'RATE_LIMITED' | 'PROVIDER'; retriable: boolean } => {
+  if (errorCode !== undefined) {
+    if (VALIDATION_CODES.includes(errorCode)) return { code: 'VALIDATION', retriable: false };
+    if (errorCode === 10203) return { code: 'CONFIG', retriable: false };
+    if (RATE_LIMITED_CODES.includes(errorCode)) return { code: 'RATE_LIMITED', retriable: true };
+  }
+  if (httpStatus === 429) return { code: 'RATE_LIMITED', retriable: true };
+  return { code: 'PROVIDER', retriable: httpStatus >= 500 };
+};
 
 const toFrom = (addr: Address): CloudflareEmailFrom => {
   if (typeof addr === 'string') return { address: addr };
@@ -102,9 +113,11 @@ export const cloudflareEmailTransport = (opts: CloudflareEmailTransportOptions):
           log.error('Cloudflare Email fetch failed', { err: result.cause, route: ctx.route });
           return {
             ok: false,
-            error: new NotifyRpcError({
+            error: new NotifyRpcProviderError({
               message: `Cloudflare Email transport: ${result.timedOut ? 'request timed out' : `network error: ${result.cause.message}`}`,
               code: result.timedOut ? 'TIMEOUT' : 'PROVIDER',
+              provider: 'cloudflare-email',
+              retriable: true,
               route: ctx.route,
               messageId: ctx.messageId,
               cause: result.cause,
@@ -119,11 +132,7 @@ export const cloudflareEmailTransport = (opts: CloudflareEmailTransportOptions):
         const errors = Array.isArray(errBody.errors) ? errBody.errors : [];
         const cfError = errors[0];
         const errorCode = cfError?.code;
-        const code = VALIDATION_CODES.includes(errorCode as number)
-          ? 'VALIDATION'
-          : errorCode === 10203
-            ? 'CONFIG'
-            : 'PROVIDER';
+        const mapped = mapCfError(errorCode as number | undefined, result.status);
         const errorMessage = cfError
           ? `Cloudflare Email transport: [${cfError.code}] ${cfError.message}`
           : `Cloudflare Email transport: unknown error`;
@@ -134,9 +143,13 @@ export const cloudflareEmailTransport = (opts: CloudflareEmailTransportOptions):
         });
         return {
           ok: false,
-          error: new NotifyRpcError({
+          error: new NotifyRpcProviderError({
             message: errorMessage,
-            code,
+            code: mapped.code,
+            provider: 'cloudflare-email',
+            retriable: mapped.retriable,
+            httpStatus: result.status,
+            providerCode: errorCode as number | undefined,
             route: ctx.route,
             messageId: ctx.messageId,
           }),
@@ -147,9 +160,11 @@ export const cloudflareEmailTransport = (opts: CloudflareEmailTransportOptions):
       if (!data) {
         return {
           ok: false,
-          error: new NotifyRpcError({
+          error: new NotifyRpcProviderError({
             message: 'Cloudflare Email transport: empty response body',
             code: 'PROVIDER',
+            provider: 'cloudflare-email',
+            retriable: true,
             route: ctx.route,
             messageId: ctx.messageId,
           }),
@@ -162,11 +177,7 @@ export const cloudflareEmailTransport = (opts: CloudflareEmailTransportOptions):
       if (!data.success || !cfResult) {
         const cfError = errors[0];
         const errorCode = cfError?.code;
-        const code = VALIDATION_CODES.includes(errorCode as number)
-          ? 'VALIDATION'
-          : errorCode === 10203
-            ? 'CONFIG'
-            : 'PROVIDER';
+        const mapped = mapCfError(errorCode as number | undefined, 200);
 
         const errorMessage = cfError
           ? `Cloudflare Email transport: [${cfError.code}] ${cfError.message}`
@@ -179,9 +190,12 @@ export const cloudflareEmailTransport = (opts: CloudflareEmailTransportOptions):
 
         return {
           ok: false,
-          error: new NotifyRpcError({
+          error: new NotifyRpcProviderError({
             message: errorMessage,
-            code,
+            code: mapped.code,
+            provider: 'cloudflare-email',
+            retriable: mapped.retriable,
+            providerCode: errorCode as number | undefined,
             route: ctx.route,
             messageId: ctx.messageId,
           }),

--- a/packages/cloudflare-email/src/is-retriable.test.ts
+++ b/packages/cloudflare-email/src/is-retriable.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { NotifyRpcProviderError } from '@betternotify/core';
+import { isCloudflareEmailRetriable } from './is-retriable.js';
+
+describe('isCloudflareEmailRetriable', () => {
+  it('returns true when NotifyRpcProviderError has retriable: true', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'timeout',
+      code: 'TIMEOUT',
+      provider: 'cloudflare-email',
+      retriable: true,
+    });
+    expect(isCloudflareEmailRetriable(err)).toBe(true);
+  });
+
+  it('returns false when NotifyRpcProviderError has retriable: false', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'validation failed',
+      code: 'VALIDATION',
+      provider: 'cloudflare-email',
+      retriable: false,
+    });
+    expect(isCloudflareEmailRetriable(err)).toBe(false);
+  });
+
+  it('returns true for non-provider errors', () => {
+    const err = new Error('unknown');
+    expect(isCloudflareEmailRetriable(err)).toBe(true);
+  });
+});

--- a/packages/cloudflare-email/src/is-retriable.ts
+++ b/packages/cloudflare-email/src/is-retriable.ts
@@ -1,0 +1,6 @@
+import { NotifyRpcProviderError } from '@betternotify/core';
+
+export const isCloudflareEmailRetriable = (err: unknown): boolean => {
+  if (err instanceof NotifyRpcProviderError) return err.retriable;
+  return true;
+};

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   NotifyRpcError,
   NotifyRpcNotImplementedError,
+  NotifyRpcProviderError,
   NotifyRpcRateLimitedError,
   NotifyRpcValidationError,
 } from './errors.js';
@@ -120,5 +121,118 @@ describe('NotifyRpcNotImplementedError', () => {
     expect(err.name).toBe('NotifyRpcNotImplementedError');
     expect(err.message).toContain('foo()');
     expect(err.message).toContain('not implemented');
+  });
+});
+
+describe('NotifyRpcProviderError', () => {
+  it('defaults code to PROVIDER', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'provider failed',
+      provider: 'resend',
+      retriable: true,
+    });
+    expect(err.code).toBe('PROVIDER');
+    expect(err.name).toBe('NotifyRpcProviderError');
+    expect(err.provider).toBe('resend');
+    expect(err.retriable).toBe(true);
+    expect(err.httpStatus).toBeUndefined();
+    expect(err.providerCode).toBeUndefined();
+    expect(err.retryAfterMs).toBeUndefined();
+  });
+
+  it('preserves all provider fields', () => {
+    const cause = new Error('underlying');
+    const err = new NotifyRpcProviderError({
+      message: 'rate limited',
+      code: 'RATE_LIMITED',
+      provider: 'twilio',
+      httpStatus: 429,
+      providerCode: 20429,
+      retryAfterMs: 5000,
+      retriable: true,
+      route: 'alerts.sms',
+      messageId: 'm1',
+      cause,
+    });
+    expect(err.code).toBe('RATE_LIMITED');
+    expect(err.provider).toBe('twilio');
+    expect(err.httpStatus).toBe(429);
+    expect(err.providerCode).toBe(20429);
+    expect(err.retryAfterMs).toBe(5000);
+    expect(err.retriable).toBe(true);
+    expect(err.route).toBe('alerts.sms');
+    expect(err.messageId).toBe('m1');
+    expect(err.cause).toBe(cause);
+  });
+
+  it('accepts string providerCode', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'invalid auth',
+      code: 'CONFIG',
+      provider: 'slack',
+      providerCode: 'invalid_auth',
+      retriable: false,
+    });
+    expect(err.providerCode).toBe('invalid_auth');
+  });
+
+  it('is instanceof NotifyRpcError', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'boom',
+      provider: 'smtp',
+      retriable: false,
+    });
+    expect(err).toBeInstanceOf(NotifyRpcError);
+    expect(err).toBeInstanceOf(NotifyRpcProviderError);
+  });
+
+  it('toJSON includes all provider fields', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'timeout',
+      code: 'TIMEOUT',
+      provider: 'discord',
+      httpStatus: undefined,
+      retryAfterMs: 1500,
+      retriable: true,
+      route: 'alerts.discord',
+      messageId: 'm2',
+    });
+    expect(err.toJSON()).toEqual({
+      name: 'NotifyRpcProviderError',
+      message: 'timeout',
+      code: 'TIMEOUT',
+      route: 'alerts.discord',
+      messageId: 'm2',
+      provider: 'discord',
+      httpStatus: undefined,
+      providerCode: undefined,
+      retryAfterMs: 1500,
+      retriable: true,
+    });
+  });
+
+  it('toJSON serializes non-retriable error with all fields', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'invalid phone',
+      code: 'VALIDATION',
+      provider: 'twilio',
+      httpStatus: 400,
+      providerCode: 21211,
+      retriable: false,
+      route: 'sms.welcome',
+      messageId: 'm3',
+    });
+    expect(err.toJSON()).toEqual({
+      name: 'NotifyRpcProviderError',
+      message: 'invalid phone',
+      code: 'VALIDATION',
+      route: 'sms.welcome',
+      messageId: 'm3',
+      provider: 'twilio',
+      httpStatus: 400,
+      providerCode: 21211,
+      retryAfterMs: undefined,
+      retriable: false,
+    });
   });
 });

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -186,3 +186,52 @@ export class NotifyRpcNotImplementedError extends NotifyRpcError {
     this.name = 'NotifyRpcNotImplementedError';
   }
 }
+
+export type ProviderErrorCode = 'PROVIDER' | 'TIMEOUT' | 'RATE_LIMITED' | 'CONFIG' | 'VALIDATION';
+
+export type NotifyRpcProviderErrorOptions = Omit<NotifyRpcErrorOptions, 'code'> & {
+  code?: ProviderErrorCode;
+  provider: string;
+  httpStatus?: number;
+  providerCode?: string | number;
+  retryAfterMs?: number;
+  retriable: boolean;
+};
+
+/**
+ * Thrown (or returned as `{ ok: false, error }`) when a transport encounters
+ * an error from the underlying provider — HTTP failures, API rejections,
+ * network timeouts, rate limits, or authentication problems.
+ *
+ * Carries structured provider metadata so consumers can branch on
+ * `retriable`, `httpStatus`, or `providerCode` without parsing message
+ * strings.
+ */
+export class NotifyRpcProviderError extends NotifyRpcError {
+  readonly provider: string;
+  readonly httpStatus: number | undefined;
+  readonly providerCode: string | number | undefined;
+  readonly retryAfterMs: number | undefined;
+  readonly retriable: boolean;
+
+  constructor(opts: NotifyRpcProviderErrorOptions) {
+    super({ ...opts, code: opts.code ?? 'PROVIDER' });
+    this.name = 'NotifyRpcProviderError';
+    this.provider = opts.provider;
+    this.httpStatus = opts.httpStatus;
+    this.providerCode = opts.providerCode;
+    this.retryAfterMs = opts.retryAfterMs;
+    this.retriable = opts.retriable;
+  }
+
+  override toJSON() {
+    return {
+      ...super.toJSON(),
+      provider: this.provider,
+      httpStatus: this.httpStatus,
+      providerCode: this.providerCode,
+      retryAfterMs: this.retryAfterMs,
+      retriable: this.retriable,
+    };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,12 +84,15 @@ export {
   NotifyRpcValidationError,
   NotifyRpcRateLimitedError,
   NotifyRpcNotImplementedError,
+  NotifyRpcProviderError,
 } from './errors.js';
 export type {
   ErrorCode,
+  ProviderErrorCode,
   NotifyRpcErrorOptions,
   NotifyRpcValidationErrorOptions,
   NotifyRpcRateLimitedErrorOptions,
+  NotifyRpcProviderErrorOptions,
 } from './errors.js';
 
 export type { Priority, Tags } from './types.js';

--- a/packages/core/src/transports/index.ts
+++ b/packages/core/src/transports/index.ts
@@ -24,3 +24,4 @@ export { createMockTransport } from './mock-transport.js';
 export type { CreateMockTransportOptions, MockTransport } from './mock-transport.js';
 export { mapTransport } from './map-transport.js';
 export type { MapTransportFn } from './map-transport.js';
+export { isProviderRetriable } from './is-provider-retriable.js';

--- a/packages/core/src/transports/is-provider-retriable.test.ts
+++ b/packages/core/src/transports/is-provider-retriable.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { NotifyRpcError, NotifyRpcProviderError } from '../errors.js';
+import { isProviderRetriable } from './is-provider-retriable.js';
+
+describe('isProviderRetriable', () => {
+  it('returns true when NotifyRpcProviderError has retriable: true', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'timeout',
+      provider: 'resend',
+      retriable: true,
+    });
+    expect(isProviderRetriable(err)).toBe(true);
+  });
+
+  it('returns false when NotifyRpcProviderError has retriable: false', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'invalid auth',
+      provider: 'slack',
+      code: 'CONFIG',
+      retriable: false,
+    });
+    expect(isProviderRetriable(err)).toBe(false);
+  });
+
+  it('returns true for non-NotifyRpcProviderError errors', () => {
+    const err = new NotifyRpcError({ message: 'unknown', code: 'UNKNOWN' });
+    expect(isProviderRetriable(err)).toBe(true);
+  });
+
+  it('returns true for plain Error', () => {
+    expect(isProviderRetriable(new Error('random'))).toBe(true);
+  });
+
+  it('returns true for non-error values', () => {
+    expect(isProviderRetriable('string error')).toBe(true);
+    expect(isProviderRetriable(null)).toBe(true);
+    expect(isProviderRetriable(undefined)).toBe(true);
+  });
+});

--- a/packages/core/src/transports/is-provider-retriable.ts
+++ b/packages/core/src/transports/is-provider-retriable.ts
@@ -1,0 +1,6 @@
+import { NotifyRpcProviderError } from '../errors.js';
+
+export const isProviderRetriable = (err: unknown): boolean => {
+  if (err instanceof NotifyRpcProviderError) return err.retriable;
+  return true;
+};

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -17,3 +17,4 @@ export type {
   MockDiscordTransport,
   DiscordTransportOptions,
 } from './transports/index.js';
+export { isDiscordRetriable } from './is-retriable.js';

--- a/packages/discord/src/is-retriable.test.ts
+++ b/packages/discord/src/is-retriable.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { NotifyRpcProviderError } from '@betternotify/core';
+import { isDiscordRetriable } from './is-retriable.js';
+
+describe('isDiscordRetriable', () => {
+  it('returns true when NotifyRpcProviderError has retriable: true', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'rate limited',
+      provider: 'discord',
+      code: 'RATE_LIMITED',
+      retriable: true,
+    });
+    expect(isDiscordRetriable(err)).toBe(true);
+  });
+
+  it('returns false when NotifyRpcProviderError has retriable: false', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'invalid webhook',
+      provider: 'discord',
+      code: 'CONFIG',
+      retriable: false,
+    });
+    expect(isDiscordRetriable(err)).toBe(false);
+  });
+
+  it('returns true for non-NotifyRpcProviderError errors', () => {
+    expect(isDiscordRetriable(new Error('random'))).toBe(true);
+    expect(isDiscordRetriable('string error')).toBe(true);
+    expect(isDiscordRetriable(null)).toBe(true);
+  });
+});

--- a/packages/discord/src/is-retriable.ts
+++ b/packages/discord/src/is-retriable.ts
@@ -1,0 +1,6 @@
+import { NotifyRpcProviderError } from '@betternotify/core';
+
+export const isDiscordRetriable = (err: unknown): boolean => {
+  if (err instanceof NotifyRpcProviderError) return err.retriable;
+  return true;
+};

--- a/packages/discord/src/transports/discord.test.ts
+++ b/packages/discord/src/transports/discord.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, afterEach, beforeEach, type Mock } from 'vitest';
-import { NotifyRpcError } from '@betternotify/core';
+import { NotifyRpcProviderError } from '@betternotify/core';
 import type { RenderedDiscord } from '../types.js';
 import type { SendContext } from '@betternotify/core';
 
@@ -158,8 +158,12 @@ describe('discordTransport — error mapping', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect(result.error).toBeInstanceOf(NotifyRpcError);
-    expect((result.error as NotifyRpcError).code).toBe('VALIDATION');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('VALIDATION');
+    expect(err.provider).toBe('discord');
+    expect(err.retriable).toBe(false);
+    expect(err.providerCode).toBe(50035);
   });
 
   it('returns CONFIG for 401 status', async () => {
@@ -172,7 +176,9 @@ describe('discordTransport — error mapping', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('CONFIG');
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('CONFIG');
+    expect(err.retriable).toBe(false);
   });
 
   it('returns CONFIG for 403 status', async () => {
@@ -185,7 +191,9 @@ describe('discordTransport — error mapping', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('CONFIG');
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('CONFIG');
+    expect(err.retriable).toBe(false);
   });
 
   it('returns CONFIG for 404 status (webhook deleted)', async () => {
@@ -198,10 +206,12 @@ describe('discordTransport — error mapping', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('CONFIG');
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('CONFIG');
+    expect(err.retriable).toBe(false);
   });
 
-  it('returns PROVIDER for 429 rate limit with retry-after', async () => {
+  it('returns RATE_LIMITED for 429 with retryAfterMs', async () => {
     const { discordTransport } = await import('./discord.js');
     fetchMock.mockResolvedValue(
       new Response(JSON.stringify({ message: 'You are being rate limited.', retry_after: 1.5 }), {
@@ -214,8 +224,11 @@ describe('discordTransport — error mapping', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
-    expect(result.error.message).toContain('retry after');
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('RATE_LIMITED');
+    expect(err.retriable).toBe(true);
+    expect(err.retryAfterMs).toBe(1500);
+    expect(err.provider).toBe('discord');
   });
 
   it('returns PROVIDER for 500 server error', async () => {
@@ -228,7 +241,9 @@ describe('discordTransport — error mapping', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('PROVIDER');
+    expect(err.retriable).toBe(true);
   });
 
   it('falls back to HTTP status when error response has no message', async () => {
@@ -249,8 +264,8 @@ describe('discordTransport — error mapping', () => {
     const result = await t.send(baseMessage, ctx);
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect(result.error).toBeInstanceOf(NotifyRpcError);
-    expect((result.error as NotifyRpcError).message).toContain('HTTP 502');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    expect((result.error as NotifyRpcProviderError).message).toContain('HTTP 502');
   });
 });
 
@@ -382,8 +397,12 @@ describe('discordTransport — network errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
-    expect(result.error.message).toContain('network error');
+    const err = result.error as NotifyRpcProviderError;
+    expect(err).toBeInstanceOf(NotifyRpcProviderError);
+    expect(err.code).toBe('PROVIDER');
+    expect(err.provider).toBe('discord');
+    expect(err.retriable).toBe(true);
+    expect(err.message).toContain('network error');
   });
 
   it('returns TIMEOUT when fetch throws TimeoutError', async () => {
@@ -395,8 +414,12 @@ describe('discordTransport — network errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('TIMEOUT');
-    expect(result.error.message).toContain('request timed out');
+    const provErr = result.error as NotifyRpcProviderError;
+    expect(provErr).toBeInstanceOf(NotifyRpcProviderError);
+    expect(provErr.code).toBe('TIMEOUT');
+    expect(provErr.provider).toBe('discord');
+    expect(provErr.retriable).toBe(true);
+    expect(provErr.message).toContain('request timed out');
   });
 
   it('returns PROVIDER when response body is not valid JSON (wait=true)', async () => {
@@ -407,6 +430,6 @@ describe('discordTransport — network errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
+    expect((result.error as NotifyRpcProviderError).code).toBe('PROVIDER');
   });
 });

--- a/packages/discord/src/transports/discord.ts
+++ b/packages/discord/src/transports/discord.ts
@@ -1,4 +1,4 @@
-import { consoleLogger, NotifyRpcError } from '@betternotify/core';
+import { consoleLogger, NotifyRpcProviderError } from '@betternotify/core';
 import { createTransport, createHttpClient } from '@betternotify/core/transports';
 import type { RenderedDiscord } from '../types.js';
 import type { DiscordTransportData, Transport } from './types.js';
@@ -17,10 +17,11 @@ type DiscordSuccessResponse = {
   [key: string]: unknown;
 };
 
-const mapErrorCode = (status: number): 'VALIDATION' | 'CONFIG' | 'PROVIDER' => {
-  if (status === 400) return 'VALIDATION';
-  if (status === 401 || status === 403 || status === 404) return 'CONFIG';
-  return 'PROVIDER';
+const mapError = (status: number): { code: 'VALIDATION' | 'CONFIG' | 'RATE_LIMITED' | 'PROVIDER'; retriable: boolean } => {
+  if (status === 400) return { code: 'VALIDATION', retriable: false };
+  if (status === 401 || status === 403 || status === 404) return { code: 'CONFIG', retriable: false };
+  if (status === 429) return { code: 'RATE_LIMITED', retriable: true };
+  return { code: 'PROVIDER', retriable: status >= 500 };
 };
 
 const buildJsonPayload = (
@@ -97,9 +98,11 @@ export const discordTransport = (opts: DiscordTransportOptions): Transport => {
           log.error('Discord fetch failed', { err: result.cause, route: ctx.route });
           return {
             ok: false,
-            error: new NotifyRpcError({
+            error: new NotifyRpcProviderError({
               message: `Discord transport: ${result.timedOut ? 'request timed out' : `network error: ${result.cause.message}`}`,
               code: result.timedOut ? 'TIMEOUT' : 'PROVIDER',
+              provider: 'discord',
+              retriable: true,
               route: ctx.route,
               messageId: ctx.messageId,
               cause: result.cause,
@@ -108,8 +111,9 @@ export const discordTransport = (opts: DiscordTransportOptions): Transport => {
         }
 
         const errData = result.body as DiscordErrorResponse;
-        const code = mapErrorCode(result.status);
+        const { code, retriable } = mapError(result.status);
         const retryAfterBody = errData.retry_after;
+        const retryAfterMs = retryAfterBody ? Math.ceil(retryAfterBody * 1000) : undefined;
         const suffix = retryAfterBody ? ` (retry after ${retryAfterBody}s)` : '';
         const errorMessage = `Discord transport: ${errData.message ?? `HTTP ${result.status}`}${suffix}`;
         log.error(errorMessage, {
@@ -119,9 +123,14 @@ export const discordTransport = (opts: DiscordTransportOptions): Transport => {
 
         return {
           ok: false,
-          error: new NotifyRpcError({
+          error: new NotifyRpcProviderError({
             message: errorMessage,
             code,
+            provider: 'discord',
+            httpStatus: result.status,
+            providerCode: errData.code,
+            retryAfterMs,
+            retriable,
             route: ctx.route,
             messageId: ctx.messageId,
           }),

--- a/packages/resend/src/index.test.ts
+++ b/packages/resend/src/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach, type Mock } from 'vitest';
 import type { RenderedMessage } from '@betternotify/email';
 import type { SendContext } from '@betternotify/core';
-import { NotifyRpcError } from '@betternotify/core';
+import { NotifyRpcProviderError } from '@betternotify/core';
 
 let fetchMock: Mock;
 
@@ -207,9 +207,13 @@ describe('resendTransport — Resend API errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect(result.error).toBeInstanceOf(NotifyRpcError);
-    expect((result.error as NotifyRpcError).code).toBe('VALIDATION');
-    expect(result.error.message).toContain('missing_required_field');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('VALIDATION');
+    expect(err.provider).toBe('resend');
+    expect(err.httpStatus).toBe(422);
+    expect(err.retriable).toBe(false);
+    expect(err.message).toContain('missing_required_field');
   });
 
   it('returns CONFIG for 401 status', async () => {
@@ -229,7 +233,12 @@ describe('resendTransport — Resend API errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('CONFIG');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('CONFIG');
+    expect(err.provider).toBe('resend');
+    expect(err.httpStatus).toBe(401);
+    expect(err.retriable).toBe(false);
   });
 
   it('returns CONFIG for 403 status', async () => {
@@ -249,7 +258,12 @@ describe('resendTransport — Resend API errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('CONFIG');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('CONFIG');
+    expect(err.provider).toBe('resend');
+    expect(err.httpStatus).toBe(403);
+    expect(err.retriable).toBe(false);
   });
 
   it('returns PROVIDER for 429 rate limit', async () => {
@@ -269,10 +283,15 @@ describe('resendTransport — Resend API errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('PROVIDER');
+    expect(err.provider).toBe('resend');
+    expect(err.httpStatus).toBe(429);
+    expect(err.retriable).toBe(false);
   });
 
-  it('returns PROVIDER for 500 server error', async () => {
+  it('returns PROVIDER for 500 server error (retriable)', async () => {
     const { resendTransport } = await import('./index.js');
     fetchMock.mockResolvedValue(
       new Response(
@@ -289,7 +308,12 @@ describe('resendTransport — Resend API errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('PROVIDER');
+    expect(err.provider).toBe('resend');
+    expect(err.httpStatus).toBe(500);
+    expect(err.retriable).toBe(true);
   });
 
   it('includes error name and message in the error string', async () => {
@@ -322,21 +346,31 @@ describe('resendTransport — network errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
-    expect(result.error.message).toContain('network error');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('PROVIDER');
+    expect(err.provider).toBe('resend');
+    expect(err.retriable).toBe(true);
+    expect(err.httpStatus).toBeUndefined();
+    expect(err.message).toContain('network error');
   });
 
   it('returns TIMEOUT when fetch throws AbortError', async () => {
     const { resendTransport } = await import('./index.js');
-    const err = new DOMException('aborted', 'AbortError');
-    fetchMock.mockRejectedValue(err);
+    const abortErr = new DOMException('aborted', 'AbortError');
+    fetchMock.mockRejectedValue(abortErr);
     const t = resendTransport({ apiKey: 're_test_123' });
     const result = await t.send(baseMessage, baseCtx);
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('TIMEOUT');
-    expect(result.error.message).toContain('request timed out');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('TIMEOUT');
+    expect(err.provider).toBe('resend');
+    expect(err.retriable).toBe(true);
+    expect(err.httpStatus).toBeUndefined();
+    expect(err.message).toContain('request timed out');
   });
 
   it('returns PROVIDER when response body is not valid JSON', async () => {
@@ -347,7 +381,11 @@ describe('resendTransport — network errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('PROVIDER');
+    expect(err.provider).toBe('resend');
+    expect(err.retriable).toBe(true);
   });
 });
 

--- a/packages/resend/src/index.ts
+++ b/packages/resend/src/index.ts
@@ -1,6 +1,6 @@
 import type { RenderedMessage } from '@betternotify/email';
 import { createTransport, formatAddress, normalizeAddress } from '@betternotify/email/transports';
-import { consoleLogger, NotifyRpcError } from '@betternotify/core';
+import { consoleLogger, NotifyRpcError, NotifyRpcProviderError } from '@betternotify/core';
 import { createHttpClient } from '@betternotify/core/transports';
 import type { WebhookAdapter } from '@betternotify/core/webhook';
 import { NotifyRpcNotImplementedError } from '@betternotify/core';
@@ -20,6 +20,8 @@ export type {
   ResendErrorResponse,
   ResendTag,
 } from './types.js';
+
+export { isResendRetriable } from './is-retriable.js';
 
 const DEFAULT_BASE_URL = 'https://api.resend.com';
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -63,10 +65,10 @@ const buildRequestBody = (message: RenderedMessage, from: string): ResendRequest
   return body;
 };
 
-const mapErrorCode = (status: number): 'VALIDATION' | 'CONFIG' | 'PROVIDER' => {
-  if (status === 422) return 'VALIDATION';
-  if (status === 401 || status === 403) return 'CONFIG';
-  return 'PROVIDER';
+const mapError = (status: number): { code: 'VALIDATION' | 'CONFIG' | 'PROVIDER'; retriable: boolean } => {
+  if (status === 422) return { code: 'VALIDATION', retriable: false };
+  if (status === 401 || status === 403) return { code: 'CONFIG', retriable: false };
+  return { code: 'PROVIDER', retriable: status >= 500 };
 };
 
 /** @experimental Resend transport using the Resend HTTP API. */
@@ -104,9 +106,11 @@ export const resendTransport = (opts: ResendTransportOptions) => {
           log.error('Resend fetch failed', { err: result.cause, route: ctx.route });
           return {
             ok: false,
-            error: new NotifyRpcError({
+            error: new NotifyRpcProviderError({
               message: `Resend transport: ${result.timedOut ? 'request timed out' : `network error: ${result.cause.message}`}`,
               code: result.timedOut ? 'TIMEOUT' : 'PROVIDER',
+              provider: 'resend',
+              retriable: true,
               route: ctx.route,
               messageId: ctx.messageId,
               cause: result.cause,
@@ -115,7 +119,7 @@ export const resendTransport = (opts: ResendTransportOptions) => {
         }
 
         const errData = result.body ?? ({} as ResendErrorResponse);
-        const code = mapErrorCode(result.status);
+        const { code, retriable } = mapError(result.status);
         const errorMessage = `Resend transport: [${errData.name}] ${errData.message}`;
         log.error(errorMessage, {
           err: { status: result.status, name: errData.name, message: errData.message },
@@ -124,9 +128,12 @@ export const resendTransport = (opts: ResendTransportOptions) => {
 
         return {
           ok: false,
-          error: new NotifyRpcError({
+          error: new NotifyRpcProviderError({
             message: errorMessage,
             code,
+            provider: 'resend',
+            httpStatus: result.status,
+            retriable,
             route: ctx.route,
             messageId: ctx.messageId,
           }),

--- a/packages/resend/src/is-retriable.test.ts
+++ b/packages/resend/src/is-retriable.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { NotifyRpcError, NotifyRpcProviderError } from '@betternotify/core';
+import { isResendRetriable } from './is-retriable.js';
+
+describe('isResendRetriable', () => {
+  it('returns true when NotifyRpcProviderError has retriable: true', () => {
+    const err = new NotifyRpcProviderError({ message: 'timeout', provider: 'resend', retriable: true });
+    expect(isResendRetriable(err)).toBe(true);
+  });
+
+  it('returns false when NotifyRpcProviderError has retriable: false', () => {
+    const err = new NotifyRpcProviderError({ message: 'invalid', provider: 'resend', code: 'VALIDATION', retriable: false });
+    expect(isResendRetriable(err)).toBe(false);
+  });
+
+  it('returns true for non-NotifyRpcProviderError errors', () => {
+    expect(isResendRetriable(new NotifyRpcError({ message: 'x' }))).toBe(true);
+    expect(isResendRetriable(new Error('random'))).toBe(true);
+  });
+});

--- a/packages/resend/src/is-retriable.ts
+++ b/packages/resend/src/is-retriable.ts
@@ -1,0 +1,6 @@
+import { NotifyRpcProviderError } from '@betternotify/core';
+
+export const isResendRetriable = (err: unknown): boolean => {
+  if (err instanceof NotifyRpcProviderError) return err.retriable;
+  return true;
+};

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -39,6 +39,7 @@ export type {
 } from './types.js';
 export { slackChannel } from './channel.js';
 export type { TextResolver, BlocksResolver, FileResolver } from './channel.js';
+export { isSlackRetriable } from './is-retriable.js';
 export { mockSlackTransport, slackTransport } from './transports/index.js';
 export type {
   Transport,

--- a/packages/slack/src/is-retriable.test.ts
+++ b/packages/slack/src/is-retriable.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { NotifyRpcProviderError } from '@betternotify/core';
+import { isSlackRetriable } from './is-retriable.js';
+
+describe('isSlackRetriable', () => {
+  it('returns true when NotifyRpcProviderError has retriable: true', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'timeout',
+      provider: 'slack',
+      retriable: true,
+    });
+    expect(isSlackRetriable(err)).toBe(true);
+  });
+
+  it('returns false when NotifyRpcProviderError has retriable: false', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'invalid auth',
+      provider: 'slack',
+      code: 'CONFIG',
+      retriable: false,
+    });
+    expect(isSlackRetriable(err)).toBe(false);
+  });
+
+  it('returns true for non-NotifyRpcProviderError errors', () => {
+    expect(isSlackRetriable(new Error('random'))).toBe(true);
+    expect(isSlackRetriable('string error')).toBe(true);
+    expect(isSlackRetriable(null)).toBe(true);
+  });
+});

--- a/packages/slack/src/is-retriable.ts
+++ b/packages/slack/src/is-retriable.ts
@@ -1,0 +1,6 @@
+import { NotifyRpcProviderError } from '@betternotify/core';
+
+export const isSlackRetriable = (err: unknown): boolean => {
+  if (err instanceof NotifyRpcProviderError) return err.retriable;
+  return true;
+};

--- a/packages/slack/src/transports/slack.test.ts
+++ b/packages/slack/src/transports/slack.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
+import { NotifyRpcProviderError } from '@betternotify/core';
 import { slackTransport } from './slack.js';
 import { mockSlackTransport } from './mock.js';
 
@@ -96,8 +97,13 @@ describe('slackTransport', () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error.message).toContain('invalid_auth');
-      expect((result.error as any).code).toBe('CONFIG');
+      expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+      const err = result.error as NotifyRpcProviderError;
+      expect(err.message).toContain('invalid_auth');
+      expect(err.code).toBe('CONFIG');
+      expect(err.provider).toBe('slack');
+      expect(err.providerCode).toBe('invalid_auth');
+      expect(err.retriable).toBe(false);
     }
   });
 
@@ -109,7 +115,14 @@ describe('slackTransport', () => {
     const result = await t.send({ text: 'hi', to: '#x' }, ctx);
 
     expect(result.ok).toBe(false);
-    if (!result.ok) expect((result.error as any).code).toBe('CONFIG');
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+      const err = result.error as NotifyRpcProviderError;
+      expect(err.code).toBe('CONFIG');
+      expect(err.provider).toBe('slack');
+      expect(err.providerCode).toBe('token_revoked');
+      expect(err.retriable).toBe(false);
+    }
   });
 
   it('returns CONFIG error for not_authed', async () => {
@@ -120,7 +133,14 @@ describe('slackTransport', () => {
     const result = await t.send({ text: 'hi', to: '#x' }, ctx);
 
     expect(result.ok).toBe(false);
-    if (!result.ok) expect((result.error as any).code).toBe('CONFIG');
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+      const err = result.error as NotifyRpcProviderError;
+      expect(err.code).toBe('CONFIG');
+      expect(err.provider).toBe('slack');
+      expect(err.providerCode).toBe('not_authed');
+      expect(err.retriable).toBe(false);
+    }
   });
 
   it('returns CONFIG error for account_inactive', async () => {
@@ -131,7 +151,14 @@ describe('slackTransport', () => {
     const result = await t.send({ text: 'hi', to: '#x' }, ctx);
 
     expect(result.ok).toBe(false);
-    if (!result.ok) expect((result.error as any).code).toBe('CONFIG');
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+      const err = result.error as NotifyRpcProviderError;
+      expect(err.code).toBe('CONFIG');
+      expect(err.provider).toBe('slack');
+      expect(err.providerCode).toBe('account_inactive');
+      expect(err.retriable).toBe(false);
+    }
   });
 
   it('returns VALIDATION error for channel_not_found', async () => {
@@ -143,8 +170,13 @@ describe('slackTransport', () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error.message).toContain('channel_not_found');
-      expect((result.error as any).code).toBe('VALIDATION');
+      expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+      const err = result.error as NotifyRpcProviderError;
+      expect(err.message).toContain('channel_not_found');
+      expect(err.code).toBe('VALIDATION');
+      expect(err.provider).toBe('slack');
+      expect(err.providerCode).toBe('channel_not_found');
+      expect(err.retriable).toBe(false);
     }
   });
 
@@ -156,7 +188,14 @@ describe('slackTransport', () => {
     const result = await t.send({ text: '', to: '#x' }, ctx);
 
     expect(result.ok).toBe(false);
-    if (!result.ok) expect((result.error as any).code).toBe('VALIDATION');
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+      const err = result.error as NotifyRpcProviderError;
+      expect(err.code).toBe('VALIDATION');
+      expect(err.provider).toBe('slack');
+      expect(err.providerCode).toBe('no_text');
+      expect(err.retriable).toBe(false);
+    }
   });
 
   it('returns PROVIDER error for ratelimited', async () => {
@@ -167,7 +206,14 @@ describe('slackTransport', () => {
     const result = await t.send({ text: 'hi', to: '#x' }, ctx);
 
     expect(result.ok).toBe(false);
-    if (!result.ok) expect((result.error as any).code).toBe('PROVIDER');
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+      const err = result.error as NotifyRpcProviderError;
+      expect(err.code).toBe('PROVIDER');
+      expect(err.provider).toBe('slack');
+      expect(err.providerCode).toBe('ratelimited');
+      expect(err.retriable).toBe(true);
+    }
   });
 
   it('returns PROVIDER error for unknown errors', async () => {
@@ -179,8 +225,13 @@ describe('slackTransport', () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error.message).toContain('some_unknown_error');
-      expect((result.error as any).code).toBe('PROVIDER');
+      expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+      const err = result.error as NotifyRpcProviderError;
+      expect(err.message).toContain('some_unknown_error');
+      expect(err.code).toBe('PROVIDER');
+      expect(err.provider).toBe('slack');
+      expect(err.providerCode).toBe('some_unknown_error');
+      expect(err.retriable).toBe(true);
     }
   });
 
@@ -392,8 +443,13 @@ describe('slackTransport', () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error.message).toContain('files.getUploadURLExternal');
-      expect((result.error as any).code).toBe('CONFIG');
+      expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+      const err = result.error as NotifyRpcProviderError;
+      expect(err.message).toContain('files.getUploadURLExternal');
+      expect(err.code).toBe('CONFIG');
+      expect(err.provider).toBe('slack');
+      expect(err.providerCode).toBe('invalid_auth');
+      expect(err.retriable).toBe(false);
     }
   });
 
@@ -415,8 +471,13 @@ describe('slackTransport', () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error.message).toContain('files.completeUploadExternal');
-      expect((result.error as any).code).toBe('VALIDATION');
+      expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+      const err = result.error as NotifyRpcProviderError;
+      expect(err.message).toContain('files.completeUploadExternal');
+      expect(err.code).toBe('VALIDATION');
+      expect(err.provider).toBe('slack');
+      expect(err.providerCode).toBe('channel_not_found');
+      expect(err.retriable).toBe(false);
     }
   });
 
@@ -475,8 +536,13 @@ describe('slackTransport', () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error.message).toContain('unknown_error');
-      expect((result.error as any).code).toBe('PROVIDER');
+      expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+      const err = result.error as NotifyRpcProviderError;
+      expect(err.message).toContain('unknown_error');
+      expect(err.code).toBe('PROVIDER');
+      expect(err.provider).toBe('slack');
+      expect(err.providerCode).toBe('unknown_error');
+      expect(err.retriable).toBe(true);
     }
   });
 
@@ -498,8 +564,13 @@ describe('slackTransport', () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error.message).toContain('unknown_error');
-      expect((result.error as any).code).toBe('PROVIDER');
+      expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+      const err = result.error as NotifyRpcProviderError;
+      expect(err.message).toContain('unknown_error');
+      expect(err.code).toBe('PROVIDER');
+      expect(err.provider).toBe('slack');
+      expect(err.providerCode).toBe('unknown_error');
+      expect(err.retriable).toBe(true);
     }
   });
 
@@ -560,8 +631,13 @@ describe('slackTransport', () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error.message).toContain('HTTP 403');
-      expect((result.error as any).code).toBe('PROVIDER');
+      expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+      const err = result.error as NotifyRpcProviderError;
+      expect(err.message).toContain('HTTP 403');
+      expect(err.code).toBe('PROVIDER');
+      expect(err.provider).toBe('slack');
+      expect(err.httpStatus).toBe(403);
+      expect(err.retriable).toBe(false);
     }
   });
 
@@ -571,9 +647,12 @@ describe('slackTransport', () => {
     const t = slackTransport({ token: 'xoxb-test' });
     const promise = t.send({ text: 'hi', to: '#x' }, ctx);
 
+    await expect(promise).rejects.toBeInstanceOf(NotifyRpcProviderError);
     await expect(promise).rejects.toMatchObject({
       message: expect.stringContaining('network error'),
       code: 'PROVIDER',
+      provider: 'slack',
+      retriable: true,
     });
   });
 
@@ -583,9 +662,12 @@ describe('slackTransport', () => {
     const t = slackTransport({ token: 'xoxb-test' });
     const promise = t.send({ text: 'hi', to: '#x' }, ctx);
 
+    await expect(promise).rejects.toBeInstanceOf(NotifyRpcProviderError);
     await expect(promise).rejects.toMatchObject({
       message: expect.stringContaining('request timed out'),
       code: 'TIMEOUT',
+      provider: 'slack',
+      retriable: true,
     });
   });
 
@@ -595,9 +677,12 @@ describe('slackTransport', () => {
     const t = slackTransport({ token: 'xoxb-test' });
     const promise = t.send({ text: 'hi', to: '#x' }, ctx);
 
+    await expect(promise).rejects.toBeInstanceOf(NotifyRpcProviderError);
     await expect(promise).rejects.toMatchObject({
       message: expect.stringContaining('network error'),
       code: 'PROVIDER',
+      provider: 'slack',
+      retriable: true,
     });
   });
 
@@ -610,9 +695,13 @@ describe('slackTransport', () => {
     const t = slackTransport({ token: 'xoxb-test' });
     const promise = t.send({ text: 'hi', to: '#x' }, ctx);
 
+    await expect(promise).rejects.toBeInstanceOf(NotifyRpcProviderError);
     await expect(promise).rejects.toMatchObject({
       message: expect.stringContaining('HTTP 429'),
       code: 'PROVIDER',
+      provider: 'slack',
+      httpStatus: 429,
+      retriable: true,
     });
     await expect(promise).rejects.toMatchObject({
       message: expect.stringContaining('ratelimited'),
@@ -633,9 +722,12 @@ describe('slackTransport', () => {
     const t = slackTransport({ token: 'xoxb-test' });
     const promise = t.send({ text: 'hi', to: '#x' }, ctx);
 
+    await expect(promise).rejects.toBeInstanceOf(NotifyRpcProviderError);
     await expect(promise).rejects.toMatchObject({
       message: 'Slack chat.postMessage: empty response body',
       code: 'PROVIDER',
+      provider: 'slack',
+      retriable: true,
     });
   });
 
@@ -656,8 +748,12 @@ describe('slackTransport', () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error.message).toContain('network error');
-      expect((result.error as any).code).toBe('PROVIDER');
+      expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+      const err = result.error as NotifyRpcProviderError;
+      expect(err.message).toContain('network error');
+      expect(err.code).toBe('PROVIDER');
+      expect(err.provider).toBe('slack');
+      expect(err.retriable).toBe(true);
     }
   });
 
@@ -678,8 +774,12 @@ describe('slackTransport', () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error.message).toContain('request timed out');
-      expect((result.error as any).code).toBe('TIMEOUT');
+      expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+      const err = result.error as NotifyRpcProviderError;
+      expect(err.message).toContain('request timed out');
+      expect(err.code).toBe('TIMEOUT');
+      expect(err.provider).toBe('slack');
+      expect(err.retriable).toBe(true);
     }
   });
 });

--- a/packages/slack/src/transports/slack.ts
+++ b/packages/slack/src/transports/slack.ts
@@ -1,4 +1,4 @@
-import { consoleLogger, handlePromise, NotifyRpcError } from '@betternotify/core';
+import { consoleLogger, handlePromise, NotifyRpcError, NotifyRpcProviderError } from '@betternotify/core';
 import { createTransport, createHttpClient } from '@betternotify/core/transports';
 import type { RenderedSlack } from '../types.js';
 import type { SlackTransportData, Transport } from './types.js';
@@ -33,10 +33,10 @@ const VALIDATION_ERRORS = new Set([
   'msg_too_long',
 ]);
 
-const mapErrorCode = (error: string): 'CONFIG' | 'VALIDATION' | 'PROVIDER' => {
-  if (CONFIG_ERRORS.has(error)) return 'CONFIG';
-  if (VALIDATION_ERRORS.has(error)) return 'VALIDATION';
-  return 'PROVIDER';
+const mapError = (error: string): { code: 'CONFIG' | 'VALIDATION' | 'PROVIDER'; retriable: boolean } => {
+  if (CONFIG_ERRORS.has(error)) return { code: 'CONFIG', retriable: false };
+  if (VALIDATION_ERRORS.has(error)) return { code: 'VALIDATION', retriable: false };
+  return { code: 'PROVIDER', retriable: true };
 };
 
 export const slackTransport = (opts: SlackTransportOptions): Transport => {
@@ -72,17 +72,22 @@ export const slackTransport = (opts: SlackTransportOptions): Transport => {
           ? 'request timed out'
           : `network error: ${result.cause.message}`
         : `HTTP ${result.status} ${result.statusText}: ${JSON.stringify(result.body)}`;
-      throw new NotifyRpcError({
+      throw new NotifyRpcProviderError({
         message: `Slack ${method}: ${detail}`,
         code: isTimeout ? 'TIMEOUT' : 'PROVIDER',
+        provider: 'slack',
+        httpStatus: isNetwork ? undefined : result.status,
+        retriable: true,
         cause: isNetwork ? result.cause : undefined,
       });
     }
 
     if (!result.data) {
-      throw new NotifyRpcError({
+      throw new NotifyRpcProviderError({
         message: `Slack ${method}: empty response body`,
         code: 'PROVIDER',
+        provider: 'slack',
+        retriable: true,
       });
     }
 
@@ -93,12 +98,15 @@ export const slackTransport = (opts: SlackTransportOptions): Transport => {
     method: string,
     error: string,
     ctx: { route: string; messageId: string },
-  ): NotifyRpcError => {
-    const code = mapErrorCode(error);
+  ): NotifyRpcProviderError => {
+    const { code, retriable } = mapError(error);
     log.error('Slack API error', { err: new Error(error), route: ctx.route });
-    return new NotifyRpcError({
+    return new NotifyRpcProviderError({
       message: `Slack ${method} failed: ${error}`,
       code,
+      provider: 'slack',
+      providerCode: error,
+      retriable,
       route: ctx.route,
       messageId: ctx.messageId,
     });
@@ -153,9 +161,11 @@ export const slackTransport = (opts: SlackTransportOptions): Transport => {
         if (!uploadUrl || !fileId) {
           return {
             ok: false,
-            error: new NotifyRpcError({
+            error: new NotifyRpcProviderError({
               message: 'Slack files.getUploadURLExternal returned incomplete upload metadata',
               code: 'PROVIDER',
+              provider: 'slack',
+              retriable: true,
               route: ctx.route,
               messageId: ctx.messageId,
             }),
@@ -175,9 +185,11 @@ export const slackTransport = (opts: SlackTransportOptions): Transport => {
           const isTimeout = uploadErr.name === 'AbortError' || uploadErr.name === 'TimeoutError';
           return {
             ok: false,
-            error: new NotifyRpcError({
+            error: new NotifyRpcProviderError({
               message: `Slack file upload: ${isTimeout ? 'request timed out' : `network error: ${uploadErr.message}`}`,
               code: isTimeout ? 'TIMEOUT' : 'PROVIDER',
+              provider: 'slack',
+              retriable: true,
               route: ctx.route,
               messageId: ctx.messageId,
               cause: uploadErr,
@@ -188,9 +200,12 @@ export const slackTransport = (opts: SlackTransportOptions): Transport => {
         if (!uploadResponse.ok) {
           return {
             ok: false,
-            error: new NotifyRpcError({
+            error: new NotifyRpcProviderError({
               message: `Slack file upload failed with HTTP ${uploadResponse.status}`,
               code: 'PROVIDER',
+              provider: 'slack',
+              httpStatus: uploadResponse.status,
+              retriable: uploadResponse.status >= 500,
               route: ctx.route,
               messageId: ctx.messageId,
             }),

--- a/packages/smtp/src/index.test.ts
+++ b/packages/smtp/src/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { NotifyRpcProviderError } from '@betternotify/core';
 
 const sendMailMock = vi.fn();
 const verifyMock = vi.fn();
@@ -271,5 +272,101 @@ describe('smtpTransport', () => {
     expect(arg.inlineAssets).toBeUndefined();
     expect(arg.tags).toBeUndefined();
     expect(arg.priority).toBeUndefined();
+  });
+});
+
+describe('smtpTransport — error normalization', () => {
+  it('returns retriable NotifyRpcProviderError for SMTP 4xx temp failure', async () => {
+    const err = new Error('Mailbox temporarily unavailable') as Error & {
+      responseCode: number;
+      code: string;
+    };
+    err.responseCode = 450;
+    err.code = 'EENVELOPE';
+    sendMailMock.mockRejectedValue(err);
+    const t = smtpTransport({ host: 'smtp.x.com', port: 587 });
+    const result = await t.send(baseMessage, baseCtx);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const providerErr = result.error as NotifyRpcProviderError;
+    expect(providerErr.code).toBe('PROVIDER');
+    expect(providerErr.provider).toBe('smtp');
+    expect(providerErr.providerCode).toBe(450);
+    expect(providerErr.retriable).toBe(true);
+    expect(providerErr.cause).toBe(err);
+  });
+
+  it('returns terminal NotifyRpcProviderError for SMTP 5xx permanent failure', async () => {
+    const err = new Error('Mailbox not found') as Error & {
+      responseCode: number;
+      code: string;
+    };
+    err.responseCode = 550;
+    err.code = 'EENVELOPE';
+    sendMailMock.mockRejectedValue(err);
+    const t = smtpTransport({ host: 'smtp.x.com', port: 587 });
+    const result = await t.send(baseMessage, baseCtx);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    const providerErr = result.error as NotifyRpcProviderError;
+    expect(providerErr.code).toBe('PROVIDER');
+    expect(providerErr.provider).toBe('smtp');
+    expect(providerErr.providerCode).toBe(550);
+    expect(providerErr.retriable).toBe(false);
+  });
+
+  it('returns terminal CONFIG error for EAUTH', async () => {
+    const err = new Error('Invalid login') as Error & { code: string };
+    err.code = 'EAUTH';
+    sendMailMock.mockRejectedValue(err);
+    const t = smtpTransport({ host: 'smtp.x.com', port: 587 });
+    const result = await t.send(baseMessage, baseCtx);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    const providerErr = result.error as NotifyRpcProviderError;
+    expect(providerErr.code).toBe('CONFIG');
+    expect(providerErr.provider).toBe('smtp');
+    expect(providerErr.retriable).toBe(false);
+  });
+
+  it('returns retriable PROVIDER error for ESOCKET', async () => {
+    const err = new Error('Connection refused') as Error & { code: string };
+    err.code = 'ESOCKET';
+    sendMailMock.mockRejectedValue(err);
+    const t = smtpTransport({ host: 'smtp.x.com', port: 587 });
+    const result = await t.send(baseMessage, baseCtx);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    const providerErr = result.error as NotifyRpcProviderError;
+    expect(providerErr.code).toBe('PROVIDER');
+    expect(providerErr.provider).toBe('smtp');
+    expect(providerErr.retriable).toBe(true);
+  });
+
+  it('returns retriable PROVIDER error for ECONNECTION', async () => {
+    const err = new Error('Connection timeout') as Error & { code: string };
+    err.code = 'ECONNECTION';
+    sendMailMock.mockRejectedValue(err);
+    const t = smtpTransport({ host: 'smtp.x.com', port: 587 });
+    const result = await t.send(baseMessage, baseCtx);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    const providerErr = result.error as NotifyRpcProviderError;
+    expect(providerErr.code).toBe('PROVIDER');
+    expect(providerErr.provider).toBe('smtp');
+    expect(providerErr.retriable).toBe(true);
+  });
+
+  it('returns retriable PROVIDER error for unknown errors', async () => {
+    sendMailMock.mockRejectedValue(new Error('something unexpected'));
+    const t = smtpTransport({ host: 'smtp.x.com', port: 587 });
+    const result = await t.send(baseMessage, baseCtx);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    const providerErr = result.error as NotifyRpcProviderError;
+    expect(providerErr.code).toBe('PROVIDER');
+    expect(providerErr.provider).toBe('smtp');
+    expect(providerErr.retriable).toBe(true);
   });
 });

--- a/packages/smtp/src/index.ts
+++ b/packages/smtp/src/index.ts
@@ -1,8 +1,28 @@
 import nodemailer from 'nodemailer';
 import type { Address, FromInput, Transport } from '@betternotify/email';
 import { formatAddress, normalizeAddress } from '@betternotify/email/transports';
-import { consoleLogger, NotifyRpcError } from '@betternotify/core';
+import { consoleLogger, handlePromise, NotifyRpcError, NotifyRpcProviderError } from '@betternotify/core';
 import type { SmtpTransportOptions } from './types.js';
+
+export { isSmtpRetriable } from './is-retriable.js';
+
+const AUTH_CODES = new Set(['EAUTH']);
+const CONNECTION_CODES = new Set(['ESOCKET', 'ECONNECTION', 'ETIMEDOUT', 'ECONNREFUSED']);
+
+const classifySmtpError = (
+  err: unknown,
+): { code: 'CONFIG' | 'PROVIDER'; retriable: boolean; providerCode?: number } => {
+  if (!(err instanceof Error)) return { code: 'PROVIDER', retriable: true };
+  const smtpErr = err as Error & { responseCode?: number; code?: string };
+  if (smtpErr.code && AUTH_CODES.has(smtpErr.code)) return { code: 'CONFIG', retriable: false };
+  if (smtpErr.code && CONNECTION_CODES.has(smtpErr.code))
+    return { code: 'PROVIDER', retriable: true };
+  if (smtpErr.responseCode) {
+    const retriable = smtpErr.responseCode >= 400 && smtpErr.responseCode < 500;
+    return { code: 'PROVIDER', retriable, providerCode: smtpErr.responseCode };
+  }
+  return { code: 'PROVIDER', retriable: true };
+};
 
 const fromInputToAddress = (input: Address | FromInput | undefined): Address | undefined => {
   if (!input) return undefined;
@@ -61,23 +81,42 @@ export const smtpTransport = (opts: SmtpTransportOptions): Transport => {
           });
         }
       }
-      const info = await transporter.sendMail({
-        from: formatAddress(from),
-        to: message.to.map(formatAddress),
-        cc: message.cc?.map(formatAddress),
-        bcc: message.bcc?.map(formatAddress),
-        replyTo: message.replyTo ? formatAddress(message.replyTo) : undefined,
-        subject: message.subject,
-        html: message.html,
-        text: message.text,
-        headers: message.headers,
-        attachments: message.attachments?.map((att) => ({
-          filename: att.filename,
-          content: att.content,
-          contentType: att.contentType,
-          cid: att.cid,
-        })),
-      });
+      const [sendErr, info] = await handlePromise(
+        transporter.sendMail({
+          from: formatAddress(from),
+          to: message.to.map(formatAddress),
+          cc: message.cc?.map(formatAddress),
+          bcc: message.bcc?.map(formatAddress),
+          replyTo: message.replyTo ? formatAddress(message.replyTo) : undefined,
+          subject: message.subject,
+          html: message.html,
+          text: message.text,
+          headers: message.headers,
+          attachments: message.attachments?.map((att) => ({
+            filename: att.filename,
+            content: att.content,
+            contentType: att.contentType,
+            cid: att.cid,
+          })),
+        }),
+      );
+
+      if (sendErr) {
+        const { code, retriable, providerCode } = classifySmtpError(sendErr);
+        return {
+          ok: false,
+          error: new NotifyRpcProviderError({
+            message: `SMTP transport: ${sendErr.message}`,
+            code,
+            provider: 'smtp',
+            providerCode,
+            retriable,
+            route: ctx.route,
+            messageId: ctx.messageId,
+            cause: sendErr,
+          }),
+        };
+      }
 
       return {
         ok: true,

--- a/packages/smtp/src/is-retriable.test.ts
+++ b/packages/smtp/src/is-retriable.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { NotifyRpcProviderError } from '@betternotify/core';
+import { isSmtpRetriable } from './is-retriable.js';
+
+describe('isSmtpRetriable', () => {
+  it('returns true when NotifyRpcProviderError has retriable=true', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'Connection refused',
+      provider: 'smtp',
+      retriable: true,
+    });
+    expect(isSmtpRetriable(err)).toBe(true);
+  });
+
+  it('returns false when NotifyRpcProviderError has retriable=false', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'Invalid login',
+      provider: 'smtp',
+      code: 'CONFIG',
+      retriable: false,
+    });
+    expect(isSmtpRetriable(err)).toBe(false);
+  });
+
+  it('returns true for unknown errors that are not NotifyRpcProviderError', () => {
+    expect(isSmtpRetriable(new Error('random'))).toBe(true);
+    expect(isSmtpRetriable('string error')).toBe(true);
+    expect(isSmtpRetriable(null)).toBe(true);
+  });
+});

--- a/packages/smtp/src/is-retriable.ts
+++ b/packages/smtp/src/is-retriable.ts
@@ -1,0 +1,6 @@
+import { NotifyRpcProviderError } from '@betternotify/core';
+
+export const isSmtpRetriable = (err: unknown): boolean => {
+  if (err instanceof NotifyRpcProviderError) return err.retriable;
+  return true;
+};

--- a/packages/telegram/src/index.ts
+++ b/packages/telegram/src/index.ts
@@ -8,6 +8,7 @@ export type {
 export { telegramChannel } from './channel.js';
 export type { BodyResolver, AttachmentResolver } from './channel.js';
 export { escapeMarkdownV2, md } from './escape.js';
+export { isTelegramRetriable } from './is-retriable.js';
 export { mockTelegramTransport, telegramTransport } from './transports/index.js';
 export type {
   Transport,

--- a/packages/telegram/src/is-retriable.test.ts
+++ b/packages/telegram/src/is-retriable.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { NotifyRpcProviderError } from '@betternotify/core';
+import { isTelegramRetriable } from './is-retriable.js';
+
+describe('isTelegramRetriable', () => {
+  it('returns true when NotifyRpcProviderError has retriable: true', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'timeout',
+      provider: 'telegram',
+      retriable: true,
+    });
+    expect(isTelegramRetriable(err)).toBe(true);
+  });
+
+  it('returns false when NotifyRpcProviderError has retriable: false', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'bad request',
+      provider: 'telegram',
+      retriable: false,
+    });
+    expect(isTelegramRetriable(err)).toBe(false);
+  });
+
+  it('returns true for unknown errors', () => {
+    expect(isTelegramRetriable(new Error('random'))).toBe(true);
+    expect(isTelegramRetriable('string error')).toBe(true);
+    expect(isTelegramRetriable(null)).toBe(true);
+  });
+});

--- a/packages/telegram/src/is-retriable.ts
+++ b/packages/telegram/src/is-retriable.ts
@@ -1,0 +1,6 @@
+import { NotifyRpcProviderError } from '@betternotify/core';
+
+export const isTelegramRetriable = (err: unknown): boolean => {
+  if (err instanceof NotifyRpcProviderError) return err.retriable;
+  return true;
+};

--- a/packages/telegram/src/transports/telegram.test.ts
+++ b/packages/telegram/src/transports/telegram.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { NotifyRpcError } from '@betternotify/core';
+import { NotifyRpcProviderError } from '@betternotify/core';
 import { telegramTransport } from './telegram.js';
 import { mockTelegramTransport } from './mock.js';
 
@@ -123,63 +123,157 @@ describe('telegramTransport', () => {
     expect(JSON.parse(call[1].body as string).audio).toBe('https://a.mp3');
   });
 
-  it('throws NotifyRpcError with code PROVIDER on non-ok response', async () => {
+  it('throws NotifyRpcProviderError with code PROVIDER on non-ok response', async () => {
     const fetchMock = mockFetch({ ok: false, description: 'Chat not found' });
     vi.stubGlobal('fetch', fetchMock);
 
     const t = telegramTransport({ token: 'T' });
 
     const promise = t.send({ body: 'hi', to: 999 }, ctx);
-    await expect(promise).rejects.toThrow(NotifyRpcError);
+    await expect(promise).rejects.toBeInstanceOf(NotifyRpcProviderError);
     await expect(promise).rejects.toMatchObject({
       code: 'PROVIDER',
+      provider: 'telegram',
+      retriable: false,
       message: expect.stringContaining('Chat not found'),
     });
   });
 
-  it('throws PROVIDER when the Telegram API returns an HTTP error', async () => {
+  it('throws RATE_LIMITED when the Telegram API returns HTTP 429', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockResolvedValue(
-        new Response(JSON.stringify({ error: 'too many requests' }), {
-          status: 429,
-          statusText: 'Too Many Requests',
-          headers: { 'Content-Type': 'application/json' },
-        }),
+      vi.fn().mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ error: 'too many requests' }), {
+            status: 429,
+            statusText: 'Too Many Requests',
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
       ),
     );
 
     const t = telegramTransport({ token: 'T' });
+    const promise = t.send({ body: 'hi', to: 1 }, ctx);
 
-    await expect(t.send({ body: 'hi', to: 1 }, ctx)).rejects.toMatchObject({
-      code: 'PROVIDER',
-      message: expect.stringContaining('HTTP 429'),
+    await expect(promise).rejects.toBeInstanceOf(NotifyRpcProviderError);
+    await expect(promise).rejects.toMatchObject({
+      code: 'RATE_LIMITED',
+      provider: 'telegram',
+      retriable: true,
+      httpStatus: 429,
     });
   });
 
-  it('throws PROVIDER when the Telegram request fails before a response', async () => {
+  it('throws PROVIDER with retriable true when the Telegram request fails before a response', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('socket closed')));
 
     const t = telegramTransport({ token: 'T' });
+    const promise = t.send({ body: 'hi', to: 1 }, ctx);
 
-    await expect(t.send({ body: 'hi', to: 1 }, ctx)).rejects.toMatchObject({
+    await expect(promise).rejects.toBeInstanceOf(NotifyRpcProviderError);
+    await expect(promise).rejects.toMatchObject({
       code: 'PROVIDER',
+      provider: 'telegram',
+      retriable: true,
       message: expect.stringContaining('network error: socket closed'),
       cause: expect.any(Error),
     });
   });
 
-  it('throws TIMEOUT when the Telegram request is aborted', async () => {
+  it('throws TIMEOUT with retriable true when the Telegram request is aborted', async () => {
     const error = new Error('aborted');
     error.name = 'AbortError';
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(error));
 
     const t = telegramTransport({ token: 'T', http: { timeoutMs: 1 } });
+    const promise = t.send({ body: 'hi', to: 1 }, ctx);
 
-    await expect(t.send({ body: 'hi', to: 1 }, ctx)).rejects.toMatchObject({
+    await expect(promise).rejects.toBeInstanceOf(NotifyRpcProviderError);
+    await expect(promise).rejects.toMatchObject({
       code: 'TIMEOUT',
+      provider: 'telegram',
+      retriable: true,
       message: expect.stringContaining('request timed out'),
       cause: error,
+    });
+  });
+
+  it('throws CONFIG when the Telegram API returns HTTP 401', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ error: 'unauthorized' }), {
+            status: 401,
+            statusText: 'Unauthorized',
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+      ),
+    );
+
+    const t = telegramTransport({ token: 'T' });
+    const promise = t.send({ body: 'hi', to: 1 }, ctx);
+
+    await expect(promise).rejects.toBeInstanceOf(NotifyRpcProviderError);
+    await expect(promise).rejects.toMatchObject({
+      code: 'CONFIG',
+      provider: 'telegram',
+      retriable: false,
+      httpStatus: 401,
+    });
+  });
+
+  it('throws CONFIG when the Telegram API returns HTTP 403', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ error: 'forbidden' }), {
+            status: 403,
+            statusText: 'Forbidden',
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+      ),
+    );
+
+    const t = telegramTransport({ token: 'T' });
+    const promise = t.send({ body: 'hi', to: 1 }, ctx);
+
+    await expect(promise).rejects.toBeInstanceOf(NotifyRpcProviderError);
+    await expect(promise).rejects.toMatchObject({
+      code: 'CONFIG',
+      provider: 'telegram',
+      retriable: false,
+      httpStatus: 403,
+    });
+  });
+
+  it('throws PROVIDER with retriable true when the Telegram API returns HTTP 500', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ error: 'internal server error' }), {
+            status: 500,
+            statusText: 'Internal Server Error',
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+      ),
+    );
+
+    const t = telegramTransport({ token: 'T' });
+    const promise = t.send({ body: 'hi', to: 1 }, ctx);
+
+    await expect(promise).rejects.toBeInstanceOf(NotifyRpcProviderError);
+    await expect(promise).rejects.toMatchObject({
+      code: 'PROVIDER',
+      provider: 'telegram',
+      retriable: true,
+      httpStatus: 500,
     });
   });
 
@@ -231,17 +325,26 @@ describe('telegramTransport', () => {
   });
 
   it('handles error response without description field', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ ok: false }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }),
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ ok: false }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+      ),
     );
-    vi.stubGlobal('fetch', fetchMock);
 
     const t = telegramTransport({ token: 'T' });
-    await expect(t.send({ body: 'hi', to: 1 }, ctx)).rejects.toMatchObject({
+    const promise = t.send({ body: 'hi', to: 1 }, ctx);
+
+    await expect(promise).rejects.toBeInstanceOf(NotifyRpcProviderError);
+    await expect(promise).rejects.toMatchObject({
       code: 'PROVIDER',
+      provider: 'telegram',
+      retriable: false,
       message: expect.stringContaining('Unknown Telegram API error'),
     });
   });
@@ -261,21 +364,27 @@ describe('telegramTransport', () => {
     expect(result).toEqual({ ok: true, data: { messageId: 0, chatId: 0 } });
   });
 
-  it('throws PROVIDER when API returns empty response body', async () => {
+  it('throws PROVIDER with retriable true when API returns empty response body', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockResolvedValue(
-        new Response('', {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        }),
+      vi.fn().mockImplementation(() =>
+        Promise.resolve(
+          new Response('', {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
       ),
     );
 
     const t = telegramTransport({ token: 'T' });
+    const promise = t.send({ body: 'hi', to: 1 }, ctx);
 
-    await expect(t.send({ body: 'hi', to: 1 }, ctx)).rejects.toMatchObject({
+    await expect(promise).rejects.toBeInstanceOf(NotifyRpcProviderError);
+    await expect(promise).rejects.toMatchObject({
       code: 'PROVIDER',
+      provider: 'telegram',
+      retriable: true,
       message: expect.stringContaining('empty response body'),
     });
   });

--- a/packages/telegram/src/transports/telegram.test.ts
+++ b/packages/telegram/src/transports/telegram.test.ts
@@ -251,6 +251,32 @@ describe('telegramTransport', () => {
     });
   });
 
+  it('throws non-retriable PROVIDER when the Telegram API returns HTTP 400', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ description: 'Bad Request' }), {
+            status: 400,
+            statusText: 'Bad Request',
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+      ),
+    );
+
+    const t = telegramTransport({ token: 'T' });
+    const promise = t.send({ body: 'hi', to: 1 }, ctx);
+
+    await expect(promise).rejects.toBeInstanceOf(NotifyRpcProviderError);
+    await expect(promise).rejects.toMatchObject({
+      code: 'PROVIDER',
+      provider: 'telegram',
+      retriable: false,
+      httpStatus: 400,
+    });
+  });
+
   it('throws PROVIDER with retriable true when the Telegram API returns HTTP 500', async () => {
     vi.stubGlobal(
       'fetch',

--- a/packages/telegram/src/transports/telegram.ts
+++ b/packages/telegram/src/transports/telegram.ts
@@ -1,4 +1,4 @@
-import { consoleLogger, NotifyRpcError } from '@betternotify/core';
+import { consoleLogger, NotifyRpcProviderError } from '@betternotify/core';
 import { createHttpClient } from '@betternotify/core/transports';
 import type { RenderedTelegram } from '../types.js';
 import type { TelegramTransportData, Transport } from './types.js';
@@ -11,6 +11,13 @@ type TelegramApiResponse = {
 };
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+
+const mapHttpError = (status: number): { code: 'CONFIG' | 'RATE_LIMITED' | 'PROVIDER'; retriable: boolean } => {
+  if (status === 401 || status === 403) return { code: 'CONFIG', retriable: false };
+  if (status === 429) return { code: 'RATE_LIMITED', retriable: true };
+  if (status >= 500) return { code: 'PROVIDER', retriable: true };
+  return { code: 'PROVIDER', retriable: false };
+};
 
 const methodForAttachment = (type: string): string => {
   const map: Record<string, string> = {
@@ -43,18 +50,32 @@ export const telegramTransport = (opts: TelegramTransportOptions): Transport => 
     });
 
     if (!result.ok) {
-      const isTimeout = result.kind === 'network' && result.timedOut;
-      throw new NotifyRpcError({
-        message: `Telegram ${method}: ${result.kind === 'network' ? (isTimeout ? 'request timed out' : `network error: ${result.cause.message}`) : `HTTP ${result.status}`}`,
-        code: isTimeout ? 'TIMEOUT' : 'PROVIDER',
-        cause: result.kind === 'network' ? result.cause : undefined,
+      if (result.kind === 'network') {
+        const isTimeout = result.timedOut;
+        throw new NotifyRpcProviderError({
+          message: `Telegram ${method}: ${isTimeout ? 'request timed out' : `network error: ${result.cause.message}`}`,
+          code: isTimeout ? 'TIMEOUT' : 'PROVIDER',
+          provider: 'telegram',
+          retriable: true,
+          cause: result.cause,
+        });
+      }
+      const { code, retriable } = mapHttpError(result.status);
+      throw new NotifyRpcProviderError({
+        message: `Telegram ${method}: HTTP ${result.status}`,
+        code,
+        provider: 'telegram',
+        retriable,
+        httpStatus: result.status,
       });
     }
 
     if (!result.data) {
-      throw new NotifyRpcError({
+      throw new NotifyRpcProviderError({
         message: `Telegram ${method}: empty response body`,
         code: 'PROVIDER',
+        provider: 'telegram',
+        retriable: true,
       });
     }
 
@@ -88,9 +109,11 @@ export const telegramTransport = (opts: TelegramTransportOptions): Transport => 
       if (!json.ok) {
         const description = json.description ?? 'Unknown Telegram API error';
         log.error('Telegram API error', { err: new Error(description), route: ctx.route });
-        throw new NotifyRpcError({
+        throw new NotifyRpcProviderError({
           message: `Telegram ${method} failed: ${description}`,
           code: 'PROVIDER',
+          provider: 'telegram',
+          retriable: false,
           route: ctx.route,
           messageId: ctx.messageId,
         });

--- a/packages/twilio/src/index.ts
+++ b/packages/twilio/src/index.ts
@@ -1,2 +1,3 @@
 export { twilioSmsTransport } from './twilio.js';
+export { isTwilioRetriable } from './is-retriable.js';
 export type { TwilioSmsTransportOptions } from './twilio.types.js';

--- a/packages/twilio/src/is-retriable.test.ts
+++ b/packages/twilio/src/is-retriable.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { NotifyRpcProviderError } from '@betternotify/core';
+import { isTwilioRetriable } from './is-retriable.js';
+
+describe('isTwilioRetriable', () => {
+  it('returns true when NotifyRpcProviderError has retriable: true', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'timeout',
+      provider: 'twilio',
+      code: 'TIMEOUT',
+      retriable: true,
+    });
+    expect(isTwilioRetriable(err)).toBe(true);
+  });
+
+  it('returns false when NotifyRpcProviderError has retriable: false', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'bad config',
+      provider: 'twilio',
+      code: 'CONFIG',
+      retriable: false,
+    });
+    expect(isTwilioRetriable(err)).toBe(false);
+  });
+
+  it('returns true for non-NotifyRpcProviderError values', () => {
+    expect(isTwilioRetriable(new Error('random'))).toBe(true);
+    expect(isTwilioRetriable('string error')).toBe(true);
+    expect(isTwilioRetriable(null)).toBe(true);
+  });
+});

--- a/packages/twilio/src/is-retriable.ts
+++ b/packages/twilio/src/is-retriable.ts
@@ -1,0 +1,6 @@
+import { NotifyRpcProviderError } from '@betternotify/core';
+
+export const isTwilioRetriable = (err: unknown): boolean => {
+  if (err instanceof NotifyRpcProviderError) return err.retriable;
+  return true;
+};

--- a/packages/twilio/src/twilio.test.ts
+++ b/packages/twilio/src/twilio.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, afterEach, beforeEach, type Mock } from 'vitest';
-import { NotifyRpcError } from '@betternotify/core';
+import { NotifyRpcError, NotifyRpcProviderError } from '@betternotify/core';
 import type { RenderedSms } from '@betternotify/sms';
 import type { SendContext } from '@betternotify/core';
 
@@ -205,7 +205,13 @@ describe('twilioSmsTransport — error mapping', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('VALIDATION');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('VALIDATION');
+    expect(err.provider).toBe('twilio');
+    expect(err.providerCode).toBe(21211);
+    expect(err.httpStatus).toBe(400);
+    expect(err.retriable).toBe(false);
   });
 
   it('maps Twilio 21610 (unsubscribed) to VALIDATION', async () => {
@@ -220,7 +226,11 @@ describe('twilioSmsTransport — error mapping', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('VALIDATION');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('VALIDATION');
+    expect(err.provider).toBe('twilio');
+    expect(err.retriable).toBe(false);
   });
 
   it('maps Twilio 20003 (auth failure) to CONFIG', async () => {
@@ -235,7 +245,13 @@ describe('twilioSmsTransport — error mapping', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('CONFIG');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('CONFIG');
+    expect(err.provider).toBe('twilio');
+    expect(err.providerCode).toBe(20003);
+    expect(err.httpStatus).toBe(401);
+    expect(err.retriable).toBe(false);
   });
 
   it('maps HTTP 401 without Twilio code to CONFIG', async () => {
@@ -252,7 +268,12 @@ describe('twilioSmsTransport — error mapping', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('CONFIG');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('CONFIG');
+    expect(err.provider).toBe('twilio');
+    expect(err.httpStatus).toBe(401);
+    expect(err.retriable).toBe(false);
   });
 
   it('maps 500 server error to PROVIDER', async () => {
@@ -267,7 +288,12 @@ describe('twilioSmsTransport — error mapping', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('PROVIDER');
+    expect(err.provider).toBe('twilio');
+    expect(err.httpStatus).toBe(500);
+    expect(err.retriable).toBe(true);
   });
 
   it('maps Twilio 14107 (rate limit) to RATE_LIMITED', async () => {
@@ -282,7 +308,11 @@ describe('twilioSmsTransport — error mapping', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('RATE_LIMITED');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('RATE_LIMITED');
+    expect(err.provider).toBe('twilio');
+    expect(err.retriable).toBe(true);
   });
 
   it('maps HTTP 429 without Twilio code to RATE_LIMITED', async () => {
@@ -299,7 +329,12 @@ describe('twilioSmsTransport — error mapping', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('RATE_LIMITED');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('RATE_LIMITED');
+    expect(err.provider).toBe('twilio');
+    expect(err.httpStatus).toBe(429);
+    expect(err.retriable).toBe(true);
   });
 
   it('maps HTTP 400 without recognized Twilio code to VALIDATION', async () => {
@@ -314,7 +349,12 @@ describe('twilioSmsTransport — error mapping', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('VALIDATION');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('VALIDATION');
+    expect(err.provider).toBe('twilio');
+    expect(err.httpStatus).toBe(400);
+    expect(err.retriable).toBe(false);
   });
 
   it('falls back to HTTP status in error message when Twilio message is missing', async () => {
@@ -329,7 +369,11 @@ describe('twilioSmsTransport — error mapping', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
     expect(result.error.message).toContain('HTTP 502');
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.httpStatus).toBe(502);
+    expect(err.retriable).toBe(true);
   });
 
   it('falls back to empty error data when response body is null', async () => {
@@ -343,11 +387,12 @@ describe('twilioSmsTransport — error mapping', () => {
     const result = await t.send(baseMessage, ctx);
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect(result.error).toBeInstanceOf(NotifyRpcError);
-    expect((result.error as NotifyRpcError).message).toContain('HTTP 500');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    expect((result.error as NotifyRpcProviderError).message).toContain('HTTP 500');
+    expect((result.error as NotifyRpcProviderError).retriable).toBe(true);
   });
 
-  it('includes Twilio error message in NotifyRpcError message', async () => {
+  it('includes Twilio error message in NotifyRpcProviderError message', async () => {
     const { twilioSmsTransport } = await import('./twilio.js');
     twilioError(400, 21211, "The 'To' number is not a valid phone number.");
     const t = twilioSmsTransport({
@@ -359,6 +404,7 @@ describe('twilioSmsTransport — error mapping', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
     expect(result.error.message).toContain("The 'To' number is not a valid phone number.");
   });
 });
@@ -376,8 +422,13 @@ describe('twilioSmsTransport — network errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('TIMEOUT');
-    expect(result.error.message).toContain('request timed out');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('TIMEOUT');
+    expect(err.provider).toBe('twilio');
+    expect(err.retriable).toBe(true);
+    expect(err.httpStatus).toBeUndefined();
+    expect(err.message).toContain('request timed out');
   });
 
   it('returns PROVIDER when fetch throws network error', async () => {
@@ -392,8 +443,13 @@ describe('twilioSmsTransport — network errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
-    expect(result.error.message).toContain('network error');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('PROVIDER');
+    expect(err.provider).toBe('twilio');
+    expect(err.retriable).toBe(true);
+    expect(err.httpStatus).toBeUndefined();
+    expect(err.message).toContain('network error');
   });
 
   it('returns PROVIDER when response body is not valid JSON', async () => {
@@ -408,7 +464,11 @@ describe('twilioSmsTransport — network errors', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect((result.error as NotifyRpcError).code).toBe('PROVIDER');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('PROVIDER');
+    expect(err.provider).toBe('twilio');
+    expect(err.retriable).toBe(true);
   });
 });
 

--- a/packages/twilio/src/twilio.ts
+++ b/packages/twilio/src/twilio.ts
@@ -1,4 +1,4 @@
-import { consoleLogger, NotifyRpcError } from '@betternotify/core';
+import { consoleLogger, NotifyRpcError, NotifyRpcProviderError } from '@betternotify/core';
 import { createTransport, createHttpClient } from '@betternotify/core/transports';
 import type { RenderedSms, SmsTransportData, Transport } from '@betternotify/sms';
 import type { TwilioSmsTransportOptions } from './twilio.types.js';
@@ -23,19 +23,19 @@ const CONFIG_CODES = new Set([20003, 20005, 20006, 20008]);
 const VALIDATION_CODES = new Set([21211, 21612, 21610, 21614, 21217, 21219]);
 const RATE_LIMITED_CODES = new Set([14107, 20429, 63018]);
 
-const mapErrorCode = (
+const mapError = (
   twilioCode: number | undefined,
   httpStatus: number,
-): 'CONFIG' | 'VALIDATION' | 'RATE_LIMITED' | 'PROVIDER' => {
+): { code: 'CONFIG' | 'VALIDATION' | 'RATE_LIMITED' | 'PROVIDER'; retriable: boolean } => {
   if (twilioCode !== undefined) {
-    if (CONFIG_CODES.has(twilioCode)) return 'CONFIG';
-    if (VALIDATION_CODES.has(twilioCode)) return 'VALIDATION';
-    if (RATE_LIMITED_CODES.has(twilioCode)) return 'RATE_LIMITED';
+    if (CONFIG_CODES.has(twilioCode)) return { code: 'CONFIG', retriable: false };
+    if (VALIDATION_CODES.has(twilioCode)) return { code: 'VALIDATION', retriable: false };
+    if (RATE_LIMITED_CODES.has(twilioCode)) return { code: 'RATE_LIMITED', retriable: true };
   }
-  if (httpStatus === 401 || httpStatus === 403) return 'CONFIG';
-  if (httpStatus === 400) return 'VALIDATION';
-  if (httpStatus === 429) return 'RATE_LIMITED';
-  return 'PROVIDER';
+  if (httpStatus === 401 || httpStatus === 403) return { code: 'CONFIG', retriable: false };
+  if (httpStatus === 400) return { code: 'VALIDATION', retriable: false };
+  if (httpStatus === 429) return { code: 'RATE_LIMITED', retriable: true };
+  return { code: 'PROVIDER', retriable: httpStatus >= 500 };
 };
 
 const encodeBasicAuth = (accountSid: string, authToken: string): string =>
@@ -99,9 +99,11 @@ export const twilioSmsTransport = (opts: TwilioSmsTransportOptions): Transport =
           log.error('Twilio fetch failed', { err: result.cause, route: ctx.route });
           return {
             ok: false,
-            error: new NotifyRpcError({
+            error: new NotifyRpcProviderError({
               message: `Twilio transport: ${result.timedOut ? 'request timed out' : `network error: ${result.cause.message}`}`,
               code: result.timedOut ? 'TIMEOUT' : 'PROVIDER',
+              provider: 'twilio',
+              retriable: true,
               route: ctx.route,
               messageId: ctx.messageId,
               cause: result.cause,
@@ -110,7 +112,7 @@ export const twilioSmsTransport = (opts: TwilioSmsTransportOptions): Transport =
         }
 
         const errData = result.body as TwilioErrorResponse;
-        const code = mapErrorCode(errData.code, result.status);
+        const { code, retriable } = mapError(errData.code, result.status);
         const errorMessage = `Twilio transport: ${errData.message ?? `HTTP ${result.status}`}`;
         log.error(errorMessage, {
           err: { status: result.status, code: errData.code, message: errData.message },
@@ -119,9 +121,13 @@ export const twilioSmsTransport = (opts: TwilioSmsTransportOptions): Transport =
 
         return {
           ok: false,
-          error: new NotifyRpcError({
+          error: new NotifyRpcProviderError({
             message: errorMessage,
             code,
+            provider: 'twilio',
+            httpStatus: result.status,
+            providerCode: errData.code,
+            retriable,
             route: ctx.route,
             messageId: ctx.messageId,
           }),

--- a/packages/zapier/src/index.ts
+++ b/packages/zapier/src/index.ts
@@ -18,3 +18,4 @@ export type {
   ZapierTransportOptions,
   MockZapierTransport,
 } from './transports/index.js';
+export { isZapierRetriable } from './is-retriable.js';

--- a/packages/zapier/src/is-retriable.test.ts
+++ b/packages/zapier/src/is-retriable.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { NotifyRpcProviderError } from '@betternotify/core';
+import { isZapierRetriable } from './is-retriable.js';
+
+describe('isZapierRetriable', () => {
+  it('returns true when provider error has retriable: true', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'Zapier: network error',
+      code: 'PROVIDER',
+      provider: 'zapier',
+      retriable: true,
+    });
+
+    expect(isZapierRetriable(err)).toBe(true);
+  });
+
+  it('returns false when provider error has retriable: false', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'Zapier: webhook URL expired or deleted',
+      code: 'CONFIG',
+      provider: 'zapier',
+      httpStatus: 410,
+      retriable: false,
+    });
+
+    expect(isZapierRetriable(err)).toBe(false);
+  });
+
+  it('returns true for non-NotifyRpcProviderError values', () => {
+    expect(isZapierRetriable(new Error('random'))).toBe(true);
+    expect(isZapierRetriable('string error')).toBe(true);
+    expect(isZapierRetriable(null)).toBe(true);
+  });
+});

--- a/packages/zapier/src/is-retriable.ts
+++ b/packages/zapier/src/is-retriable.ts
@@ -1,0 +1,6 @@
+import { NotifyRpcProviderError } from '@betternotify/core';
+
+export const isZapierRetriable = (err: unknown): boolean => {
+  if (err instanceof NotifyRpcProviderError) return err.retriable;
+  return true;
+};

--- a/packages/zapier/src/lib/post-webhook.test.ts
+++ b/packages/zapier/src/lib/post-webhook.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, afterEach, beforeEach, type Mock } from 'vitest';
-import { NotifyRpcError } from '@betternotify/core';
+import { NotifyRpcProviderError } from '@betternotify/core';
 
 let fetchMock: Mock;
 
@@ -60,7 +60,7 @@ describe('postWebhook', () => {
     expect(result.status).toBe(200);
   });
 
-  it('returns error with TIMEOUT code on timeout', async () => {
+  it('returns NotifyRpcProviderError with TIMEOUT code on timeout', async () => {
     const { postWebhook } = await import('./post-webhook.js');
     const err = new DOMException('aborted', 'AbortError');
     fetchMock.mockRejectedValue(err);
@@ -69,11 +69,13 @@ describe('postWebhook', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
-    expect(result.error).toBeInstanceOf(NotifyRpcError);
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
     expect(result.error.code).toBe('TIMEOUT');
+    expect(result.error.provider).toBe('zapier');
+    expect(result.error.retriable).toBe(true);
   });
 
-  it('returns error with PROVIDER code on network failure', async () => {
+  it('returns NotifyRpcProviderError with PROVIDER code on network failure', async () => {
     const { postWebhook } = await import('./post-webhook.js');
     fetchMock.mockRejectedValue(new TypeError('fetch failed'));
 
@@ -81,11 +83,14 @@ describe('postWebhook', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
     expect(result.error.code).toBe('PROVIDER');
+    expect(result.error.provider).toBe('zapier');
+    expect(result.error.retriable).toBe(true);
     expect(result.error.message).toContain('network error');
   });
 
-  it('returns error with CONFIG code on 410 Gone', async () => {
+  it('returns NotifyRpcProviderError with CONFIG code on 410 Gone', async () => {
     const { postWebhook } = await import('./post-webhook.js');
     fetchMock.mockResolvedValue(new Response('Gone', { status: 410 }));
 
@@ -93,11 +98,15 @@ describe('postWebhook', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
     expect(result.error.code).toBe('CONFIG');
+    expect(result.error.provider).toBe('zapier');
+    expect(result.error.httpStatus).toBe(410);
+    expect(result.error.retriable).toBe(false);
     expect(result.error.message).toContain('expired');
   });
 
-  it('returns error with PROVIDER code on 4xx (non-410)', async () => {
+  it('returns NotifyRpcProviderError with PROVIDER code on 4xx (non-410)', async () => {
     const { postWebhook } = await import('./post-webhook.js');
     fetchMock.mockResolvedValue(new Response('Bad Request', { status: 400 }));
 
@@ -105,10 +114,14 @@ describe('postWebhook', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
     expect(result.error.code).toBe('PROVIDER');
+    expect(result.error.provider).toBe('zapier');
+    expect(result.error.httpStatus).toBe(400);
+    expect(result.error.retriable).toBe(false);
   });
 
-  it('returns error with PROVIDER code on 5xx', async () => {
+  it('returns NotifyRpcProviderError with PROVIDER code on 5xx', async () => {
     const { postWebhook } = await import('./post-webhook.js');
     fetchMock.mockResolvedValue(new Response('Internal Server Error', { status: 500 }));
 
@@ -116,10 +129,14 @@ describe('postWebhook', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
     expect(result.error.code).toBe('PROVIDER');
+    expect(result.error.provider).toBe('zapier');
+    expect(result.error.httpStatus).toBe(500);
+    expect(result.error.retriable).toBe(true);
   });
 
-  it('includes route and messageId in error when provided', async () => {
+  it('includes route and messageId in provider error when provided', async () => {
     const { postWebhook } = await import('./post-webhook.js');
     fetchMock.mockRejectedValue(new TypeError('fetch failed'));
 
@@ -127,6 +144,7 @@ describe('postWebhook', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected not ok');
+    expect(result.error).toBeInstanceOf(NotifyRpcProviderError);
     expect(result.error.route).toBe('orders.new');
     expect(result.error.messageId).toBe('msg-1');
   });

--- a/packages/zapier/src/lib/post-webhook.ts
+++ b/packages/zapier/src/lib/post-webhook.ts
@@ -1,4 +1,4 @@
-import { NotifyRpcError } from '@betternotify/core';
+import { NotifyRpcProviderError } from '@betternotify/core';
 import { createHttpClient } from '@betternotify/core/transports';
 import type { HttpClientBehaviorOptions } from '@betternotify/core/transports';
 
@@ -13,7 +13,7 @@ export type PostWebhookOptions = {
 
 export type PostWebhookResult =
   | { ok: true; status: number; data: unknown }
-  | { ok: false; error: NotifyRpcError };
+  | { ok: false; error: NotifyRpcProviderError };
 
 export const postWebhook = async (opts: PostWebhookOptions): Promise<PostWebhookResult> => {
   const http = createHttpClient({ ...opts.http, timeoutMs: opts.timeoutMs });
@@ -27,9 +27,11 @@ export const postWebhook = async (opts: PostWebhookOptions): Promise<PostWebhook
     if (result.kind === 'network') {
       return {
         ok: false,
-        error: new NotifyRpcError({
+        error: new NotifyRpcProviderError({
           message: `Zapier: ${result.timedOut ? 'request timed out' : `network error: ${result.cause.message}`}`,
           code: result.timedOut ? 'TIMEOUT' : 'PROVIDER',
+          provider: 'zapier',
+          retriable: true,
           route: opts.route,
           messageId: opts.messageId,
           cause: result.cause,
@@ -42,9 +44,12 @@ export const postWebhook = async (opts: PostWebhookOptions): Promise<PostWebhook
       result.status === 410 ? 'webhook URL expired or deleted' : `HTTP ${result.status}`;
     return {
       ok: false,
-      error: new NotifyRpcError({
+      error: new NotifyRpcProviderError({
         message: `Zapier: ${detail}`,
         code,
+        provider: 'zapier',
+        httpStatus: result.status,
+        retriable: result.status >= 500,
         route: opts.route,
         messageId: opts.messageId,
       }),


### PR DESCRIPTION
# Overview

Adds `NotifyRpcProviderError` subclass and migrates all 8 transports to use it, giving consumers a consistent error shape with retriable/terminal classification.

# What's changed and why?

- `packages/core/src/errors.ts` — New `NotifyRpcProviderError` subclass with `provider`, `httpStatus`, `providerCode`, `retryAfterMs`, `retriable` fields
- `packages/core/src/transports/is-provider-retriable.ts` — Generic `isProviderRetriable` predicate for `multiTransport`
- `packages/resend/src/index.ts` — Use `NotifyRpcProviderError` for all provider errors
- `packages/cloudflare-email/src/index.ts` — Use `NotifyRpcProviderError`, add `RATE_LIMITED` classification for CF 10004
- `packages/twilio/src/twilio.ts` — Use `NotifyRpcProviderError` with Twilio error codes
- `packages/smtp/src/index.ts` — Wrap nodemailer errors with `handlePromise`, classify SMTP 4xx/5xx
- `packages/slack/src/transports/slack.ts` — Use `NotifyRpcProviderError` in both `callApi` and `buildError` paths
- `packages/discord/src/transports/discord.ts` — Use `NotifyRpcProviderError`, add `retryAfterMs` from Discord 429
- `packages/telegram/src/transports/telegram.ts` — Use `NotifyRpcProviderError`, add HTTP status classification
- `packages/zapier/src/lib/post-webhook.ts` — Use `NotifyRpcProviderError` for webhook errors
- `packages/*/src/is-retriable.ts` — Each adapter exports `is<Provider>Retriable` predicate

# How to test

1. `pnpm install && pnpm build`
2. `pnpm test` — all pass
3. `pnpm typecheck && pnpm lint` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced structured provider errors with metadata (provider, provider code, HTTP status, retriable).
  * Added per-provider "is...Retriable" helpers to standardize retry decisions across transports.

* **Bug Fixes**
  * Transports now return consistent provider-aware errors for network/HTTP failures and empty responses.

* **Tests**
  * Updated and expanded tests to validate the new provider-specific error shape and retriable semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->