### PR TITLE
fix: oRPC zod4 export, release latest tag, and create-better-notify README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,16 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Tag as latest
+        working-directory: ${{ matrix.path }}
+        run: |
+          set -euo pipefail
+          PKG_NAME=$(node -e "console.log(require('./package.json').name)")
+          PKG_VERSION=$(node -e "console.log(require('./package.json').version)")
+          npm dist-tag add "${PKG_NAME}@${PKG_VERSION}" latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   deploy-web:
     name: Deploy website
     runs-on: ubuntu-latest

--- a/packages/create-better-notify/README.md
+++ b/packages/create-better-notify/README.md
@@ -1,0 +1,103 @@
+# create-better-notify
+
+Scaffold a [Better Notify](https://github.com/better-notify/better-notify) project with your preferred framework and RPC layer. One command gives you a working server with typed notifications, OpenAPI playground, and email templates ready to go.
+
+## Usage
+
+```sh
+# npm
+npx create-better-notify
+
+# pnpm
+pnpm create better-notify
+
+# yarn
+yarn create better-notify
+
+# bun
+bun create better-notify
+```
+
+The CLI walks you through project name, framework, RPC layer, and package manager — then scaffolds, installs dependencies, and prints next steps.
+
+### Non-interactive
+
+Pass flags to skip the prompts:
+
+```sh
+npx create-better-notify my-app --framework hono --rpc orpc --pm pnpm
+```
+
+| Flag | Values | Default |
+| --- | --- | --- |
+| `--framework` | `hono` | prompted |
+| `--rpc` | `orpc` | prompted |
+| `--pm` | `npm`, `pnpm`, `yarn`, `bun` | auto-detected |
+
+## What you get
+
+The scaffolded project includes:
+
+- **HTTP server** — Hono with RPC and OpenAPI handlers
+- **OpenAPI playground** — browse and test your API at `/api/docs`
+- **Typed notifications** — a working `welcome` email using Better Notify's typed pipeline
+- **React Email template** — a responsive, Tailwind-styled verification email
+- **Multi-transport** — SMTP primary + Resend fallback, configured via `.env`
+- **Dev mode** — `npm run dev` starts a watching server with hot reload
+
+### Project structure
+
+```
+my-app/
+  src/
+    server.ts       # Hono app with RPC + OpenAPI routes
+    rpc.ts          # oRPC router with a sendWelcome procedure
+    notify.ts       # Better Notify catalog, client, and transport setup
+    emails/
+      welcome.tsx   # React Email template
+  .env.example      # SMTP and Resend credentials
+  package.json
+  tsconfig.json
+```
+
+### Environment variables
+
+Copy `.env.example` to `.env` and fill in your credentials:
+
+```sh
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=
+
+RESEND_API_KEY=
+
+FROM_NAME=My App
+FROM_EMAIL=hello@example.com
+PORT=3000
+```
+
+## Running the project
+
+```sh
+cd my-app
+npm run dev     # starts tsx --watch on src/server.ts
+```
+
+Open [http://localhost:3000/api/docs](http://localhost:3000/api/docs) to explore the API playground.
+
+## Templates
+
+| Template | Framework | RPC | Status |
+| --- | --- | --- | --- |
+| `hono-orpc` | Hono | oRPC | Available |
+
+More templates are on the roadmap.
+
+## Requirements
+
+- Node.js >= 22
+
+## License
+
+MIT

--- a/templates/hono-orpc/package.json
+++ b/templates/hono-orpc/package.json
@@ -13,6 +13,7 @@
     "@betternotify/resend": "0.0.0-inject",
     "@betternotify/smtp": "0.0.0-inject",
     "@hono/node-server": "2.0.1",
+    "@orpc/json-schema": "1.14.2",
     "@orpc/openapi": "1.14.2",
     "@orpc/server": "1.14.2",
     "@orpc/zod": "1.14.2",

--- a/templates/hono-orpc/src/server.ts
+++ b/templates/hono-orpc/src/server.ts
@@ -3,7 +3,8 @@ import { serve } from '@hono/node-server';
 import { RPCHandler } from '@orpc/server/fetch';
 import { OpenAPIHandler } from '@orpc/openapi/fetch';
 import { OpenAPIReferencePlugin } from '@orpc/openapi/plugins';
-import { ZodSmartCoercionPlugin, ZodToJsonSchemaConverter } from '@orpc/zod/zod4';
+import { SmartCoercionPlugin } from '@orpc/json-schema';
+import { ZodToJsonSchemaConverter } from '@orpc/zod/zod4';
 import { router } from './rpc';
 
 const app = new Hono();
@@ -26,7 +27,9 @@ app.use('/rpc/*', async (c, next) => {
 
 const openAPIHandler = new OpenAPIHandler(router, {
   plugins: [
-    new ZodSmartCoercionPlugin(),
+    new SmartCoercionPlugin({
+      schemaConverters: [new ZodToJsonSchemaConverter()],
+    }),
     new OpenAPIReferencePlugin({
       clientPath: '/docs',
       schemaConverters: [new ZodToJsonSchemaConverter()],


### PR DESCRIPTION
# Overview

Fix broken scaffolded projects, ensure npm packages are discoverable via `latest` tag, and add a README for the `create-better-notify` npm page.

# What's changed and why?

- **`templates/hono-orpc/src/server.ts`** — Replaced deprecated `ZodSmartCoercionPlugin` from `@orpc/zod/zod4` with `SmartCoercionPlugin` from `@orpc/json-schema`. The old export doesn't exist, causing scaffolded projects to crash on startup.
- **`templates/hono-orpc/package.json`** — Added `@orpc/json-schema` dependency required by the new import.
- **`.github/workflows/release.yml`** — Added a step to tag published packages as `latest` after the `alpha` publish, so `npm install @betternotify/core` resolves correctly.
- **`packages/create-better-notify/README.md`** — New README covering usage, flags, scaffolded project structure, and env setup. Displays on the npm page.

# How to test

1. Run `npx create-better-notify my-test --framework hono --rpc orpc --pm pnpm`
2. `cd my-test && pnpm run dev` — server should start without import errors
3. Open `http://localhost:3000/api/docs` — OpenAPI playground should load

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for scaffolding Better Notify projects, including setup commands, environment variables, and project structure.

* **Chores**
  * Enhanced release workflow with automatic npm dist-tag configuration for published packages.
  * Updated Hono oRPC template with improved schema handling and new dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->