### PR TITLE
fix(create-better-notify): update OpenAPIReferencePlugin path from clientPath to docsPath

### DIFF
--- a/templates/hono-orpc/src/server.ts
+++ b/templates/hono-orpc/src/server.ts
@@ -31,7 +31,7 @@ const openAPIHandler = new OpenAPIHandler(router, {
       schemaConverters: [new ZodToJsonSchemaConverter()],
     }),
     new OpenAPIReferencePlugin({
-      clientPath: '/docs',
+      docsPath: '/docs',
       schemaConverters: [new ZodToJsonSchemaConverter()],
       specGenerateOptions: {
         info: {


### PR DESCRIPTION
# Overview

Fix incorrect property name in the `OpenAPIReferencePlugin` configuration for the hono-orpc template.

# What's changed and why?

- **`templates/hono-orpc/src/server.ts`** — Changed `clientPath` to `docsPath` in `OpenAPIReferencePlugin` config to match the updated API.

# How to test

1. Run `pnpm build`
2. Scaffold a new project using the hono-orpc template
3. Verify the `/docs` route loads correctly

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API documentation configuration in the Hono oRPC template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->