### PR TITLE
ci: scope release build to matrix package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Build
-        run: pnpm build
+        run: pnpm exec turbo run build --filter='./${{ matrix.path }}...'
 
       - uses: ./.github/actions/publish-packages
         with:


### PR DESCRIPTION
## Summary
- Release publish jobs now build only the target package and its workspace dependencies instead of the full monorepo
- Matches the existing canary workflow pattern (`--filter='./${{ matrix.path }}...'`)

## Test plan
- [ ] Trigger a release and verify each matrix job builds only its package + deps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the release build process to execute targeted per-package builds instead of rebuilding the entire codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->