### PR TITLE
fix(create-better-notify,web): add @latest to hero CLI command and format landing components

### DIFF
--- a/apps/web/src/components/landing/author.tsx
+++ b/apps/web/src/components/landing/author.tsx
@@ -1,4 +1,9 @@
-import { EnvelopeSimpleIcon, GithubLogoIcon, LinkedinLogoIcon, XLogoIcon } from '@phosphor-icons/react';
+import {
+  EnvelopeSimpleIcon,
+  GithubLogoIcon,
+  LinkedinLogoIcon,
+  XLogoIcon,
+} from '@phosphor-icons/react';
 
 import { appConfig } from '@/lib/shared';
 import { useInView } from '@/hooks/use-in-view';

--- a/apps/web/src/components/landing/cli-preview.tsx
+++ b/apps/web/src/components/landing/cli-preview.tsx
@@ -13,7 +13,7 @@ export function CliPreview() {
   const [copied, setCopied] = useState(false);
 
   const commands = {
-    cli: 'npx create-better-notify',
+    cli: 'npx create-better-notify@latest',
     skill: 'npx skills add better-notify/better-notify',
   } as const;
 

--- a/packages/create-better-notify/README.md
+++ b/packages/create-better-notify/README.md
@@ -28,11 +28,11 @@ Pass flags to skip the prompts:
 npx create-better-notify my-app --framework hono --rpc orpc --pm pnpm
 ```
 
-| Flag | Values | Default |
-| --- | --- | --- |
-| `--framework` | `hono` | prompted |
-| `--rpc` | `orpc` | prompted |
-| `--pm` | `npm`, `pnpm`, `yarn`, `bun` | auto-detected |
+| Flag          | Values                       | Default       |
+| ------------- | ---------------------------- | ------------- |
+| `--framework` | `hono`                       | prompted      |
+| `--rpc`       | `orpc`                       | prompted      |
+| `--pm`        | `npm`, `pnpm`, `yarn`, `bun` | auto-detected |
 
 ## What you get
 
@@ -88,9 +88,9 @@ Open [http://localhost:3000/api/docs](http://localhost:3000/api/docs) to explore
 
 ## Templates
 
-| Template | Framework | RPC | Status |
-| --- | --- | --- | --- |
-| `hono-orpc` | Hono | oRPC | Available |
+| Template    | Framework | RPC  | Status    |
+| ----------- | --------- | ---- | --------- |
+| `hono-orpc` | Hono      | oRPC | Available |
 
 More templates are on the roadmap.
 


### PR DESCRIPTION
# Overview

Minor fixes to the landing page hero CLI command and code formatting.

# What's changed and why?

- **`apps/web/src/components/landing/cli-preview.tsx`** — Added `@latest` to the `npx create-better-notify` command so users always get the latest version.
- **`apps/web/src/components/landing/author.tsx`** — Formatted multi-line import for readability.
- **`packages/create-better-notify/README.md`** — Formatted markdown tables for alignment.

# How to test

1. Run `pnpm dev` and open the landing page
2. Verify the CLI command in the hero shows `npx create-better-notify@latest`
3. Verify the copy button copies the correct command

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved README formatting with better styling for tables and code examples.

* **Chores**
  * Updated CLI installation command to specify latest version.

* **Style**
  * Reformatted component import statements for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->