### PR TITLE
docs(repo): add release checklist and release notes guide

### DIFF
--- a/RELEASE-NOTES-GUIDE.md
+++ b/RELEASE-NOTES-GUIDE.md
@@ -1,0 +1,144 @@
+# Writing Release Notes
+
+After each release, write a curated summary. The auto-generated changelogs from release-please are commit-level and per-package — useful as a reference, but too granular for users. Release notes tell the story: what changed, why it matters, and what to do about it.
+
+A human or an AI agent can write these.
+
+---
+
+## Gather the raw material
+
+Collect everything that went into the release.
+
+```sh
+# 1. See which packages were released and their new versions
+cat .release-please-manifest.json
+
+# 2. Read the auto-generated changelog entries for a specific package
+cat packages/core/CHANGELOG.md
+
+# 3. See all commits since the last release tag
+git log --oneline @betternotify/core-v0.0.2-alpha.0..@betternotify/core-v0.0.3-alpha.0
+
+# 4. Get the full diff between releases
+git diff @betternotify/core-v0.0.2-alpha.0..@betternotify/core-v0.0.3-alpha.0
+
+# 5. List merged PRs in a date range (adjust dates)
+gh pr list --state merged --search "merged:>2026-04-01" --json number,title,labels
+```
+
+## Release notes structure
+
+```markdown
+# Better-Notify v0.0.X-alpha.0
+
+One or two sentences on the theme of this release.
+
+## Highlights
+
+- **Feature name** — what it does and why it matters. ([#PR](link))
+- **Another feature** — brief explanation. ([#PR](link))
+
+## Breaking changes
+
+- `functionName` was renamed to `newName`. Update your imports:
+  ```diff
+  - import { functionName } from '@betternotify/core'
+  + import { newName } from '@betternotify/core'
+  ```
+
+## Bug fixes
+
+- Fixed edge case in X when Y. ([#PR](link))
+
+## Packages released
+
+| Package | Version |
+|---------|---------|
+| @betternotify/core | 0.0.X-alpha.0 |
+| ... | ... |
+
+## Upgrade
+
+\`\`\`sh
+pnpm add @betternotify/core@alpha
+\`\`\`
+```
+
+### Guidelines
+
+- **Lead with value, not commits.** Group related commits into a single bullet that explains the user-facing change.
+- **One bullet per feature, not per commit.** A feature that took 5 commits gets one bullet.
+- **Breaking changes get migration snippets.** Show a diff of what to change.
+- **Skip internal-only changes.** Omit CI tweaks, internal refactors, and test improvements — include only changes that affect users.
+- **Link PRs.** Every highlight links to its PR.
+
+---
+
+## Using an AI agent
+
+Paste the following prompt into Claude Code, Cursor, or any AI coding assistant. Adjust the tag range for your release.
+
+````
+Write release notes for the Better-Notify release that just landed.
+
+Gather context:
+1. Read `.release-please-manifest.json` for current versions.
+2. Read the CHANGELOG.md files for each package that was bumped.
+3. Run `gh pr list --state merged --search "merged:>YYYY-MM-DD"` to find the merged PRs.
+4. Read the PR descriptions for any PR that looks significant.
+
+Then write release notes following the structure in RELEASE-NOTES-GUIDE.md:
+- Group commits into user-facing features (one bullet per feature, not per commit).
+- Call out breaking changes with migration diffs.
+- Skip internal-only changes (CI, refactors, test improvements).
+- Link every highlight to its PR.
+- Include the packages-released table with versions.
+
+Output the notes as markdown. Don't commit or publish — just print them for review.
+````
+
+### Review the draft
+
+Review before publishing:
+
+- [ ] Does every highlight describe a user-facing change?
+- [ ] Are breaking changes listed with migration steps?
+- [ ] Are PR links correct?
+- [ ] Is the package version table accurate against `.release-please-manifest.json`?
+- [ ] Is the tone concise and informative, free of marketing-speak?
+
+---
+
+## Where to publish
+
+1. **GitHub Release** — replace the auto-generated commit list in the GitHub release with the curated notes.
+2. **Docs site** — add a blog post or announcement page when the release warrants one.
+3. **Social channels** — copy the highlights for announcements (see the Social Announcement section in `RELEASING.md`).
+
+---
+
+## Example
+
+These raw changelog entries:
+
+```
+### Features
+* **core:** add race, parallel, and mirrored strategies to multiTransport (f9fdd59)
+* **core:** implement createClient with executeRender and executeSend (a7a5108)
+* **core:** wire built-in logger through createClient send pipeline (ba79e59)
+* **core:** add LoggerLike, consoleLogger, and fromPino (e5e88bc)
+```
+
+Become:
+
+```markdown
+## Highlights
+
+- **Client send pipeline** — `createClient` now handles the full render → send flow
+  with built-in logging. Bring your own logger via the `LoggerLike` interface, or use
+  the default `consoleLogger`. Pino users can wrap with `fromPino()`. ([#12](link))
+
+- **Multi-transport strategies** — `multiTransport` supports `race`, `parallel`, and
+  `mirrored` strategies for sending through multiple providers simultaneously. ([#14](link))
+```

