### PR TITLE
feat(web): add CLI preview widget to landing hero

### DIFF
--- a/apps/web/src/components/landing/cli-preview.tsx
+++ b/apps/web/src/components/landing/cli-preview.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { handlePromise } from '@betternotify/core';
 import { Check, Copy } from '@phosphor-icons/react';
+import { useState } from 'react';
 
 const tabs = [
   { id: 'cli', label: 'CLI', soon: false },
@@ -12,10 +13,15 @@ export function CliPreview() {
   const [active, setActive] = useState<TabId>('cli');
   const [copied, setCopied] = useState(false);
 
-  function handleCopy() {
-    navigator.clipboard?.writeText('npx create-better-notify');
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1200);
+  async function handleCopy() {
+    const [err] = await handlePromise(
+      navigator.clipboard?.writeText('npx create-better-notify') ??
+        Promise.reject(new Error('clipboard-unavailable')),
+    );
+    if (!err) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    }
   }
 
   return (
@@ -24,7 +30,9 @@ export function CliPreview() {
         {tabs.map((tab) => (
           <button
             key={tab.id}
-            onClick={() => !tab.soon && setActive(tab.id)}
+            type="button"
+            disabled={tab.soon}
+            onClick={() => setActive(tab.id)}
             className={`relative border-0 bg-transparent px-3.5 pb-2.5 pt-3 font-sans text-[13px] font-medium transition-colors ${
               tab.soon
                 ? 'cursor-default text-bn-slate-300 dark:text-bn-slate-600'
@@ -57,6 +65,8 @@ export function CliPreview() {
           create-better-notify
         </code>
         <button
+          type="button"
+          aria-label={copied ? 'Copied' : 'Copy command'}
           onClick={handleCopy}
           className={`flex-shrink-0 border-0 bg-transparent transition-colors ${
             copied

--- a/apps/web/src/components/landing/cli-preview.tsx
+++ b/apps/web/src/components/landing/cli-preview.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { Check, Copy } from '@phosphor-icons/react';
+
+const tabs = [
+  { id: 'cli', label: 'CLI', soon: false },
+  { id: 'skill', label: 'Skill', soon: true },
+] as const;
+
+type TabId = (typeof tabs)[number]['id'];
+
+export function CliPreview() {
+  const [active, setActive] = useState<TabId>('cli');
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    navigator.clipboard?.writeText('npx create-better-notify');
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-bn-slate-200 bg-bn-slate-50 dark:border-bn-slate-800 dark:bg-bn-slate-950">
+      <div className="flex border-b border-bn-slate-200 px-1 dark:border-bn-slate-800">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => !tab.soon && setActive(tab.id)}
+            className={`relative border-0 bg-transparent px-3.5 pb-2.5 pt-3 font-sans text-[13px] font-medium transition-colors ${
+              tab.soon
+                ? 'cursor-default text-bn-slate-300 dark:text-bn-slate-600'
+                : active === tab.id
+                  ? 'cursor-pointer text-bn-slate-900 dark:text-bn-slate-100'
+                  : 'cursor-pointer text-bn-slate-400 hover:text-bn-slate-600 dark:text-bn-slate-500 dark:hover:text-bn-slate-300'
+            }`}
+          >
+            <span className="flex items-center gap-1.5">
+              {tab.label}
+              {tab.soon && (
+                <span className="rounded bg-bn-slate-200 px-1 py-px text-[10px] font-medium text-bn-slate-400 dark:bg-bn-slate-800 dark:text-bn-slate-500">
+                  soon
+                </span>
+              )}
+            </span>
+            {active === tab.id && !tab.soon && (
+              <span className="absolute bottom-[-1px] left-3.5 right-3.5 h-[2px] rounded-full bg-bn-navy-600 dark:bg-bn-navy-400" />
+            )}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-3 px-4 py-3 text-left">
+        <span className="select-none font-mono text-[13px] text-bn-slate-400 dark:text-bn-slate-600">
+          $
+        </span>
+        <code className="flex-1 font-mono text-[13px] text-bn-slate-700 dark:text-bn-slate-300">
+          <span className="font-medium text-bn-navy-700 dark:text-bn-navy-300">npx</span>{' '}
+          create-better-notify
+        </code>
+        <button
+          onClick={handleCopy}
+          className={`flex-shrink-0 border-0 bg-transparent transition-colors ${
+            copied
+              ? 'text-bn-success-700 dark:text-bn-success-300'
+              : 'text-bn-slate-400 hover:text-bn-slate-600 dark:text-bn-slate-500 dark:hover:text-bn-slate-300'
+          }`}
+        >
+          {copied ? <Check size={14} /> : <Copy size={14} />}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/landing/cli-preview.tsx
+++ b/apps/web/src/components/landing/cli-preview.tsx
@@ -1,4 +1,3 @@
-import { handlePromise } from '@betternotify/core';
 import { Check, Copy } from '@phosphor-icons/react';
 import { useState } from 'react';
 
@@ -13,15 +12,10 @@ export function CliPreview() {
   const [active, setActive] = useState<TabId>('cli');
   const [copied, setCopied] = useState(false);
 
-  async function handleCopy() {
-    const [err] = await handlePromise(
-      navigator.clipboard?.writeText('npx create-better-notify') ??
-        Promise.reject(new Error('clipboard-unavailable')),
-    );
-    if (!err) {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1200);
-    }
+  function handleCopy() {
+    navigator.clipboard?.writeText('npx create-better-notify');
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
   }
 
   return (

--- a/apps/web/src/components/landing/hero.tsx
+++ b/apps/web/src/components/landing/hero.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { ArrowRightIcon, GithubLogoIcon } from '@phosphor-icons/react';
 
 import { appConfig } from '@/lib/shared';
+import { CliPreview } from '@/components/landing/cli-preview';
 import { EmailSnippet } from '@/components/landing/snippets/email';
 import { TelegramSnippet } from '@/components/landing/snippets/telegram';
 import { CrossTransportSnippet } from '@/components/landing/snippets/cross-transport';
@@ -85,8 +86,15 @@ export function Hero() {
             </div>
 
             <div
-              className="hero-anim text-muted-foreground/60 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 font-mono text-[12px] lg:justify-start"
+              className="hero-anim mb-8 max-w-[400px] lg:mx-0"
               style={{ animationDelay: '220ms' }}
+            >
+              <CliPreview />
+            </div>
+
+            <div
+              className="hero-anim text-muted-foreground/60 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 font-mono text-[12px] lg:justify-start"
+              style={{ animationDelay: '280ms' }}
             >
               <span>ESM · Node ≥ 22</span>
               <span className="text-muted-foreground/30 hidden sm:inline">|</span>


### PR DESCRIPTION
# Overview

Add a tabbed CLI preview widget to the landing page hero section, showcasing the `npx create-better-notify` scaffolding command with a "Skill" tab placeholder for future use.

# What's changed and why?

- **`apps/web/src/components/landing/cli-preview.tsx`** — New component with tabbed interface (CLI / Skill), underline active indicator, copy-to-clipboard, and a "soon" badge on the Skill tab
- **`apps/web/src/components/landing/hero.tsx`** — Integrated `CliPreview` below the CTA buttons, adjusted animation delays

# How to test

1. Run `pnpm dev` and open `http://localhost:4265`
2. Verify the CLI widget appears below the hero buttons
3. Click the copy button and confirm `npx create-better-notify` is copied
4. Toggle dark mode — both themes should look correct
5. Resize to mobile — command text should be left-aligned

<!--
### Screenshots

| Before | After |
|--------|-------|
| ![Before Screenshot](URL_BEFORE_IMAGE) | ![After Screenshot](URL_AFTER_IMAGE)
-->

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI preview card on the landing page with a copy-to-clipboard button for the install command.
  * Shows visual feedback when copying: icon and aria-label switch to a checkmark for ~1.2s.
  * Includes a disabled "Skill" tab as a coming-soon teaser.

* **Style**
  * Slightly increased animation delay for the metadata tagline row.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->