### PR TITLE
ci: add canary workflow for staging packages and docs

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,101 @@
+name: Generate canary packages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  DO_NOT_TRACK: '1'
+  TURBO_TELEMETRY_DISABLED: '1'
+  TURBO_TELEMETRY_MESSAGE_DISABLED: '1'
+
+concurrency:
+  group: canary
+  cancel-in-progress: false
+
+jobs:
+  detect-affected:
+    runs-on: ubuntu-latest
+    outputs:
+      projects: ${{ steps.projects.outputs.projects }}
+      has-projects: ${{ steps.projects.outputs.has-projects }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/prepare
+
+      - id: base
+        shell: bash
+        run: |
+          before="${{ github.event.before }}"
+          if [[ "$before" == "0000000000000000000000000000000000000000" ]]; then
+            echo "ref=HEAD~1" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=$before" >> "$GITHUB_OUTPUT"
+          fi
+
+      - id: projects
+        uses: ./.github/actions/affected-projects
+        with:
+          base: ${{ steps.base.outputs.ref }}
+          head: HEAD
+          task: build
+          summary-title: Canary Canary Packages
+
+  publish-canary:
+    name: Canary ${{ matrix.project.name }}
+    runs-on: ubuntu-latest
+    needs: [detect-affected]
+    if: needs.detect-affected.outputs.has-projects == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        project: ${{ fromJSON(needs.detect-affected.outputs.projects) }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/prepare
+        with:
+          registry-url: https://registry.npmjs.org
+
+      - run: pnpm exec turbo run build --filter="${{ matrix.project.name }}..."
+
+      - id: meta
+        shell: bash
+        run: |
+          current=$(jq -r .version "${{ matrix.project.path }}/package.json")
+          echo "version=${current}.canary.$(date -u +%Y%m%d%H%M%S).${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
+
+      - uses: ./.github/actions/publish-packages
+        with:
+          filter: './${{ matrix.project.path }}'
+          tag: canary
+          version: ${{ steps.meta.outputs.version }}
+          provenance: 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  deploy-canary-docs:
+    name: Deploy canary docs
+    runs-on: ubuntu-latest
+    environment: canary
+    concurrency:
+      group: deploy-canary-docs
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/prepare
+
+      - run: pnpm exec turbo run build --filter=@betternotify/web...
+
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/web
+          command: deploy --env canary

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -19,4 +19,9 @@
       "head_sampling_rate": 0.5,
     },
   },
+  "env": {
+    "canary": {
+      "routes": [{ "pattern": "canary.better-notify.com", "custom_domain": true }],
+    },
+  },
 }

--- a/skills/better-notify/setup/SKILL.md
+++ b/skills/better-notify/setup/SKILL.md
@@ -68,6 +68,7 @@ Present a concise implementation plan as a markdown checklist. Example:
 - **Features:** Rate limiting, event logging
 
 ### Steps
+
 1. Install `@betternotify/core`, `@betternotify/email`, `@betternotify/slack`
 2. Install `@betternotify/smtp`, `@betternotify/react-email`
 3. Create `lib/notify.ts` with channel config and catalog
@@ -91,32 +92,32 @@ Only proceed after the user confirms the plan.
 
 **Channels:**
 
-| Package | When |
-|---------|------|
-| `@betternotify/email` | Email channel |
-| `@betternotify/sms` | SMS channel |
-| `@betternotify/push` | Push notifications |
-| `@betternotify/discord` | Discord webhooks |
-| `@betternotify/slack` | Slack messages |
-| `@betternotify/telegram` | Telegram bot |
+| Package                  | When               |
+| ------------------------ | ------------------ |
+| `@betternotify/email`    | Email channel      |
+| `@betternotify/sms`      | SMS channel        |
+| `@betternotify/push`     | Push notifications |
+| `@betternotify/discord`  | Discord webhooks   |
+| `@betternotify/slack`    | Slack messages     |
+| `@betternotify/telegram` | Telegram bot       |
 
 **Transports:**
 
-| Package | When |
-|---------|------|
-| `@betternotify/smtp` | SMTP email (Nodemailer) |
-| `@betternotify/resend` | Resend email |
-| `@betternotify/mailchimp` | Mailchimp Transactional |
-| `@betternotify/cloudflare-email` | Cloudflare Email |
-| `@betternotify/twilio` | Twilio SMS |
+| Package                          | When                    |
+| -------------------------------- | ----------------------- |
+| `@betternotify/smtp`             | SMTP email (Nodemailer) |
+| `@betternotify/resend`           | Resend email            |
+| `@betternotify/mailchimp`        | Mailchimp Transactional |
+| `@betternotify/cloudflare-email` | Cloudflare Email        |
+| `@betternotify/twilio`           | Twilio SMS              |
 
 **Templates:**
 
-| Package | When |
-|---------|------|
+| Package                     | When                  |
+| --------------------------- | --------------------- |
 | `@betternotify/react-email` | React Email templates |
-| `@betternotify/mjml` | MJML templates |
-| `@betternotify/handlebars` | Handlebars templates |
+| `@betternotify/mjml`        | MJML templates        |
+| `@betternotify/handlebars`  | Handlebars templates  |
 
 ### Step 2: Define the catalog (`lib/notify.ts`)
 


### PR DESCRIPTION
# Overview

On every push to main, publish canary npm packages and deploy canary docs to `canary.better-notify.com`.

# What's changed and why?

- **`.github/workflows/canary.yml`** — new workflow triggered on push to main with 3 jobs: detect affected packages, publish canary versions to npm (`{version}.canary.{timestamp}.{sha}` with `canary` tag), deploy docs to Cloudflare Workers
- **`apps/web/wrangler.jsonc`** — added `canary` environment with custom domain `canary.better-notify.com`
- **`skills/better-notify/setup/SKILL.md`** — formatting fixes (table alignment)

# How to test

1. Merge to main and verify the workflow runs in the Actions tab
2. Check that affected packages are published with the `canary` tag on npm
3. Verify `canary.better-notify.com` serves the docs site

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated canary package publishing and deployment pipeline triggered on updates to main branch.
  * Added canary environment for testing new versions.

* **Documentation**
  * Enhanced Better Notify setup guide with expanded package matrix, installation steps, and multi-channel usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->