### PR TITLE
docs: add agent skills for setup and best practices

### DIFF
--- a/apps/web/src/components/landing/cli-preview.tsx
+++ b/apps/web/src/components/landing/cli-preview.tsx
@@ -17,8 +17,12 @@ export function CliPreview() {
     skill: 'npx skills add better-notify/better-notify',
   } as const;
 
-  function handleCopy() {
-    navigator.clipboard?.writeText(commands[active]);
+  async function handleCopy() {
+    const ok = await navigator.clipboard?.writeText(commands[active]).then(
+      () => true,
+      () => false,
+    );
+    if (!ok) return;
     setCopied(true);
     setTimeout(() => setCopied(false), 1200);
   }
@@ -61,7 +65,7 @@ export function CliPreview() {
         </span>
         <code className="flex-1 font-mono text-[13px] text-bn-slate-700 dark:text-bn-slate-300">
           <span className="font-medium text-bn-navy-700 dark:text-bn-navy-300">npx</span>{' '}
-          {active === 'cli' ? 'create-better-notify' : 'skills add better-notify/better-notify'}
+          {commands[active].replace(/^npx\s+/, '')}
         </code>
         <button
           type="button"

--- a/apps/web/src/components/landing/cli-preview.tsx
+++ b/apps/web/src/components/landing/cli-preview.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 
 const tabs = [
   { id: 'cli', label: 'CLI', soon: false },
-  { id: 'skill', label: 'Skill', soon: true },
+  { id: 'skill', label: 'Skill', soon: false },
 ] as const;
 
 type TabId = (typeof tabs)[number]['id'];
@@ -12,8 +12,13 @@ export function CliPreview() {
   const [active, setActive] = useState<TabId>('cli');
   const [copied, setCopied] = useState(false);
 
+  const commands = {
+    cli: 'npx create-better-notify',
+    skill: 'npx skills add better-notify/better-notify',
+  } as const;
+
   function handleCopy() {
-    navigator.clipboard?.writeText('npx create-better-notify');
+    navigator.clipboard?.writeText(commands[active]);
     setCopied(true);
     setTimeout(() => setCopied(false), 1200);
   }
@@ -56,7 +61,7 @@ export function CliPreview() {
         </span>
         <code className="flex-1 font-mono text-[13px] text-bn-slate-700 dark:text-bn-slate-300">
           <span className="font-medium text-bn-navy-700 dark:text-bn-navy-300">npx</span>{' '}
-          create-better-notify
+          {active === 'cli' ? 'create-better-notify' : 'skills add better-notify/better-notify'}
         </code>
         <button
           type="button"

--- a/skills/better-notify/SKILL.md
+++ b/skills/better-notify/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: better-notify
+description: Context and API guidance for Better Notify — end-to-end typed notification infrastructure for Node.js
+metadata:
+  author: betternotify
+  homepage: https://better-notify.com
+---
+
+# Better Notify
+
+End-to-end typed notification infrastructure for Node.js (ESM-only, Node >= 22). A single catalog type drives the typed sender, queue worker, and webhook router — analogous to tRPC, but for notifications.
+
+## When to use
+
+When setting up typed notifications, adding email/SMS/push transports, defining notification catalogs, configuring queue workers, or answering questions about `@betternotify/*` packages.
+
+## Skills
+
+- **[setup](./setup/SKILL.md)** — Interactive setup wizard. Scans your project, asks what channels/transports you need, and scaffolds the catalog + client.
+- **[best-practices](./best-practices/SKILL.md)** — Quick reference for configuration, channel slots, subpath imports, middleware, hooks, and common gotchas.
+
+## Core Concepts
+
+**Catalog** — Typed contract defining notification routes. Built with `createNotify()`, composed via `.catalog()`. Sub-catalogs flatten into dot-path IDs (`transactional.welcome`).
+
+**Client** — Type-safe sender derived from a catalog. `createClient()` returns `mail.<route>.send(input)`, `.queue()`, and `.render()`.
+
+**Channel** — Notification medium (email, SMS, push, etc.). Each defines its own message shape and transport interface. `defineChannel()` creates custom channels.
+
+**Transport** — Delivery adapter for a channel. Receives a resolved message and sends it.
+
+**Middleware** — Composable pipeline functions. Named with `with` prefix (`withRateLimit`, `withDryRun`).
+
+**Template Adapter** — Renders input into HTML/text. Adapters for React Email, MJML, and Handlebars.
+
+## Packages
+
+**Core:** `@betternotify/core` — contracts, client, middleware, hooks, webhook router. Subpath exports: `/transports`, `/middlewares`, `/stores`, `/sinks`, `/tracers`, `/logger`, `/plugins`, `/config`.
+
+**Channels:** `@betternotify/{email, sms, push, discord, slack, telegram}`, `@betternotify/zapier` (channel + email transport)
+
+**Transports:** `@betternotify/smtp` (Nodemailer), `@betternotify/{resend, cloudflare-email, twilio}`, `@betternotify/mailchimp` (Mandrill)
+
+**Templates:** `@betternotify/{react-email, mjml, handlebars}`
+
+**Queue:** `@betternotify/bullmq`
+
+**CLI:** `create-better-notify` — scaffolding tool (`npx create-better-notify`)
+
+Docs: [better-notify.com/docs](https://better-notify.com/docs)

--- a/skills/better-notify/SKILL.md
+++ b/skills/better-notify/SKILL.md
@@ -8,11 +8,11 @@ metadata:
 
 # Better Notify
 
-End-to-end typed notification infrastructure for Node.js (ESM-only, Node >= 22). A single catalog type drives the typed sender, queue worker, and webhook router — analogous to tRPC, but for notifications.
+End-to-end typed notification infrastructure for Node.js (ESM-only, Node >= 22). A single catalog type drives the typed sender and webhook router — analogous to tRPC, but for notifications.
 
 ## When to use
 
-When setting up typed notifications, adding email/SMS/push transports, defining notification catalogs, configuring queue workers, or answering questions about `@betternotify/*` packages.
+When setting up typed notifications, adding email/SMS/push transports, defining notification catalogs, or answering questions about `@betternotify/*` packages.
 
 ## Skills
 
@@ -23,7 +23,7 @@ When setting up typed notifications, adding email/SMS/push transports, defining 
 
 **Catalog** — Typed contract defining notification routes. Built with `createNotify()`, composed via `.catalog()`. Sub-catalogs flatten into dot-path IDs (`transactional.welcome`).
 
-**Client** — Type-safe sender derived from a catalog. `createClient()` returns `mail.<route>.send(input)`, `.queue()`, and `.render()`.
+**Client** — Type-safe sender derived from a catalog. `createClient()` returns `mail.<route>.send(input)` and `.render()`.
 
 **Channel** — Notification medium (email, SMS, push, etc.). Each defines its own message shape and transport interface. `defineChannel()` creates custom channels.
 
@@ -42,8 +42,6 @@ When setting up typed notifications, adding email/SMS/push transports, defining 
 **Transports:** `@betternotify/smtp` (Nodemailer), `@betternotify/{resend, cloudflare-email, twilio}`, `@betternotify/mailchimp` (Mandrill)
 
 **Templates:** `@betternotify/{react-email, mjml, handlebars}`
-
-**Queue:** `@betternotify/bullmq`
 
 **CLI:** `create-better-notify` — scaffolding tool (`npx create-better-notify`)
 

--- a/skills/better-notify/best-practices/SKILL.md
+++ b/skills/better-notify/best-practices/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: better-notify/best-practices
+description: Quick reference for Better Notify configuration, patterns, and common gotchas
+---
+
+# Better Notify Quick Reference
+
+**Always consult [better-notify.com/docs](https://better-notify.com/docs) for latest API.**
+
+---
+
+## Setup Workflow
+
+1. Install: `npm install @betternotify/core @betternotify/email` (+ channel/transport packages)
+2. Define channels and catalog in `lib/notify.ts`
+3. Create client with transports in `lib/notify-client.ts`
+4. Send: `mail.<route>.send({ to, input })`
+
+---
+
+## Core API
+
+| Function                                                   | Import               | Purpose                                         |
+| ---------------------------------------------------------- | -------------------- | ----------------------------------------------- |
+| `createNotify({ channels })`                               | `@betternotify/core` | Root builder with channel map                   |
+| `createClient({ catalog, channels, transportsByChannel })` | `@betternotify/core` | Type-safe send client                           |
+| `createCatalog(map)`                                       | `@betternotify/core` | Standalone catalog (without builder)            |
+| `defineChannel({ name, slots, validateArgs, render })`     | `@betternotify/core` | Custom channel definition                       |
+| `slot.resolver<T>()` / `slot.value<T>()`                   | `@betternotify/core` | Template slot declarations                      |
+| `consoleLogger({ level })`                                 | `@betternotify/core` | Built-in console logger                         |
+| `handlePromise(promise)`                                   | `@betternotify/core` | Tuple-returning async wrapper `[error, result]` |
+
+---
+
+## Channel Slots
+
+Each channel has typed slots set via the builder:
+
+### Email (`@betternotify/email`)
+
+| Slot                 | Type                                          | Required |
+| -------------------- | --------------------------------------------- | -------- |
+| `.input(schema)`     | Standard Schema (Zod, Valibot, ArkType)       | Yes      |
+| `.subject(resolver)` | `string` or `(args) => string`                | Yes      |
+| `.template(adapter)` | `TemplateAdapter` or `{ render }`             | Yes      |
+| `.from(resolver)`    | `Address` or `(args) => Address`              | No       |
+| `.replyTo(address)`  | `Address`                                     | No       |
+| `.tags(tags)`        | `Record<string, string \| number \| boolean>` | No       |
+| `.priority(level)`   | `'low' \| 'normal' \| 'high'`                 | No       |
+
+**Send args:** `{ to, input, cc?, bcc?, replyTo?, from?, headers?, attachments? }`
+
+### SMS (`@betternotify/sms`)
+
+| Slot              | Type                           | Required |
+| ----------------- | ------------------------------ | -------- |
+| `.input(schema)`  | Standard Schema                | Yes      |
+| `.body(resolver)` | `string` or `(args) => string` | Yes      |
+
+**Send args:** `{ to: string, input }` (phone number)
+
+### Push (`@betternotify/push`)
+
+| Slot               | Type                           | Required |
+| ------------------ | ------------------------------ | -------- |
+| `.input(schema)`   | Standard Schema                | Yes      |
+| `.title(resolver)` | `string` or `(args) => string` | Yes      |
+| `.body(resolver)`  | `string` or `(args) => string` | Yes      |
+| `.data(resolver)`  | `Record<string, unknown>`      | No       |
+| `.badge(resolver)` | `number`                       | No       |
+
+**Send args:** `{ to: string \| string[], input }` (device tokens)
+
+### Slack (`@betternotify/slack`)
+
+| Slot                | Type                           | Required |
+| ------------------- | ------------------------------ | -------- |
+| `.input(schema)`    | Standard Schema                | Yes      |
+| `.text(resolver)`   | `string` or `(args) => string` | Yes      |
+| `.blocks(resolver)` | `SlackBlock[]`                 | No       |
+
+**Send args:** `{ input, to?: string, threadTs?: string }` (channel ID)
+
+### Discord (`@betternotify/discord`)
+
+| Slot                | Type                           | Required |
+| ------------------- | ------------------------------ | -------- |
+| `.input(schema)`    | Standard Schema                | Yes      |
+| `.body(resolver)`   | `string` or `(args) => string` | Yes      |
+| `.embeds(resolver)` | `DiscordEmbed[]`               | No       |
+| `.username(value)`  | `string`                       | No       |
+| `.avatarUrl(value)` | `string`                       | No       |
+
+**Send args:** `{ input }`
+
+### Telegram (`@betternotify/telegram`)
+
+| Slot                    | Type                                   | Required |
+| ----------------------- | -------------------------------------- | -------- |
+| `.input(schema)`        | Standard Schema                        | Yes      |
+| `.body(resolver)`       | `string` or `(args) => string`         | Yes      |
+| `.parseMode(mode)`      | `'HTML' \| 'Markdown' \| 'MarkdownV2'` | No       |
+| `.attachment(resolver)` | `TelegramAttachment`                   | No       |
+
+**Send args:** `{ to: string \| number, input }` (chat ID)
+
+---
+
+## Subpath Imports
+
+Import optional features from subpaths, **not** the root barrel:
+
+```typescript
+// Correct
+import { withRateLimit } from '@betternotify/core/middlewares';
+import { inMemoryRateLimitStore } from '@betternotify/core/stores';
+import { consoleEventSink } from '@betternotify/core/sinks';
+import { inMemoryTracer } from '@betternotify/core/tracers';
+
+// Wrong — do not import these from '@betternotify/core'
+```
+
+| Subpath        | Exports                                                                                                                                                    |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/middlewares` | `withDryRun`, `withTagInject`, `withEventLogger`, `withRateLimit`, `withIdempotency`, `withTracing`, `createMiddleware`                                    |
+| `/stores`      | `inMemorySuppressionList`, `inMemoryRateLimitStore`, `inMemoryIdempotencyStore`, `createSuppressionList`, `createRateLimitStore`, `createIdempotencyStore` |
+| `/sinks`       | `inMemoryEventSink`, `consoleEventSink`, `createEventSink`                                                                                                 |
+| `/tracers`     | `inMemoryTracer`                                                                                                                                           |
+| `/transports`  | `createHttpClient`, `createTransport`, `multiTransport`, `mapTransport`                                                                                    |
+| `/logger`      | `consoleLogger`, `fromPino`                                                                                                                                |
+| `/plugins`     | `createPlugin`                                                                                                                                             |
+
+---
+
+## Middleware
+
+Middleware mutates context or short-circuits the pipeline. Named with `with` prefix.
+
+```typescript
+const rpc = createNotify({ channels: { email: ch } })
+  .use(withRateLimit({ store, key, max, window }))
+  .use(withIdempotency({ store, key, ttl }))
+  .use(withDryRun());
+```
+
+**Custom middleware:**
+
+```typescript
+import { createMiddleware } from '@betternotify/core/middlewares';
+
+const withLogging = createMiddleware(async ({ next, route, messageId }) => {
+  console.log(`Sending ${route} (${messageId})`);
+  return next();
+});
+```
+
+---
+
+## Hooks
+
+Hooks observe but don't mutate. Set on `createClient`:
+
+```typescript
+const mail = createClient({
+  catalog,
+  channels: { email: ch },
+  transportsByChannel: { email: transport },
+  hooks: {
+    onBeforeSend: ({ route, messageId, args }) => { ... },
+    onExecute: ({ rendered }) => { ... },
+    onAfterSend: ({ result, timing }) => { ... },
+    onError: ({ error, phase }) => { ... },
+  },
+})
+```
+
+**Error phases:** `'validate' | 'middleware' | 'render' | 'send' | 'hook'`
+
+**Rule:** If removing it would change whether the notification goes out, it must be middleware, not a hook.
+
+---
+
+## Client API
+
+```typescript
+// Single send
+const result = await mail.welcome.send({ to, input })
+// result: { messageId, data, envelope?, timing: { renderMs, sendMs } }
+
+// Batch send
+const batch = await mail.welcome.batch([{ to, input }, ...], { interval: 250 })
+// batch: { okCount, errorCount, results: [{ status, result?, error? }] }
+
+// Render only (no send)
+const rendered = await mail.welcome.render(input)
+
+// Cleanup
+await mail.close()
+```
+
+---
+
+## Address Types (Email)
+
+```typescript
+// String shorthand
+{ to: 'user@example.com' }
+
+// Object with name
+{ to: { name: 'Alice', email: 'alice@example.com' } }
+
+// Multiple recipients
+{ to: ['alice@example.com', { name: 'Bob', email: 'bob@example.com' }] }
+
+// From — both fields optional (merges with defaults)
+{ from: { name: 'Support' } }         // uses default email
+{ from: { email: 'no-reply@...' } }   // uses default name
+```
+
+---
+
+## Error Classes
+
+All errors subclass `NotifyRpcError` and are JSON-serializable.
+
+| Error                          | When                                     |
+| ------------------------------ | ---------------------------------------- |
+| `NotifyRpcValidationError`     | Input fails schema validation            |
+| `NotifyRpcRateLimitedError`    | Rate limit exceeded (has `retryAfterMs`) |
+| `NotifyRpcNotImplementedError` | Feature not yet available                |
+| `NotifyRpcProviderError`       | Transport delivery failure               |
+
+---
+
+## Multi-Transport Strategies
+
+```typescript
+import { multiTransport } from '@betternotify/email';
+
+multiTransport({
+  strategy: 'failover', // try next on failure
+  transports: [{ transport: primary }, { transport: fallback }],
+});
+```
+
+| Strategy      | Behavior                                   |
+| ------------- | ------------------------------------------ |
+| `failover`    | Try transports in order until one succeeds |
+| `round-robin` | Rotate between transports                  |
+| `random`      | Pick randomly                              |
+| `race`        | Send via all, return first success         |
+| `parallel`    | Send via all, wait for all                 |
+| `mirrored`    | Send via all, return primary result        |
+
+---
+
+## Common Gotchas
+
+1. **Import from subpaths** — `@betternotify/core/middlewares`, not `@betternotify/core`. Root barrel only exports core primitives.
+2. **Standard Schema, not just Zod** — `.input()` accepts Zod, Valibot, or ArkType schemas. Don't assume Zod.
+3. **Resolvers can be static or functions** — `.subject('Hello')` and `.subject(({ input }) => input.title)` are both valid.
+4. **`from` merges per-field** — Per-email `from` and `defaults.from` shallow-merge. `{ from: { name: 'Support' } }` keeps the default email.
+5. **Transport is dumb** — Transports receive fully-resolved messages. No validation, no rendering. That happens upstream in the pipeline.
+6. **Middleware vs hooks** — If removing it changes whether the notification sends, it's middleware. Hooks only observe.
+7. **Mock transports for testing** — Each channel package exports a mock: `mockTransport()` (email), `mockSmsTransport()` (SMS), etc. Check `.sent` or `.messages` array.
+8. **Sub-catalogs flatten** — `{ transactional: rpc.catalog({ welcome: ... }) }` creates route `transactional.welcome`, accessed as `mail.transactional.welcome.send()`.
+9. **ESM only** — Better Notify is ESM-only, requires Node >= 22.
+10. **`handlePromise` over try/catch** — Use `const [err, result] = await handlePromise(promise)` for async error handling.
+
+---
+
+## Resources
+
+- [Docs](https://better-notify.com/docs)
+- [GitHub](https://github.com/better-notify/better-notify)
+- [Examples](https://github.com/better-notify/better-notify/tree/main/examples)

--- a/skills/better-notify/setup/SKILL.md
+++ b/skills/better-notify/setup/SKILL.md
@@ -1,0 +1,360 @@
+---
+name: better-notify/setup
+description: Interactive setup wizard for adding Better Notify to a TypeScript/JavaScript project
+---
+
+# Better Notify Setup
+
+Guide for adding typed notifications to TypeScript/JavaScript applications using Better Notify.
+
+**For code examples and syntax, see [better-notify.com/docs](https://better-notify.com/docs).**
+
+---
+
+## Phase 1: Planning (REQUIRED before implementation)
+
+Scan the project and ask the user structured questions before writing any code.
+
+### Step 1: Scan the project
+
+Analyze the codebase to auto-detect:
+
+- **Framework** — Look for `next.config`, `hono`, `express`, `fastify`, or other server entry files.
+- **Existing notifications** — Look for `nodemailer`, `@sendgrid`, `resend`, `postmark`, `ses` in `package.json`.
+- **Validation library** — Look for `zod`, `valibot`, `arktype` in `package.json` (Better Notify uses Standard Schema).
+- **Package manager** — Check for `pnpm-lock.yaml`, `yarn.lock`, `bun.lockb`, or `package-lock.json`.
+
+Use what you find to pre-fill defaults and skip questions you can already answer.
+
+### Step 2: Ask planning questions
+
+Ask all applicable questions in a single call. Skip any you already answered from the scan.
+
+1. **Notification channels** (always ask, allow multiple)
+   - "Which notification channels do you need?"
+   - Options: Email | SMS | Push notifications | Discord | Slack | Telegram | Custom channel
+
+2. **Email transport** (only if Email selected)
+   - "Which email transport will you use?"
+   - Options: SMTP (Nodemailer) | Resend | Mailchimp Transactional (Mandrill) | Cloudflare Email | Mock (for development)
+
+3. **SMS transport** (only if SMS selected)
+   - "Which SMS transport will you use?"
+   - Options: Twilio | Mock (for development)
+
+4. **Template engine** (only if Email selected)
+   - "How do you want to write email templates?"
+   - Options: React Email | MJML | Handlebars | Inline HTML (no adapter needed)
+
+5. **Validation library** (skip if detected)
+   - "Which validation library do you use? Better Notify supports any Standard Schema provider."
+   - Options: Zod | Valibot | ArkType
+
+6. **Queue** (always ask)
+   - "Do you need background queue processing?"
+   - Options: Yes (BullMQ + Redis) | No (send synchronously)
+
+7. **Features** (always ask, allow multiple)
+   - "Which additional features do you need?"
+   - Options: Rate limiting | Idempotency (deduplication) | Suppression list | Tracing | Event logging | Dry-run mode | None
+
+### Step 3: Summarize the plan
+
+Present a concise implementation plan as a markdown checklist. Example:
+
+```
+## Notification Setup Plan
+
+- **Channels:** Email, Slack
+- **Email transport:** SMTP
+- **Templates:** React Email
+- **Validation:** Zod
+- **Queue:** No
+- **Features:** Rate limiting, event logging
+
+### Steps
+1. Install `@betternotify/core`, `@betternotify/email`, `@betternotify/slack`
+2. Install `@betternotify/smtp`, `@betternotify/react-email`
+3. Create `lib/notify.ts` with channel config and catalog
+4. Create `lib/notify-client.ts` with client setup
+5. Create email templates under `emails/`
+6. Add middleware (rate limiting, event logging)
+7. Set up environment variables
+```
+
+Ask the user to confirm before proceeding to Phase 2.
+
+---
+
+## Phase 2: Implementation
+
+Only proceed after the user confirms the plan.
+
+### Step 1: Install packages
+
+**Core (always):** `@betternotify/core`
+
+**Channels:**
+| Package | When |
+|---------|------|
+| `@betternotify/email` | Email channel |
+| `@betternotify/sms` | SMS channel |
+| `@betternotify/push` | Push notifications |
+| `@betternotify/discord` | Discord webhooks |
+| `@betternotify/slack` | Slack messages |
+| `@betternotify/telegram` | Telegram bot |
+
+**Transports:**
+| Package | When |
+|---------|------|
+| `@betternotify/smtp` | SMTP email (Nodemailer) |
+| `@betternotify/resend` | Resend email |
+| `@betternotify/mailchimp` | Mailchimp Transactional |
+| `@betternotify/cloudflare-email` | Cloudflare Email |
+| `@betternotify/twilio` | Twilio SMS |
+
+**Templates:**
+| Package | When |
+|---------|------|
+| `@betternotify/react-email` | React Email templates |
+| `@betternotify/mjml` | MJML templates |
+| `@betternotify/handlebars` | Handlebars templates |
+
+**Queue:**
+| Package | When |
+|---------|------|
+| `@betternotify/bullmq` | Background processing |
+
+### Step 2: Define the catalog (`lib/notify.ts`)
+
+```typescript
+import { createNotify } from '@betternotify/core';
+import { emailChannel } from '@betternotify/email';
+import { z } from 'zod';
+
+export const ch = emailChannel({
+  defaults: { from: { name: 'My App', email: 'noreply@example.com' } },
+});
+
+const rpc = createNotify({ channels: { email: ch } });
+
+export const catalog = rpc.catalog({
+  welcome: rpc
+    .email()
+    .input(z.object({ name: z.string(), verifyUrl: z.string().url() }))
+    .subject(({ input }) => `Welcome, ${input.name}!`)
+    .template({
+      render: async ({ input }) => ({
+        html: `<p>Welcome, ${input.name}!</p>`,
+        text: `Welcome, ${input.name}!`,
+      }),
+    }),
+});
+```
+
+**Multi-channel example:**
+
+```typescript
+import { createNotify } from '@betternotify/core';
+import { emailChannel } from '@betternotify/email';
+import { slackChannel } from '@betternotify/slack';
+
+const rpc = createNotify({
+  channels: {
+    email: emailChannel({ defaults: { from: 'noreply@example.com' } }),
+    slack: slackChannel(),
+  },
+});
+
+export const catalog = rpc.catalog({
+  welcome: rpc
+    .email()
+    .input(z.object({ name: z.string() }))
+    .subject(({ input }) => `Welcome, ${input.name}!`)
+    .template({ render: async ({ input }) => ({ html: `...`, text: `...` }) }),
+
+  alert: rpc
+    .slack()
+    .input(z.object({ message: z.string() }))
+    .text(({ input }) => input.message),
+});
+```
+
+**Sub-catalogs (nested routes):**
+
+```typescript
+export const catalog = rpc.catalog({
+  transactional: rpc.catalog({
+    welcome: rpc.email()...,
+    reset: rpc.email()...,
+  }),
+  marketing: rpc.catalog({
+    newsletter: rpc.email()...,
+  }),
+})
+// Routes: transactional.welcome, transactional.reset, marketing.newsletter
+```
+
+### Step 3: Create the client (`lib/notify-client.ts`)
+
+```typescript
+import { createClient, consoleLogger } from '@betternotify/core';
+import { smtpTransport } from '@betternotify/smtp';
+import { catalog, ch } from './notify';
+
+export const mail = createClient({
+  catalog,
+  channels: { email: ch },
+  transportsByChannel: {
+    email: smtpTransport({
+      host: process.env.SMTP_HOST!,
+      port: Number(process.env.SMTP_PORT),
+      auth: { user: process.env.SMTP_USER!, pass: process.env.SMTP_PASS! },
+    }),
+  },
+  logger: consoleLogger({ level: 'info' }),
+});
+```
+
+### Step 4: Send notifications
+
+```typescript
+import { mail } from './lib/notify-client';
+
+const result = await mail.welcome.send({
+  to: 'user@example.com',
+  input: { name: 'Alice', verifyUrl: 'https://...' },
+});
+
+// Batch sending
+const batch = await mail.welcome.batch(
+  [
+    { to: 'alice@example.com', input: { name: 'Alice', verifyUrl: '...' } },
+    { to: 'bob@example.com', input: { name: 'Bob', verifyUrl: '...' } },
+  ],
+  { interval: 250 },
+);
+```
+
+### Step 5: Environment variables
+
+```env
+# SMTP
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your-user
+SMTP_PASS=your-pass
+
+# Resend (alternative)
+RESEND_API_KEY=re_...
+
+# Slack
+SLACK_TOKEN=xoxb-...
+SLACK_DEFAULT_CHANNEL=C0123456789
+
+# Twilio
+TWILIO_ACCOUNT_SID=AC...
+TWILIO_AUTH_TOKEN=...
+TWILIO_FROM_NUMBER=+1234567890
+
+# Discord
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+
+# Telegram
+TELEGRAM_BOT_TOKEN=...
+```
+
+### Step 6: Add middleware (optional)
+
+```typescript
+import { withRateLimit, withEventLogger } from '@betternotify/core/middlewares';
+import { inMemoryRateLimitStore } from '@betternotify/core/stores';
+import { consoleEventSink } from '@betternotify/core/sinks';
+
+const rpc = createNotify({ channels: { email: ch } })
+  .use(
+    withRateLimit({
+      store: inMemoryRateLimitStore(),
+      key: ({ args }) => args.to,
+      max: 5,
+      window: 60_000,
+    }),
+  )
+  .use(withEventLogger({ sink: consoleEventSink() }));
+```
+
+### Step 7: Testing with mock transports
+
+```typescript
+import { mockTransport } from '@betternotify/email';
+
+const mock = mockTransport();
+const mail = createClient({
+  catalog,
+  channels: { email: ch },
+  transportsByChannel: { email: mock },
+});
+
+await mail.welcome.send({ to: 'test@example.com', input: { name: 'Test' } });
+
+assert(mock.sent.length === 1);
+assert(mock.sent[0].subject === 'Welcome, Test!');
+mock.reset();
+```
+
+---
+
+## Template Adapters
+
+### React Email
+
+```typescript
+import { reactEmail } from '@betternotify/react-email'
+import { WelcomeEmail } from '../emails/welcome'
+
+.template(({ input }) => reactEmail(WelcomeEmail, { name: input.name }))
+```
+
+### Handlebars
+
+```typescript
+import { handlebarsTemplate } from '@betternotify/handlebars'
+
+.template(handlebarsTemplate('<h1>Hello {{name}}</h1>', {
+  text: 'Hello {{name}}',
+  subject: 'Welcome, {{name}}!',
+}))
+```
+
+### MJML
+
+```typescript
+import { mjml } from '@betternotify/mjml'
+
+.template(mjml(`<mjml><mj-body>...</mj-body></mjml>`))
+```
+
+---
+
+## Transport Options
+
+### Multi-transport (failover)
+
+```typescript
+import { multiTransport } from '@betternotify/email';
+
+const transport = multiTransport({
+  strategy: 'failover',
+  transports: [{ transport: primaryTransport }, { transport: fallbackTransport }],
+});
+```
+
+Strategies: `failover`, `round-robin`, `random`, `race`, `parallel`, `mirrored`.
+
+---
+
+## Resources
+
+- [Docs](https://better-notify.com/docs)
+- [GitHub](https://github.com/better-notify/better-notify)
+- [Examples](https://github.com/better-notify/better-notify/tree/main/examples)

--- a/skills/better-notify/setup/SKILL.md
+++ b/skills/better-notify/setup/SKILL.md
@@ -261,9 +261,11 @@ TELEGRAM_BOT_TOKEN=...
 ### Step 6: Add middleware (optional)
 
 ```typescript
+import { createNotify } from '@betternotify/core';
 import { withRateLimit, withEventLogger } from '@betternotify/core/middlewares';
 import { inMemoryRateLimitStore } from '@betternotify/core/stores';
 import { consoleEventSink } from '@betternotify/core/sinks';
+import { ch } from './notify';
 
 const rpc = createNotify({ channels: { email: ch } })
   .use(
@@ -280,7 +282,10 @@ const rpc = createNotify({ channels: { email: ch } })
 ### Step 7: Testing with mock transports
 
 ```typescript
+import assert from 'node:assert/strict';
+import { createClient } from '@betternotify/core';
 import { mockTransport } from '@betternotify/email';
+import { catalog, ch } from './notify';
 
 const mock = mockTransport();
 const mail = createClient({

--- a/skills/better-notify/setup/SKILL.md
+++ b/skills/better-notify/setup/SKILL.md
@@ -58,7 +58,7 @@ Ask all applicable questions in a single call. Skip any you already answered fro
 
 Present a concise implementation plan as a markdown checklist. Example:
 
-```
+```markdown
 ## Notification Setup Plan
 
 - **Channels:** Email, Slack
@@ -90,6 +90,7 @@ Only proceed after the user confirms the plan.
 **Core (always):** `@betternotify/core`
 
 **Channels:**
+
 | Package | When |
 |---------|------|
 | `@betternotify/email` | Email channel |
@@ -100,6 +101,7 @@ Only proceed after the user confirms the plan.
 | `@betternotify/telegram` | Telegram bot |
 
 **Transports:**
+
 | Package | When |
 |---------|------|
 | `@betternotify/smtp` | SMTP email (Nodemailer) |
@@ -109,6 +111,7 @@ Only proceed after the user confirms the plan.
 | `@betternotify/twilio` | Twilio SMS |
 
 **Templates:**
+
 | Package | When |
 |---------|------|
 | `@betternotify/react-email` | React Email templates |
@@ -148,6 +151,7 @@ export const catalog = rpc.catalog({
 import { createNotify } from '@betternotify/core';
 import { emailChannel } from '@betternotify/email';
 import { slackChannel } from '@betternotify/slack';
+import { z } from 'zod';
 
 const rpc = createNotify({
   channels: {
@@ -285,7 +289,10 @@ const mail = createClient({
   transportsByChannel: { email: mock },
 });
 
-await mail.welcome.send({ to: 'test@example.com', input: { name: 'Test' } });
+await mail.welcome.send({
+  to: 'test@example.com',
+  input: { name: 'Test', verifyUrl: 'https://example.com/verify' },
+});
 
 assert(mock.sent.length === 1);
 assert(mock.sent[0].subject === 'Welcome, Test!');

--- a/skills/better-notify/setup/SKILL.md
+++ b/skills/better-notify/setup/SKILL.md
@@ -50,11 +50,7 @@ Ask all applicable questions in a single call. Skip any you already answered fro
    - "Which validation library do you use? Better Notify supports any Standard Schema provider."
    - Options: Zod | Valibot | ArkType
 
-6. **Queue** (always ask)
-   - "Do you need background queue processing?"
-   - Options: Yes (BullMQ + Redis) | No (send synchronously)
-
-7. **Features** (always ask, allow multiple)
+6. **Features** (always ask, allow multiple)
    - "Which additional features do you need?"
    - Options: Rate limiting | Idempotency (deduplication) | Suppression list | Tracing | Event logging | Dry-run mode | None
 
@@ -69,7 +65,6 @@ Present a concise implementation plan as a markdown checklist. Example:
 - **Email transport:** SMTP
 - **Templates:** React Email
 - **Validation:** Zod
-- **Queue:** No
 - **Features:** Rate limiting, event logging
 
 ### Steps
@@ -119,11 +114,6 @@ Only proceed after the user confirms the plan.
 | `@betternotify/react-email` | React Email templates |
 | `@betternotify/mjml` | MJML templates |
 | `@betternotify/handlebars` | Handlebars templates |
-
-**Queue:**
-| Package | When |
-|---------|------|
-| `@betternotify/bullmq` | Background processing |
 
 ### Step 2: Define the catalog (`lib/notify.ts`)
 


### PR DESCRIPTION
# Overview

Add agent skills so users can install Better Notify guidance into their coding agents via `npx skills add better-notify/better-notify`.

# What's changed and why?

- **`skills/better-notify/SKILL.md`** — Root skill with project overview, core concepts (catalog, client, channel, transport, middleware), and full package list.
- **`skills/better-notify/setup/SKILL.md`** — Interactive setup wizard. Scans the user's project, asks planning questions (channels, transports, templates, queue), then walks through implementation step by step with code examples.
- **`skills/better-notify/best-practices/SKILL.md`** — Quick reference covering channel slot tables, subpath imports, middleware/hooks, client API, error classes, multi-transport strategies, and 10 common gotchas.

# How to test

1. Run `npx skills add ./skills --list` from repo root to verify all three skills are discovered.
2. Install into a test project with `npx skills add better-notify/better-notify` and confirm the skills appear in `.claude/skills/` (or equivalent agent directory).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Better Notify documentation: core concepts, roles, ecosystem overview, a Quick Reference with API examples and per-channel requirements, middleware patterns, multi-transport strategies, error guidance, common gotchas, and an interactive Setup wizard (planning + implementation).
* **New Features**
  * Landing page CLI preview now supports two selectable command tabs (CLI and Skill) with per-tab display and copy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->