--- a/RELEASE-NOTES-GUIDE.md
+++ b/RELEASE-NOTES-GUIDE.md
@@ -63,6 +63,7 @@ One or two sentences on the theme of this release.
 \`\`\`sh
 pnpm add @betternotify/core@alpha
 \`\`\`
+
 ```
 
 ### Guidelines
@@ -79,7 +80,7 @@ pnpm add @betternotify/core@alpha
 
 Paste the following prompt into Claude Code, Cursor, or any AI coding assistant. Adjust the tag range for your release.
 
-````
+````markdown
 Write release notes for the Better-Notify release that just landed.
 
 Gather context:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,10 +34,12 @@ All packages build and publish in parallel via a matrix job. After merging the r
 - [ ] Watch the `Release Please + npm publish` workflow in GitHub Actions.
 - [ ] Confirm all matrix jobs pass (one per released package, up to 16 packages + web).
 - [ ] Spot-check a published package:
+
   ```sh
   npm info @betternotify/core versions --json | tail -5
   npm info @betternotify/core dist-tags
   ```
+
 - [ ] Verify the `alpha` dist-tag points to the new version.
 - [ ] For packages that depend on other `@betternotify/*` packages, confirm the published `package.json` references the correct version range (not a stale `workspace:*`).
 
@@ -97,11 +99,13 @@ The docs site (`apps/web`) deploys to Cloudflare Workers only when `apps/web` is
 Verify examples work with the released versions.
 
 - [ ] `examples/welcome-text`: install fresh and run:
+
   ```sh
   cd examples/welcome-text
   pnpm install
   pnpm start
   ```
+
 - [ ] Confirm it runs without errors and produces expected output.
 - [ ] Verify any examples added since the last release the same way.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,148 @@
