### PR TITLE
fix(web): fix canary wrangler deploy and block indexing

### DIFF
--- a/apps/web/src/routes/robots[.]txt.ts
+++ b/apps/web/src/routes/robots[.]txt.ts
@@ -5,21 +5,26 @@ import { appConfig } from '@/lib/shared';
 export const Route = createFileRoute('/robots.txt')({
   server: {
     handlers: {
-      GET() {
-        const body = [
-          'User-agent: *',
-          'Allow: /',
-          '',
-          'User-agent: Googlebot',
-          'Allow: /',
-          'Crawl-delay: 1',
-          '',
-          'User-agent: Bingbot',
-          'Allow: /',
-          'Crawl-delay: 5',
-          '',
-          `Sitemap: ${appConfig.baseUrl}/sitemap.xml`,
-        ].join('\n');
+      GET({ request }) {
+        const url = new URL(request.url);
+        const isCanary = url.hostname === 'canary.better-notify.com';
+
+        const body = isCanary
+          ? ['User-agent: *', 'Disallow: /'].join('\n')
+          : [
+              'User-agent: *',
+              'Allow: /',
+              '',
+              'User-agent: Googlebot',
+              'Allow: /',
+              'Crawl-delay: 1',
+              '',
+              'User-agent: Bingbot',
+              'Allow: /',
+              'Crawl-delay: 5',
+              '',
+              `Sitemap: ${appConfig.baseUrl}/sitemap.xml`,
+            ].join('\n');
 
         return new Response(body, {
           headers: { 'Content-Type': 'text/plain; charset=utf-8' },

--- a/apps/web/wrangler.canary.jsonc
+++ b/apps/web/wrangler.canary.jsonc
@@ -3,7 +3,10 @@
   "name": "better-notify-canary",
   "compatibility_date": "2025-09-02",
   "compatibility_flags": ["nodejs_compat"],
-  "main": "@tanstack/react-start/server-entry",
+  "main": "dist/server/index.js",
+  "no_bundle": true,
+  "assets": { "directory": "dist/client" },
+  "rules": [{ "type": "ESModule", "globs": ["**/*.js", "**/*.mjs"] }],
   "workers_dev": false,
   "routes": [{ "pattern": "canary.better-notify.com", "custom_domain": true }],
   "observability": {


### PR DESCRIPTION
# Overview

Fix the canary Cloudflare Workers deployment and prevent search engines from indexing the canary site.

# What's changed and why?

- **`apps/web/wrangler.canary.jsonc`** — Point `main` to the Vite-built output (`dist/server/index.js`) instead of the virtual `@tanstack/react-start/server-entry` module, which wrangler can't resolve when called with `--config`. Added `no_bundle`, `assets`, and `rules` to match the Vite plugin's deploy output.
- **`apps/web/src/routes/robots[.]txt.ts`** — Return `Disallow: /` for `canary.better-notify.com` so crawlers don't index the canary site. Production robots.txt is unchanged.

# How to test

1. Run `pnpm build` in `apps/web`
2. Run `pnpm exec wrangler deploy --dry-run --config wrangler.canary.jsonc` — should succeed
3. Verify `curl https://canary.better-notify.com/robots.txt` returns `Disallow: /`

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated robots.txt response behavior to accommodate different deployment environments
  * Updated build configuration for canary deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->