+# Releasing Better-Notify
+
+Repeatable checklist for cutting a release. The pipeline is fully automated via release-please and GitHub Actions — this document covers the human verification layer around it.
+
+## How the pipeline works
+
+1. Conventional commits land on `main`.
+2. Release-please opens (or updates) a release PR bumping versions and changelogs.
+3. Merging the release PR triggers the `release.yml` workflow:
+   - **npm publish**: each affected package publishes to npm with the `alpha` dist-tag (matrix job, one per package).
+   - **Docs deploy**: `apps/web` deploys to Cloudflare Workers (only when `apps/web` is part of the release).
+4. GitHub releases and tags (`@betternotify/<package>-v<version>`) are created automatically.
+
+Preview packages (`0.0.0-preview.<pr>.<sha>`) published during CI clean up automatically when the PR closes.
+
+---
+
+## 1. Changelog generation and review
+
+Before merging the release PR:
+
+- [ ] Open the release-please PR and review every `CHANGELOG.md` diff.
+- [ ] Verify entries match the actual changes — misleading commits produce misleading changelogs.
+- [ ] Confirm breaking changes are called out explicitly.
+- [ ] Confirm version bumps are correct — `alpha` pre-releases should bump patch, not minor/major, unless intentional.
+- [ ] Verify `.release-please-manifest.json` versions match what you expect.
+
+`apps/web/scripts/generate-changelog.ts` runs during `prebuild` and pulls each package's `CHANGELOG.md` into the docs site. Changelogs must be committed (via the release PR) before the web build runs.
+
+## 2. Package publish order and verification
+
+All packages build and publish in parallel via a matrix job. After merging the release PR:
+
+- [ ] Watch the `Release Please + npm publish` workflow in GitHub Actions.
+- [ ] Confirm all matrix jobs pass (one per released package, up to 16 packages + web).
+- [ ] Spot-check a published package:
+  ```sh
+  npm info @betternotify/core versions --json | tail -5
+  npm info @betternotify/core dist-tags
+  ```
+- [ ] Verify the `alpha` dist-tag points to the new version.
+- [ ] For packages that depend on other `@betternotify/*` packages, confirm the published `package.json` references the correct version range (not a stale `workspace:*`).
+
+### Current packages
+
+| Package | Path |
+|---------|------|
+| `@betternotify/core` | `packages/core` |
+| `@betternotify/email` | `packages/email` |
+| `@betternotify/sms` | `packages/sms` |
+| `@betternotify/push` | `packages/push` |
+| `@betternotify/react-email` | `packages/react-email` |
+| `@betternotify/mjml` | `packages/mjml` |
+| `@betternotify/handlebars` | `packages/handlebars` |
+| `@betternotify/smtp` | `packages/smtp` |
+| `@betternotify/ses` | `packages/ses` |
+| `@betternotify/resend` | `packages/resend` |
+| `@betternotify/cloudflare-email` | `packages/cloudflare-email` |
+| `@betternotify/bullmq` | `packages/bullmq` |
+| `@betternotify/slack` | `packages/slack` |
+| `@betternotify/discord` | `packages/discord` |
+| `@betternotify/telegram` | `packages/telegram` |
+| `@betternotify/zapier` | `packages/zapier` |
+
+`apps/web` (`@betternotify/web`) deploys to Cloudflare Workers via a separate job — it is never published to npm.
+
+### If a publish job fails
+
+1. Check the workflow logs for the failing matrix entry.
+2. Common causes:
+   - **npm auth**: verify `NPM_TOKEN` secret is valid and has publish access to the `@betternotify` scope.
+   - **Version conflict**: the version already exists on npm (retry won't help — bump and re-release).
+   - **Build failure**: run `pnpm --filter <package> build` locally to reproduce.
+3. Fix the issue, land the fix on `main`, and let release-please pick it up in the next cycle.
+
+## 3. Docs deploy and version alignment
+
+The docs site (`apps/web`) deploys to Cloudflare Workers only when `apps/web` is included in the release PR.
+
+- [ ] Confirm the `deploy-web` job ran and succeeded (it gates on `web_release_created`).
+- [ ] Visit the production docs URL and verify:
+  - Changelog pages reflect the newly released versions (generated from `CHANGELOG.md` files by `apps/web/scripts/generate-changelog.ts`).
+  - Installation snippets show the correct version/tag.
+  - API docs match the released code.
+- [ ] If docs need a deploy without a package release, manually trigger or push a docs-only change that bumps `apps/web`.
+
+### If the docs deploy fails
+
+1. Check the `deploy-web` job logs.
+2. Common causes:
+   - **Cloudflare auth**: verify `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` secrets.
+   - **Build failure**: run `pnpm exec turbo run build --filter=@betternotify/web...` locally.
+3. Re-run the failed job or push a fix.
+
+## 4. Example verification
+
+Verify examples work with the released versions.
+
+- [ ] `examples/welcome-text`: install fresh and run:
+  ```sh
+  cd examples/welcome-text
+  pnpm install
+  pnpm start
+  ```
+- [ ] Confirm it runs without errors and produces expected output.
+- [ ] Verify any examples added since the last release the same way.
+
+Add new examples to this checklist as they appear in `examples/`.
+
+## 5. Social announcement
+
+> This section is a placeholder — define channels and templates as the project grows.
+
+- [ ] Draft announcement covering: what changed, who benefits, migration notes (if any).
+- [ ] Post to relevant channels (TBD: Twitter/X, Discord, GitHub Discussions, etc.).
+- [ ] Link to the changelog or release notes.
+- [ ] Highlight migration steps for any breaking changes.
+
+---
+
+## Required secrets
+
+| Secret | Used by | Purpose |
+|--------|---------|---------|
+| `BETTER_NOTIFY_APP_ID` | release-please | GitHub App authentication |
+| `BETTER_NOTIFY_APP_PRIVATE_KEY` | release-please | GitHub App authentication |
+| `NPM_TOKEN` | publish + preview | npm registry publish access |
+| `CLOUDFLARE_ACCOUNT_ID` | deploy-web + preview docs | Cloudflare Workers deployment |
+| `CLOUDFLARE_API_TOKEN` | deploy-web + preview docs | Cloudflare Workers deployment |
+
+## Quick reference
+
+```sh
+# Check latest published versions
+npm info @betternotify/core dist-tags
+
+# Check all alpha versions
+npm info @betternotify/core versions --json
+
+# Run full CI locally before release
+pnpm ci
+
+# Build and verify docs locally
+pnpm exec turbo run build --filter=@betternotify/web...
+
+# Run examples
+cd examples/welcome-text && pnpm install && pnpm start
+```


### PR DESCRIPTION
# Overview

Repeatable release checklist and a guide for writing curated release notes (by human or AI agent). Closes BET-60.

# What's changed and why?

- **`RELEASING.md`** — step-by-step release checklist covering changelog review, package publish verification, docs deploy, example verification, social announcement, required secrets, and troubleshooting.
- **`RELEASE-NOTES-GUIDE.md`** — guide for writing curated release notes from the raw release-please changelogs. Includes a structure template, writing guidelines, a ready-to-paste AI agent prompt, a review checklist, and a before/after example.

# How to test

1. Read both files and confirm they match the actual release pipeline in `.github/workflows/release.yml`.
2. Cross-check the package table in `RELEASING.md` against `release-please-config.json`.

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive release notes guide with a repeatable markdown template, user-facing writing guidelines, an AI-agent prompt for draft generation, review checklist, and publishing recommendations.
  * Added a release checklist documenting the automated release workflow, verification steps for changelogs/docs/publishing, failure triage guidance, local verification commands, and required environment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->