### PR TITLE
feat(web): move blog to landing page with standalone routes

### DIFF
--- a/apps/web/content/blog/announcements/introducing-betternotify.mdx
+++ b/apps/web/content/blog/announcements/introducing-betternotify.mdx
@@ -1,0 +1,10 @@
+---
+title: Introducing Better-Notify
+description: End-to-end typed notifications for Node.js
+date: "2026-04-15"
+tags:
+  - release
+author: Lucas Reis
+---
+
+Documentation coming soon.

--- a/apps/web/content/docs/blog/introducing-betternotify.mdx
+++ b/apps/web/content/docs/blog/introducing-betternotify.mdx
@@ -1,7 +1,0 @@
----
-title: Introducing Better-Notify
-icon: Megaphone
-description: End-to-end typed notifications for Node.js
----
-
-Documentation coming soon.

--- a/apps/web/content/docs/blog/meta.json
+++ b/apps/web/content/docs/blog/meta.json
@@ -1,5 +1,0 @@
-{
-  "title": "Blog",
-  "icon": "Newspaper",
-  "pages": ["introducing-betternotify"]
-}

--- a/apps/web/content/docs/meta.json
+++ b/apps/web/content/docs/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Documentation",
-  "pages": ["index", "get-started", "concepts", "channels", "transports", "templates", "middlewares", "infrastructure", "advanced", "reference", "changelog", "blog"]
+  "pages": ["index", "get-started", "concepts", "channels", "transports", "templates", "middlewares", "infrastructure", "advanced", "reference", "changelog"]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,7 +33,8 @@
     "shadcn": "^4.6.0",
     "tailwind-merge": "^3.5.0",
     "tslib": "catalog:",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "catalog:",

--- a/apps/web/source.config.ts
+++ b/apps/web/source.config.ts
@@ -1,5 +1,6 @@
-import { defineConfig, defineDocs } from 'fumadocs-mdx/config';
+import { defineConfig, defineDocs, defineCollections, frontmatterSchema } from 'fumadocs-mdx/config';
 import { remarkNpm } from 'fumadocs-core/mdx-plugins';
+import { z } from 'zod';
 
 export const docs = defineDocs({
   dir: 'content/docs',
@@ -8,6 +9,17 @@ export const docs = defineDocs({
       includeProcessedMarkdown: true,
     },
   },
+});
+
+export const blogPosts = defineCollections({
+  type: 'doc',
+  dir: 'content/blog',
+  schema: frontmatterSchema.extend({
+    date: z.string().date().or(z.date()),
+    tags: z.array(z.string()).optional().default([]),
+    author: z.string().optional().default('Lucas Reis'),
+    image: z.string().optional(),
+  }),
 });
 
 export default defineConfig({

--- a/apps/web/source.config.ts
+++ b/apps/web/source.config.ts
@@ -15,7 +15,7 @@ export const blogPosts = defineCollections({
   type: 'doc',
   dir: 'content/blog',
   schema: frontmatterSchema.extend({
-    date: z.string().date().or(z.date()),
+    date: z.iso.date().or(z.date()),
     tags: z.array(z.string()).optional().default([]),
     author: z.string().optional().default('Lucas Reis'),
     image: z.string().optional(),

--- a/apps/web/src/components/landing/author.tsx
+++ b/apps/web/src/components/landing/author.tsx
@@ -1,4 +1,7 @@
+import { Link } from '@tanstack/react-router';
 import {
+  ArrowRightIcon,
+  CalendarIcon,
   EnvelopeSimpleIcon,
   GithubLogoIcon,
   LinkedinLogoIcon,
@@ -7,6 +10,15 @@ import {
 
 import { appConfig } from '@/lib/shared';
 import { useInView } from '@/hooks/use-in-view';
+
+type BlogPreviewPost = {
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  category: string | null;
+  tags: string[];
+};
 
 const author = {
   name: 'Lucas Reis',
@@ -36,7 +48,7 @@ const projectSocials = [
   },
 ] as const;
 
-export function Author() {
+export function BlogAndAuthor({ posts }: { posts: BlogPreviewPost[] }) {
   const [ref, inView, hydrated] = useInView();
 
   return (
@@ -47,44 +59,129 @@ export function Author() {
       >
         <div className="border-border rounded-2xl border bg-linear-to-b from-white to-bn-slate-100 dark:from-bn-slate-950 dark:to-bn-slate-900">
           <div className="flex flex-col md:flex-row">
-            <div className="flex flex-1 items-start gap-5 p-8 md:gap-6 md:p-12">
-              <img
-                src={author.photo}
-                alt={`Photo of ${author.name}`}
-                className="size-20 shrink-0 rounded-xl object-cover md:size-24"
-              />
-              <div className="min-w-0">
-                <p className="bn-eyebrow mb-1.5">Crafted by</p>
-                <h2
-                  id="author-name"
-                  className="text-foreground mb-1.5 text-lg font-bold tracking-tight"
+            <div className="flex flex-1 flex-col gap-3 p-8 md:p-12">
+              <div className="mb-1 flex items-center justify-between">
+                <p className="bn-eyebrow">Latest from the blog</p>
+                <Link
+                  to="/blog"
+                  className="text-primary flex items-center gap-1 text-[13px] font-medium no-underline transition-opacity hover:opacity-80"
                 >
-                  {author.name}
-                </h2>
-                <p className="text-muted-foreground text-sm leading-relaxed">{author.bio}</p>
-                <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-                  Shoutouts, partnerships, or coffee chats:{' '}
-                  <a
-                    href={`mailto:${appConfig.contactEmail}`}
-                    className="text-foreground hover:text-bn-navy-500 dark:hover:text-bn-navy-400 font-medium transition-colors"
+                  View all
+                  <ArrowRightIcon size={12} weight="bold" />
+                </Link>
+              </div>
+
+              {posts.map((post) => (
+                <Link
+                  key={post.slug}
+                  to="/blog/$slug"
+                  params={{ slug: post.slug }}
+                  className="border-border group rounded-lg border bg-white/60 p-4 no-underline transition-colors hover:bg-white/90 dark:bg-bn-slate-900/40 dark:hover:bg-bn-slate-900/70"
+                >
+                  <div className="mb-2 flex items-center justify-between">
+                    {post.category && (
+                      <span className="bg-primary text-primary-foreground rounded-md px-2 py-0.5 text-[10px] font-medium capitalize">
+                        {post.category}
+                      </span>
+                    )}
+                    <span className="text-muted-foreground flex items-center gap-1 text-[11px]">
+                      <CalendarIcon size={11} />
+                      {new Date(post.date).toLocaleDateString('en-US', {
+                        year: 'numeric',
+                        month: 'short',
+                        day: 'numeric',
+                      })}
+                    </span>
+                  </div>
+                  <h3 className="text-foreground group-hover:text-primary mb-1 text-sm font-semibold tracking-bn-snug transition-colors">
+                    {post.title}
+                  </h3>
+                  <p className="text-muted-foreground text-[13px] leading-relaxed line-clamp-2">
+                    {post.description}
+                  </p>
+                  {post.tags.length > 0 && (
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {post.tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className="border-border text-muted-foreground rounded border px-1.5 py-0.5 text-[9px]"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </Link>
+              ))}
+            </div>
+
+            <div className="border-border border-t md:border-t-0 md:border-l" />
+
+            <div className="flex flex-col justify-center px-8 py-6 md:w-[340px] md:px-12 md:py-0">
+              <div className="flex items-start gap-5 md:gap-6">
+                <img
+                  src={author.photo}
+                  alt={`Photo of ${author.name}`}
+                  className="size-20 shrink-0 rounded-xl object-cover md:size-24"
+                />
+                <div className="min-w-0">
+                  <p className="bn-eyebrow mb-1.5">Crafted by</p>
+                  <h2
+                    id="author-name"
+                    className="text-foreground mb-1.5 text-lg font-bold tracking-tight"
                   >
-                    <EnvelopeSimpleIcon
-                      size={14}
-                      aria-hidden="true"
-                      className="mr-1 inline-block align-[-2px]"
-                    />
-                    {appConfig.contactEmail}
-                  </a>
+                    {author.name}
+                  </h2>
+                  <p className="text-muted-foreground text-sm leading-relaxed">{author.bio}</p>
+                  <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+                    Shoutouts, partnerships, or coffee chats:{' '}
+                    <a
+                      href={`mailto:${appConfig.contactEmail}`}
+                      className="text-foreground hover:text-bn-navy-500 dark:hover:text-bn-navy-400 font-medium transition-colors"
+                    >
+                      <EnvelopeSimpleIcon
+                        size={14}
+                        aria-hidden="true"
+                        className="mr-1 inline-block align-[-2px]"
+                      />
+                      {appConfig.contactEmail}
+                    </a>
+                  </p>
+                  <nav aria-label={`${author.name}'s social links`}>
+                    <ul className="mt-4 flex list-none flex-wrap items-center gap-1.5 p-0">
+                      {author.socials.map((s) => (
+                        <li key={s.label}>
+                          <a
+                            href={s.href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            aria-label={`${author.name} on ${s.label}`}
+                            className="border-border text-muted-foreground hover:text-foreground hover:bg-bn-slate-100 dark:hover:bg-bn-slate-800 inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors"
+                          >
+                            <s.icon size={14} aria-hidden="true" />
+                            {s.label}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </nav>
+                </div>
+              </div>
+
+              <div className="border-border mt-6 border-t pt-5 md:mt-8">
+                <p className="text-foreground mb-1.5 text-sm font-semibold">{appConfig.name}</p>
+                <p className="text-muted-foreground mb-3 max-w-[240px] text-[13px] leading-relaxed">
+                  Type-safe notification infrastructure for Node. Open source, MIT licensed.
                 </p>
-                <nav aria-label={`${author.name}'s social links`}>
-                  <ul className="mt-4 flex list-none flex-wrap items-center gap-1.5 p-0">
-                    {author.socials.map((s) => (
+                <nav aria-label={`${appConfig.name} social links`}>
+                  <ul className="flex list-none items-center gap-1.5 p-0">
+                    {projectSocials.map((s) => (
                       <li key={s.label}>
                         <a
                           href={s.href}
                           target="_blank"
                           rel="noopener noreferrer"
-                          aria-label={`${author.name} on ${s.label}`}
+                          aria-label={`${appConfig.name} on ${s.label}`}
                           className="border-border text-muted-foreground hover:text-foreground hover:bg-bn-slate-100 dark:hover:bg-bn-slate-800 inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors"
                         >
                           <s.icon size={14} aria-hidden="true" />
@@ -95,31 +192,6 @@ export function Author() {
                   </ul>
                 </nav>
               </div>
-            </div>
-
-            <div className="border-border flex flex-col justify-center border-t px-8 py-6 md:border-t-0 md:border-l md:px-12 md:py-0">
-              <p className="text-foreground mb-1.5 text-sm font-semibold">{appConfig.name}</p>
-              <p className="text-muted-foreground mb-3 max-w-[240px] text-[13px] leading-relaxed">
-                Type-safe notification infrastructure for Node. Open source, MIT licensed.
-              </p>
-              <nav aria-label={`${appConfig.name} social links`}>
-                <ul className="flex list-none items-center gap-1.5 p-0">
-                  {projectSocials.map((s) => (
-                    <li key={s.label}>
-                      <a
-                        href={s.href}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label={`${appConfig.name} on ${s.label}`}
-                        className="border-border text-muted-foreground hover:text-foreground hover:bg-bn-slate-100 dark:hover:bg-bn-slate-800 inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors"
-                      >
-                        <s.icon size={14} aria-hidden="true" />
-                        {s.label}
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </nav>
             </div>
           </div>
         </div>

--- a/apps/web/src/components/landing/author.tsx
+++ b/apps/web/src/components/landing/author.tsx
@@ -58,8 +58,8 @@ export function BlogAndAuthor({ posts }: { posts: BlogPreviewPost[] }) {
         className={`${hydrated ? 'reveal' : ''} mx-auto max-w-[1200px] px-5 md:px-8${inView ? ' in-view' : ''}`}
       >
         <div className="border-border rounded-2xl border bg-linear-to-b from-white to-bn-slate-100 dark:from-bn-slate-950 dark:to-bn-slate-900">
-          <div className="flex flex-col md:flex-row">
-            <div className="flex flex-1 flex-col gap-3 p-8 md:p-12">
+          <div className="flex flex-col md:grid md:grid-cols-[1fr_auto_340px]">
+            <div className="flex flex-col gap-3 p-8 md:p-12">
               <div className="mb-1 flex items-center justify-between">
                 <p className="bn-eyebrow">Latest from the blog</p>
                 <Link
@@ -117,64 +117,62 @@ export function BlogAndAuthor({ posts }: { posts: BlogPreviewPost[] }) {
 
             <div className="border-border border-t md:border-t-0 md:border-l" />
 
-            <div className="flex flex-col justify-center px-8 py-6 md:w-[340px] md:px-12 md:py-0">
-              <div className="flex items-start gap-5 md:gap-6">
+            <div className="flex flex-col justify-center px-8 py-6 md:px-12 md:py-8">
+              <div className="flex flex-col items-center text-center">
                 <img
                   src={author.photo}
                   alt={`Photo of ${author.name}`}
-                  className="size-20 shrink-0 rounded-xl object-cover md:size-24"
+                  className="mb-4 size-20 rounded-xl object-cover"
                 />
-                <div className="min-w-0">
-                  <p className="bn-eyebrow mb-1.5">Crafted by</p>
-                  <h2
-                    id="author-name"
-                    className="text-foreground mb-1.5 text-lg font-bold tracking-tight"
+                <p className="bn-eyebrow mb-1.5">Crafted by</p>
+                <h2
+                  id="author-name"
+                  className="text-foreground mb-1.5 text-lg font-bold tracking-tight"
+                >
+                  {author.name}
+                </h2>
+                <p className="text-muted-foreground text-sm leading-relaxed">{author.bio}</p>
+                <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+                  Shoutouts, partnerships, or coffee chats:{' '}
+                  <a
+                    href={`mailto:${appConfig.contactEmail}`}
+                    className="text-foreground hover:text-bn-navy-500 dark:hover:text-bn-navy-400 font-medium transition-colors"
                   >
-                    {author.name}
-                  </h2>
-                  <p className="text-muted-foreground text-sm leading-relaxed">{author.bio}</p>
-                  <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-                    Shoutouts, partnerships, or coffee chats:{' '}
-                    <a
-                      href={`mailto:${appConfig.contactEmail}`}
-                      className="text-foreground hover:text-bn-navy-500 dark:hover:text-bn-navy-400 font-medium transition-colors"
-                    >
-                      <EnvelopeSimpleIcon
-                        size={14}
-                        aria-hidden="true"
-                        className="mr-1 inline-block align-[-2px]"
-                      />
-                      {appConfig.contactEmail}
-                    </a>
-                  </p>
-                  <nav aria-label={`${author.name}'s social links`}>
-                    <ul className="mt-4 flex list-none flex-wrap items-center gap-1.5 p-0">
-                      {author.socials.map((s) => (
-                        <li key={s.label}>
-                          <a
-                            href={s.href}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            aria-label={`${author.name} on ${s.label}`}
-                            className="border-border text-muted-foreground hover:text-foreground hover:bg-bn-slate-100 dark:hover:bg-bn-slate-800 inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors"
-                          >
-                            <s.icon size={14} aria-hidden="true" />
-                            {s.label}
-                          </a>
-                        </li>
-                      ))}
-                    </ul>
-                  </nav>
-                </div>
+                    <EnvelopeSimpleIcon
+                      size={14}
+                      aria-hidden="true"
+                      className="mr-1 inline-block align-[-2px]"
+                    />
+                    {appConfig.contactEmail}
+                  </a>
+                </p>
+                <nav aria-label={`${author.name}'s social links`}>
+                  <ul className="mt-4 flex list-none flex-wrap items-center justify-center gap-1.5 p-0">
+                    {author.socials.map((s) => (
+                      <li key={s.label}>
+                        <a
+                          href={s.href}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          aria-label={`${author.name} on ${s.label}`}
+                          className="border-border text-muted-foreground hover:text-foreground hover:bg-bn-slate-100 dark:hover:bg-bn-slate-800 inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors"
+                        >
+                          <s.icon size={14} aria-hidden="true" />
+                          {s.label}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </nav>
               </div>
 
-              <div className="border-border mt-6 border-t pt-5 md:mt-8">
+              <div className="border-border mt-6 border-t pt-5 text-center md:mt-8">
                 <p className="text-foreground mb-1.5 text-sm font-semibold">{appConfig.name}</p>
-                <p className="text-muted-foreground mb-3 max-w-[240px] text-[13px] leading-relaxed">
+                <p className="text-muted-foreground mb-3 text-[13px] leading-relaxed">
                   Type-safe notification infrastructure for Node. Open source, MIT licensed.
                 </p>
                 <nav aria-label={`${appConfig.name} social links`}>
-                  <ul className="flex list-none items-center gap-1.5 p-0">
+                  <ul className="flex list-none items-center justify-center gap-1.5 p-0">
                     {projectSocials.map((s) => (
                       <li key={s.label}>
                         <a

--- a/apps/web/src/components/landing/author.tsx
+++ b/apps/web/src/components/landing/author.tsx
@@ -90,6 +90,7 @@ export function BlogAndAuthor({ posts }: { posts: BlogPreviewPost[] }) {
                         year: 'numeric',
                         month: 'short',
                         day: 'numeric',
+                        timeZone: 'UTC',
                       })}
                     </span>
                   </div>

--- a/apps/web/src/components/landing/footer.tsx
+++ b/apps/web/src/components/landing/footer.tsx
@@ -16,6 +16,7 @@ const navColumns = [
     title: 'Developers',
     links: [
       { label: 'Documentation', href: '/docs' },
+      { label: 'Blog', href: '/blog' },
       { label: 'Quick start', href: '/docs' },
       {
         label: 'GitHub',

--- a/apps/web/src/components/landing/header.tsx
+++ b/apps/web/src/components/landing/header.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@tanstack/react-router';
+import { Link, useRouterState } from '@tanstack/react-router';
 import { useSearchContext } from 'fumadocs-ui/contexts/search';
 import {
   MagnifyingGlassIcon,
@@ -27,6 +27,9 @@ export function LandingHeader() {
   const { setTheme, resolvedTheme } = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
   const isDark = resolvedTheme === 'dark';
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const isHome = pathname === '/';
+  const visibleLinks = isHome ? navLinks : navLinks.filter((l) => l.href.startsWith('/'));
 
   return (
     <header className="sticky top-0 z-30 border-b border-bn-slate-200 bg-[color-mix(in_oklch,var(--background)_88%,transparent)] backdrop-blur-md backdrop-saturate-[1.4] dark:border-bn-slate-800">
@@ -44,25 +47,22 @@ export function LandingHeader() {
         </Link>
 
         <nav className="hidden items-center gap-5 md:flex">
-          {navLinks.map((link) =>
-            link.href.startsWith('/') ? (
+          {visibleLinks.map((link) => {
+            const isActive = link.href.startsWith('/') && pathname.startsWith(link.href);
+            return (
               <a
                 key={link.label}
                 href={link.href}
-                className="text-muted-foreground hover:text-foreground text-[13px] font-medium no-underline transition-colors"
+                className={`text-[13px] font-medium no-underline transition-colors ${
+                  isActive
+                    ? 'text-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
               >
                 {link.label}
               </a>
-            ) : (
-              <a
-                key={link.label}
-                href={link.href}
-                className="text-muted-foreground hover:text-foreground text-[13px] font-medium no-underline transition-colors"
-              >
-                {link.label}
-              </a>
-            ),
-          )}
+            );
+          })}
         </nav>
 
         <div className="ml-auto flex items-center gap-2">
@@ -132,16 +132,23 @@ export function LandingHeader() {
 
       {mobileOpen && (
         <nav className="border-border flex flex-col gap-1 border-t px-5 py-3 md:hidden">
-          {navLinks.map((link) => (
-            <a
-              key={link.label}
-              href={link.href}
-              className="text-muted-foreground hover:text-foreground rounded-md px-3 py-2 text-sm font-medium no-underline transition-colors"
-              onClick={() => setMobileOpen(false)}
-            >
-              {link.label}
-            </a>
-          ))}
+          {visibleLinks.map((link) => {
+            const isActive = link.href.startsWith('/') && pathname.startsWith(link.href);
+            return (
+              <a
+                key={link.label}
+                href={link.href}
+                className={`rounded-md px-3 py-2 text-sm font-medium no-underline transition-colors ${
+                  isActive
+                    ? 'text-foreground bg-bn-slate-100 dark:bg-bn-slate-800'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+                onClick={() => setMobileOpen(false)}
+              >
+                {link.label}
+              </a>
+            );
+          })}
         </nav>
       )}
     </header>

--- a/apps/web/src/components/landing/header.tsx
+++ b/apps/web/src/components/landing/header.tsx
@@ -16,6 +16,7 @@ import { appConfig } from '@/lib/shared';
 
 const navLinks = [
   { label: 'Docs', href: '/docs' },
+  { label: 'Blog', href: '/blog' },
   { label: 'Channels', href: '#channels' },
   { label: 'Pipeline', href: '#pipeline' },
   { label: 'Compare', href: '#compare' },

--- a/apps/web/src/components/landing/hero.tsx
+++ b/apps/web/src/components/landing/hero.tsx
@@ -86,7 +86,7 @@ export function Hero() {
             </div>
 
             <div
-              className="hero-anim mb-8 max-w-[400px] lg:mx-0"
+              className="hero-anim mb-8 max-w-[480px] lg:mx-0"
               style={{ animationDelay: '220ms' }}
             >
               <CliPreview />

--- a/apps/web/src/components/landing/install.tsx
+++ b/apps/web/src/components/landing/install.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Check, Copy } from '@phosphor-icons/react';
 
 import { useInView } from '@/hooks/use-in-view';
+import { CliPreview } from '@/components/landing/cli-preview';
 import { K, F, S } from '@/components/landing/syntax';
 
 const commands: Record<string, string> = {
@@ -44,7 +45,17 @@ export function Install() {
         </div>
 
         <div className="mx-auto grid max-w-[640px] gap-4">
-          <InstallStep n={1} title="Install">
+          <InstallStep n={1} title="Bootstrap your project">
+            <CliPreview />
+          </InstallStep>
+
+          <div className="flex items-center gap-3">
+            <div className="border-border h-px flex-1 border-t" />
+            <span className="text-muted-foreground text-xs font-medium">or install manually</span>
+            <div className="border-border h-px flex-1 border-t" />
+          </div>
+
+          <InstallStep n={2} title="Install">
             <div className="mb-2.5 flex gap-1">
               {Object.keys(commands).map((x) => (
                 <button
@@ -72,7 +83,7 @@ export function Install() {
             </div>
           </InstallStep>
 
-          <InstallStep n={2} title="Define your catalog">
+          <InstallStep n={3} title="Define your catalog">
             <pre className="m-0 overflow-x-auto rounded-md border border-bn-slate-200 bg-bn-slate-50 px-3.5 py-2.5 font-mono text-xs leading-relaxed text-bn-slate-700 dark:border-bn-slate-800 dark:bg-bn-slate-950 dark:text-bn-slate-300">
               <K>const</K> welcome = rpc.<F>email</F>(){'\n'}
               {'  '}.<F>input</F>(WelcomeSchema){'\n'}
@@ -81,7 +92,7 @@ export function Install() {
             </pre>
           </InstallStep>
 
-          <InstallStep n={3} title="Send anywhere">
+          <InstallStep n={4} title="Send anywhere">
             <pre className="m-0 overflow-x-auto rounded-md border border-bn-slate-200 bg-bn-slate-50 px-3.5 py-2.5 font-mono text-xs leading-relaxed text-bn-slate-700 dark:border-bn-slate-800 dark:bg-bn-slate-950 dark:text-bn-slate-300">
               <K>await</K> mail.welcome.<F>send</F>({'{'}
               {'\n'}

--- a/apps/web/src/lib/blog-source.ts
+++ b/apps/web/src/lib/blog-source.ts
@@ -18,7 +18,7 @@ export type BlogPost = {
 };
 
 export function mapPageToPost(page: (typeof blogSource)['$inferPage']): BlogPost {
-  const data = page.data as Record<string, unknown>;
+  const data = page.data as unknown as Record<string, unknown>;
   return {
     slug: page.slugs.at(-1) ?? '',
     title: page.data.title,

--- a/apps/web/src/lib/blog-source.ts
+++ b/apps/web/src/lib/blog-source.ts
@@ -1,7 +1,8 @@
 import { blogPosts } from 'collections/server';
+import { toFumadocsSource } from 'fumadocs-mdx/runtime/server';
 import { loader } from 'fumadocs-core/source';
 
 export const blogSource = loader({
   baseUrl: '/blog',
-  source: blogPosts.toFumadocsSource(),
+  source: toFumadocsSource(blogPosts, []),
 });

--- a/apps/web/src/lib/blog-source.ts
+++ b/apps/web/src/lib/blog-source.ts
@@ -17,7 +17,7 @@ export type BlogPost = {
   category: string | null;
 };
 
-export function mapPageToPost(page: (typeof blogSource)['$inferPage']): BlogPost {
+export const mapPageToPost = (page: (typeof blogSource)['$inferPage']): BlogPost => {
   const data = page.data as unknown as Record<string, unknown>;
   return {
     slug: page.slugs.at(-1) ?? '',
@@ -28,17 +28,17 @@ export function mapPageToPost(page: (typeof blogSource)['$inferPage']): BlogPost
     tags: (data.tags as string[]) ?? [],
     category: page.slugs.length > 1 ? (page.slugs[0] ?? null) : null,
   };
-}
+};
 
-export function getLatestBlogPosts(limit = 3): BlogPost[] {
+export const getLatestBlogPosts = (limit = 3): BlogPost[] => {
   return blogSource
     .getPages()
     .map(mapPageToPost)
     .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
     .slice(0, limit);
-}
+};
 
-export function getAllBlogPosts() {
+export const getAllBlogPosts = () => {
   const posts = blogSource
     .getPages()
     .map(mapPageToPost)
@@ -48,4 +48,4 @@ export function getAllBlogPosts() {
   const allTags = [...new Set(posts.flatMap((p) => p.tags))].sort();
 
   return { posts, categories, allTags };
-}
+};

--- a/apps/web/src/lib/blog-source.ts
+++ b/apps/web/src/lib/blog-source.ts
@@ -1,0 +1,7 @@
+import { blogPosts } from 'collections/server';
+import { loader } from 'fumadocs-core/source';
+
+export const blogSource = loader({
+  baseUrl: '/blog',
+  source: blogPosts.toFumadocsSource(),
+});

--- a/apps/web/src/lib/blog-source.ts
+++ b/apps/web/src/lib/blog-source.ts
@@ -6,3 +6,46 @@ export const blogSource = loader({
   baseUrl: '/blog',
   source: toFumadocsSource(blogPosts, []),
 });
+
+export type BlogPost = {
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  author: string;
+  tags: string[];
+  category: string | null;
+};
+
+export function mapPageToPost(page: (typeof blogSource)['$inferPage']): BlogPost {
+  const data = page.data as Record<string, unknown>;
+  return {
+    slug: page.slugs.at(-1) ?? '',
+    title: page.data.title,
+    description: (page.data.description as string) ?? '',
+    date: typeof data.date === 'string' ? data.date : data.date instanceof Date ? data.date.toISOString().split('T')[0] : '',
+    author: (data.author as string) ?? 'Lucas Reis',
+    tags: (data.tags as string[]) ?? [],
+    category: page.slugs.length > 1 ? (page.slugs[0] ?? null) : null,
+  };
+}
+
+export function getLatestBlogPosts(limit = 3): BlogPost[] {
+  return blogSource
+    .getPages()
+    .map(mapPageToPost)
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+    .slice(0, limit);
+}
+
+export function getAllBlogPosts() {
+  const posts = blogSource
+    .getPages()
+    .map(mapPageToPost)
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+  const categories = [...new Set(posts.map((p) => p.category).filter(Boolean))] as string[];
+  const allTags = [...new Set(posts.flatMap((p) => p.tags))].sort();
+
+  return { posts, categories, allTags };
+}

--- a/apps/web/src/lib/blog-source.ts
+++ b/apps/web/src/lib/blog-source.ts
@@ -17,6 +17,21 @@ export type BlogPost = {
   category: string | null;
 };
 
+const toEpoch = (date: string): number => {
+  const epoch = Date.parse(date);
+  return Number.isNaN(epoch) ? Number.NEGATIVE_INFINITY : epoch;
+};
+
+const assertUniqueSlugs = (posts: BlogPost[]): void => {
+  const seen = new Set<string>();
+  for (const post of posts) {
+    if (seen.has(post.slug)) {
+      throw new Error(`Duplicate blog slug detected: "${post.slug}"`);
+    }
+    seen.add(post.slug);
+  }
+};
+
 export const mapPageToPost = (page: (typeof blogSource)['$inferPage']): BlogPost => {
   const data = page.data as unknown as Record<string, unknown>;
   return {
@@ -31,18 +46,20 @@ export const mapPageToPost = (page: (typeof blogSource)['$inferPage']): BlogPost
 };
 
 export const getLatestBlogPosts = (limit = 3): BlogPost[] => {
-  return blogSource
+  const posts = blogSource
     .getPages()
     .map(mapPageToPost)
-    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
-    .slice(0, limit);
+    .sort((a, b) => toEpoch(b.date) - toEpoch(a.date));
+  assertUniqueSlugs(posts);
+  return posts.slice(0, limit);
 };
 
 export const getAllBlogPosts = () => {
   const posts = blogSource
     .getPages()
     .map(mapPageToPost)
-    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+    .sort((a, b) => toEpoch(b.date) - toEpoch(a.date));
+  assertUniqueSlugs(posts);
 
   const categories = [...new Set(posts.map((p) => p.category).filter(Boolean))] as string[];
   const allTags = [...new Set(posts.flatMap((p) => p.tags))].sort();

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as RobotsDottxtRouteImport } from './routes/robots[.]txt'
 import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
 import { Route as LlmsFullDottxtRouteImport } from './routes/llms-full[.]txt'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as BlogIndexRouteImport } from './routes/blog/index'
 import { Route as OgSplatRouteImport } from './routes/og.$'
 import { Route as DocsSplatRouteImport } from './routes/docs/$'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
@@ -43,6 +44,11 @@ const LlmsFullDottxtRoute = LlmsFullDottxtRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BlogIndexRoute = BlogIndexRouteImport.update({
+  id: '/blog/',
+  path: '/blog/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const OgSplatRoute = OgSplatRouteImport.update({
@@ -81,6 +87,7 @@ export interface FileRoutesByFullPath {
   '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
   '/og/$': typeof OgSplatRoute
+  '/blog/': typeof BlogIndexRoute
   '/llms.mdx/docs/$': typeof LlmsDotmdxDocsSplatRoute
 }
 export interface FileRoutesByTo {
@@ -93,6 +100,7 @@ export interface FileRoutesByTo {
   '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
   '/og/$': typeof OgSplatRoute
+  '/blog': typeof BlogIndexRoute
   '/llms.mdx/docs/$': typeof LlmsDotmdxDocsSplatRoute
 }
 export interface FileRoutesById {
@@ -106,6 +114,7 @@ export interface FileRoutesById {
   '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
   '/og/$': typeof OgSplatRoute
+  '/blog/': typeof BlogIndexRoute
   '/llms.mdx/docs/$': typeof LlmsDotmdxDocsSplatRoute
 }
 export interface FileRouteTypes {
@@ -120,6 +129,7 @@ export interface FileRouteTypes {
     | '/blog/$slug'
     | '/docs/$'
     | '/og/$'
+    | '/blog/'
     | '/llms.mdx/docs/$'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -132,6 +142,7 @@ export interface FileRouteTypes {
     | '/blog/$slug'
     | '/docs/$'
     | '/og/$'
+    | '/blog'
     | '/llms.mdx/docs/$'
   id:
     | '__root__'
@@ -144,6 +155,7 @@ export interface FileRouteTypes {
     | '/blog/$slug'
     | '/docs/$'
     | '/og/$'
+    | '/blog/'
     | '/llms.mdx/docs/$'
   fileRoutesById: FileRoutesById
 }
@@ -157,6 +169,7 @@ export interface RootRouteChildren {
   BlogSlugRoute: typeof BlogSlugRoute
   DocsSplatRoute: typeof DocsSplatRoute
   OgSplatRoute: typeof OgSplatRoute
+  BlogIndexRoute: typeof BlogIndexRoute
   LlmsDotmdxDocsSplatRoute: typeof LlmsDotmdxDocsSplatRoute
 }
 
@@ -195,6 +208,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/blog/': {
+      id: '/blog/'
+      path: '/blog'
+      fullPath: '/blog/'
+      preLoaderRoute: typeof BlogIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/og/$': {
@@ -245,6 +265,7 @@ const rootRouteChildren: RootRouteChildren = {
   BlogSlugRoute: BlogSlugRoute,
   DocsSplatRoute: DocsSplatRoute,
   OgSplatRoute: OgSplatRoute,
+  BlogIndexRoute: BlogIndexRoute,
   LlmsDotmdxDocsSplatRoute: LlmsDotmdxDocsSplatRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as LlmsFullDottxtRouteImport } from './routes/llms-full[.]txt'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as OgSplatRouteImport } from './routes/og.$'
 import { Route as DocsSplatRouteImport } from './routes/docs/$'
+import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 import { Route as ApiSearchRouteImport } from './routes/api/search'
 import { Route as LlmsDotmdxDocsSplatRouteImport } from './routes/llms[.]mdx.docs.$'
 
@@ -54,6 +55,11 @@ const DocsSplatRoute = DocsSplatRouteImport.update({
   path: '/docs/$',
   getParentRoute: () => rootRouteImport,
 } as any)
+const BlogSlugRoute = BlogSlugRouteImport.update({
+  id: '/blog/$slug',
+  path: '/blog/$slug',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiSearchRoute = ApiSearchRouteImport.update({
   id: '/api/search',
   path: '/api/search',
@@ -72,6 +78,7 @@ export interface FileRoutesByFullPath {
   '/robots.txt': typeof RobotsDottxtRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
   '/api/search': typeof ApiSearchRoute
+  '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
   '/og/$': typeof OgSplatRoute
   '/llms.mdx/docs/$': typeof LlmsDotmdxDocsSplatRoute
@@ -83,6 +90,7 @@ export interface FileRoutesByTo {
   '/robots.txt': typeof RobotsDottxtRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
   '/api/search': typeof ApiSearchRoute
+  '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
   '/og/$': typeof OgSplatRoute
   '/llms.mdx/docs/$': typeof LlmsDotmdxDocsSplatRoute
@@ -95,6 +103,7 @@ export interface FileRoutesById {
   '/robots.txt': typeof RobotsDottxtRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
   '/api/search': typeof ApiSearchRoute
+  '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
   '/og/$': typeof OgSplatRoute
   '/llms.mdx/docs/$': typeof LlmsDotmdxDocsSplatRoute
@@ -108,6 +117,7 @@ export interface FileRouteTypes {
     | '/robots.txt'
     | '/sitemap.xml'
     | '/api/search'
+    | '/blog/$slug'
     | '/docs/$'
     | '/og/$'
     | '/llms.mdx/docs/$'
@@ -119,6 +129,7 @@ export interface FileRouteTypes {
     | '/robots.txt'
     | '/sitemap.xml'
     | '/api/search'
+    | '/blog/$slug'
     | '/docs/$'
     | '/og/$'
     | '/llms.mdx/docs/$'
@@ -130,6 +141,7 @@ export interface FileRouteTypes {
     | '/robots.txt'
     | '/sitemap.xml'
     | '/api/search'
+    | '/blog/$slug'
     | '/docs/$'
     | '/og/$'
     | '/llms.mdx/docs/$'
@@ -142,6 +154,7 @@ export interface RootRouteChildren {
   RobotsDottxtRoute: typeof RobotsDottxtRoute
   SitemapDotxmlRoute: typeof SitemapDotxmlRoute
   ApiSearchRoute: typeof ApiSearchRoute
+  BlogSlugRoute: typeof BlogSlugRoute
   DocsSplatRoute: typeof DocsSplatRoute
   OgSplatRoute: typeof OgSplatRoute
   LlmsDotmdxDocsSplatRoute: typeof LlmsDotmdxDocsSplatRoute
@@ -198,6 +211,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DocsSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/blog/$slug': {
+      id: '/blog/$slug'
+      path: '/blog/$slug'
+      fullPath: '/blog/$slug'
+      preLoaderRoute: typeof BlogSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/search': {
       id: '/api/search'
       path: '/api/search'
@@ -222,6 +242,7 @@ const rootRouteChildren: RootRouteChildren = {
   RobotsDottxtRoute: RobotsDottxtRoute,
   SitemapDotxmlRoute: SitemapDotxmlRoute,
   ApiSearchRoute: ApiSearchRoute,
+  BlogSlugRoute: BlogSlugRoute,
   DocsSplatRoute: DocsSplatRoute,
   OgSplatRoute: OgSplatRoute,
   LlmsDotmdxDocsSplatRoute: LlmsDotmdxDocsSplatRoute,

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -1,0 +1,139 @@
+import { createFileRoute, notFound } from '@tanstack/react-router';
+import { createServerFn } from '@tanstack/react-start';
+import { Suspense } from 'react';
+import { InlineTOC } from 'fumadocs-ui/components/inline-toc';
+import browserCollections from 'collections/browser';
+import { blogSource } from '@/lib/blog-source';
+import { LandingHeader } from '@/components/landing/header';
+import { Footer } from '@/components/landing/footer';
+import { useMDXComponents } from '@/components/mdx';
+import { seo } from '@/lib/seo';
+import { appConfig } from '@/lib/shared';
+
+export const Route = createFileRoute('/blog/$slug')({
+  component: BlogArticlePage,
+  loader: async ({ params }) => {
+    const data = await serverLoader({ data: params.slug });
+    await clientLoader.preload(data.path);
+    return data;
+  },
+  head: ({ loaderData }) => {
+    if (!loaderData) return { meta: [], links: [] };
+
+    const title = `${loaderData.pageTitle} — ${appConfig.name} Blog`;
+    const description = loaderData.pageDescription ?? 'Better-Notify blog.';
+    const url = `${appConfig.baseUrl}/blog/${loaderData.slug}`;
+    const image = loaderData.pageImage ?? `${appConfig.baseUrl}/og-image.png`;
+
+    const { meta, links } = seo({
+      title,
+      description,
+      image,
+      url,
+      canonicalUrl: url,
+      type: 'article',
+      article: {
+        publishedTime: loaderData.pageDate,
+        author: loaderData.pageAuthor,
+        section: loaderData.pageCategory,
+        tags: loaderData.pageTags,
+      },
+    });
+
+    return { meta, links };
+  },
+});
+
+const serverLoader = createServerFn({
+  method: 'GET',
+})
+  .inputValidator((slug: string) => slug)
+  .handler(async ({ data: slug }) => {
+    const pages = blogSource.getPages();
+    const page = pages.find((p) => p.slugs[p.slugs.length - 1] === slug);
+    if (!page) throw notFound();
+
+    const category = page.slugs.length > 1 ? page.slugs[0] : null;
+
+    return {
+      path: page.path,
+      slug,
+      pageTitle: page.data.title,
+      pageDescription: (page.data.description as string | undefined) ?? null,
+      pageDate: (page.data as Record<string, unknown>).date as string,
+      pageAuthor: ((page.data as Record<string, unknown>).author as string) ?? 'Lucas Reis',
+      pageTags: ((page.data as Record<string, unknown>).tags as string[]) ?? [],
+      pageCategory: category,
+      pageImage: ((page.data as Record<string, unknown>).image as string | undefined) ?? null,
+    };
+  });
+
+const clientLoader = browserCollections.blogPosts.createClientLoader({
+  component({ toc, default: MDX }, _props: undefined) {
+    return (
+      <>
+        <InlineTOC items={toc} />
+        <div className="prose prose-neutral dark:prose-invert max-w-none">
+          <MDX components={useMDXComponents()} />
+        </div>
+      </>
+    );
+  },
+});
+
+function BlogArticlePage() {
+  const loaderData = Route.useLoaderData();
+
+  return (
+    <>
+      <LandingHeader />
+      <main className="min-h-screen">
+        <article className="mx-auto w-full max-w-[720px] px-5 py-12 md:px-8">
+          <header className="mb-10">
+            {loaderData.pageCategory && (
+              <span className="bg-primary/10 text-primary mb-3 inline-block rounded-md px-2.5 py-1 text-xs font-medium capitalize">
+                {loaderData.pageCategory}
+              </span>
+            )}
+            <h1
+              className="text-foreground mb-3 text-3xl font-bold tracking-tight md:text-4xl"
+              style={{ lineHeight: 1.15 }}
+            >
+              {loaderData.pageTitle}
+            </h1>
+            {loaderData.pageDescription && (
+              <p className="text-muted-foreground mb-4 text-lg leading-relaxed">
+                {loaderData.pageDescription}
+              </p>
+            )}
+            <div className="text-muted-foreground flex items-center gap-3 text-sm">
+              <span>{loaderData.pageAuthor}</span>
+              <span className="text-border">·</span>
+              <time>
+                {new Date(loaderData.pageDate).toLocaleDateString('en-US', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              </time>
+            </div>
+            {loaderData.pageTags.length > 0 && (
+              <div className="mt-3 flex flex-wrap gap-1.5">
+                {loaderData.pageTags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="border-border text-muted-foreground rounded-md border px-2 py-0.5 text-xs"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+          </header>
+          <Suspense>{clientLoader.useContent(loaderData.path)}</Suspense>
+        </article>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -1,6 +1,7 @@
-import { createFileRoute, notFound } from '@tanstack/react-router';
+import { createFileRoute, Link, notFound } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { Suspense } from 'react';
+import { CaretRightIcon } from '@phosphor-icons/react';
 import { InlineTOC } from 'fumadocs-ui/components/inline-toc';
 import browserCollections from 'collections/browser';
 import { blogSource } from '@/lib/blog-source';
@@ -72,7 +73,7 @@ const clientLoader = browserCollections.blogPosts.createClientLoader({
   component({ toc, default: MDX }, _props: undefined) {
     return (
       <>
-        <InlineTOC items={toc} />
+        {toc.length >= 2 && <InlineTOC items={toc} className="mb-8" />}
         <div className="prose prose-neutral dark:prose-invert max-w-none">
           <MDX components={useMDXComponents()} />
         </div>
@@ -88,13 +89,33 @@ function BlogArticlePage() {
     <>
       <LandingHeader />
       <main className="min-h-screen">
-        <article className="mx-auto w-full max-w-[720px] px-5 py-12 md:px-8">
+        <article className="mx-auto w-full max-w-[1200px] px-5 py-12 md:px-8">
+          <nav aria-label="Breadcrumb" className="mb-6">
+            <ol className="text-muted-foreground flex list-none items-center gap-1.5 p-0 text-sm">
+              <li>
+                <Link to="/blog" className="hover:text-foreground no-underline transition-colors">
+                  Blog
+                </Link>
+              </li>
+              {loaderData.pageCategory && (
+                <>
+                  <li><CaretRightIcon size={12} className="text-border" /></li>
+                  <li>
+                    <Link
+                      to="/blog"
+                      search={{ category: loaderData.pageCategory }}
+                      className="hover:text-foreground capitalize no-underline transition-colors"
+                    >
+                      {loaderData.pageCategory}
+                    </Link>
+                  </li>
+                </>
+              )}
+              <li><CaretRightIcon size={12} className="text-border" /></li>
+              <li className="text-foreground font-medium">{loaderData.pageTitle}</li>
+            </ol>
+          </nav>
           <header className="mb-10">
-            {loaderData.pageCategory && (
-              <span className="bg-primary/10 text-primary mb-3 inline-block rounded-md px-2.5 py-1 text-xs font-medium capitalize">
-                {loaderData.pageCategory}
-              </span>
-            )}
             <h1
               className="text-foreground mb-3 text-3xl font-bold tracking-tight md:text-4xl"
               style={{ lineHeight: 1.15 }}

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -4,7 +4,7 @@ import { Suspense } from 'react';
 import { CaretRightIcon } from '@phosphor-icons/react';
 import { InlineTOC } from 'fumadocs-ui/components/inline-toc';
 import browserCollections from 'collections/browser';
-import { blogSource } from '@/lib/blog-source';
+import { blogSource, mapPageToPost } from '@/lib/blog-source';
 import { LandingHeader } from '@/components/landing/header';
 import { Footer } from '@/components/landing/footer';
 import { useMDXComponents } from '@/components/mdx';
@@ -54,18 +54,19 @@ const serverLoader = createServerFn({
     const page = pages.find((p) => p.slugs[p.slugs.length - 1] === slug);
     if (!page) throw notFound();
 
-    const category = page.slugs.length > 1 ? page.slugs[0] : null;
+    const post = mapPageToPost(page);
+    const image = (page.data as Record<string, unknown>).image as string | undefined;
 
     return {
       path: page.path,
-      slug,
-      pageTitle: page.data.title,
-      pageDescription: (page.data.description as string | undefined) ?? null,
-      pageDate: (page.data as unknown as Record<string, unknown>).date as string,
-      pageAuthor: ((page.data as unknown as Record<string, unknown>).author as string) ?? 'Lucas Reis',
-      pageTags: ((page.data as unknown as Record<string, unknown>).tags as string[]) ?? [],
-      pageCategory: category,
-      pageImage: ((page.data as unknown as Record<string, unknown>).image as string | undefined) ?? null,
+      slug: post.slug,
+      pageTitle: post.title,
+      pageDescription: post.description || null,
+      pageDate: post.date,
+      pageAuthor: post.author,
+      pageTags: post.tags,
+      pageCategory: post.category,
+      pageImage: image ?? null,
     };
   });
 
@@ -135,6 +136,7 @@ function BlogArticlePage() {
                   year: 'numeric',
                   month: 'long',
                   day: 'numeric',
+                  timeZone: 'UTC',
                 })}
               </time>
             </div>

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -55,7 +55,7 @@ const serverLoader = createServerFn({
     if (!page) throw notFound();
 
     const post = mapPageToPost(page);
-    const image = (page.data as Record<string, unknown>).image as string | undefined;
+    const image = (page.data as unknown as Record<string, unknown>).image as string | undefined;
 
     return {
       path: page.path,

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -35,7 +35,7 @@ export const Route = createFileRoute('/blog/$slug')({
       article: {
         publishedTime: loaderData.pageDate,
         author: loaderData.pageAuthor,
-        section: loaderData.pageCategory,
+        section: loaderData.pageCategory ?? undefined,
         tags: loaderData.pageTags,
       },
     });
@@ -60,11 +60,11 @@ const serverLoader = createServerFn({
       slug,
       pageTitle: page.data.title,
       pageDescription: (page.data.description as string | undefined) ?? null,
-      pageDate: (page.data as Record<string, unknown>).date as string,
-      pageAuthor: ((page.data as Record<string, unknown>).author as string) ?? 'Lucas Reis',
-      pageTags: ((page.data as Record<string, unknown>).tags as string[]) ?? [],
+      pageDate: (page.data as unknown as Record<string, unknown>).date as string,
+      pageAuthor: ((page.data as unknown as Record<string, unknown>).author as string) ?? 'Lucas Reis',
+      pageTags: ((page.data as unknown as Record<string, unknown>).tags as string[]) ?? [],
       pageCategory: category,
-      pageImage: ((page.data as Record<string, unknown>).image as string | undefined) ?? null,
+      pageImage: ((page.data as unknown as Record<string, unknown>).image as string | undefined) ?? null,
     };
   });
 

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { createFileRoute, Link } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { CalendarIcon, TagIcon, FunnelIcon } from '@phosphor-icons/react';
 import { z } from 'zod';
@@ -47,10 +47,10 @@ function BlogIndexPage() {
   const { posts, categories, allTags } = Route.useLoaderData();
   const { category: activeCategory } = Route.useSearch();
   const [activeTags, setActiveTags] = useState<string[]>([]);
-  const navigate = useNavigate();
+  const navigate = Route.useNavigate();
 
   const setActiveCategory = (cat: string | null) => {
-    void navigate({ search: (prev) => ({ ...prev, category: cat ?? undefined }) });
+    void navigate({ search: { category: cat ?? undefined } });
   };
 
   const filtered = posts.filter((post) => {

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
-import { createFileRoute, Link, useSearch } from '@tanstack/react-router';
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { CalendarIcon, TagIcon, FunnelIcon } from '@phosphor-icons/react';
 import { z } from 'zod';
-import { blogSource } from '@/lib/blog-source';
+import { getAllBlogPosts } from '@/lib/blog-source';
 import { LandingHeader } from '@/components/landing/header';
 import { Footer } from '@/components/landing/footer';
 import { Button } from '@/components/ui/button';
@@ -37,50 +37,21 @@ export const Route = createFileRoute('/blog/')({
   },
 });
 
-type BlogPost = {
-  slug: string;
-  title: string;
-  description: string;
-  date: string;
-  author: string;
-  tags: string[];
-  category: string | null;
-};
-
 const serverLoader = createServerFn({
   method: 'GET',
 }).handler(async () => {
-  const pages = blogSource.getPages();
-
-  const posts: BlogPost[] = pages
-    .map((page) => {
-      const data = page.data as unknown as Record<string, unknown>;
-      const category = page.slugs.length > 1 ? page.slugs[0] : null;
-      const slug = page.slugs[page.slugs.length - 1];
-
-      return {
-        slug,
-        title: page.data.title,
-        description: (page.data.description as string) ?? '',
-        date: (data.date as string) ?? '',
-        author: (data.author as string) ?? 'Lucas Reis',
-        tags: (data.tags as string[]) ?? [],
-        category,
-      };
-    })
-    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
-
-  const categories = [...new Set(posts.map((p) => p.category).filter(Boolean))] as string[];
-  const allTags = [...new Set(posts.flatMap((p) => p.tags))].sort();
-
-  return { posts, categories, allTags };
+  return getAllBlogPosts();
 });
 
 function BlogIndexPage() {
   const { posts, categories, allTags } = Route.useLoaderData();
-  const { category: searchCategory } = Route.useSearch();
-  const [activeCategory, setActiveCategory] = useState<string | null>(searchCategory ?? null);
+  const { category: activeCategory } = Route.useSearch();
   const [activeTags, setActiveTags] = useState<string[]>([]);
+  const navigate = useNavigate();
+
+  const setActiveCategory = (cat: string | null) => {
+    void navigate({ search: (prev) => ({ ...prev, category: cat ?? undefined }) });
+  };
 
   const filtered = posts.filter((post) => {
     if (activeCategory && post.category !== activeCategory) return false;
@@ -160,6 +131,7 @@ function BlogIndexPage() {
                             year: 'numeric',
                             month: 'short',
                             day: 'numeric',
+                            timeZone: 'UTC',
                           })}
                         </span>
                       </div>

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -1,15 +1,23 @@
 import { useState } from 'react';
-import { createFileRoute, Link } from '@tanstack/react-router';
+import { createFileRoute, Link, useSearch } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { CalendarIcon, TagIcon, FunnelIcon } from '@phosphor-icons/react';
+import { z } from 'zod';
 import { blogSource } from '@/lib/blog-source';
 import { LandingHeader } from '@/components/landing/header';
 import { Footer } from '@/components/landing/footer';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { seo } from '@/lib/seo';
 import { appConfig } from '@/lib/shared';
 
+const searchSchema = z.object({
+  category: z.string().optional(),
+});
+
 export const Route = createFileRoute('/blog/')({
   component: BlogIndexPage,
+  validateSearch: searchSchema,
   loader: async () => {
     return await serverLoader();
   },
@@ -70,7 +78,8 @@ const serverLoader = createServerFn({
 
 function BlogIndexPage() {
   const { posts, categories, allTags } = Route.useLoaderData();
-  const [activeCategory, setActiveCategory] = useState<string | null>(null);
+  const { category: searchCategory } = Route.useSearch();
+  const [activeCategory, setActiveCategory] = useState<string | null>(searchCategory ?? null);
   const [activeTags, setActiveTags] = useState<string[]>([]);
 
   const filtered = posts.filter((post) => {
@@ -102,28 +111,23 @@ function BlogIndexPage() {
           </div>
 
           <div className="mb-6 flex flex-wrap gap-2 md:hidden">
-            <button
+            <Button
+              variant={!activeCategory ? 'default' : 'outline'}
+              size="sm"
               onClick={() => setActiveCategory(null)}
-              className={`cursor-pointer rounded-md border px-3 py-1.5 text-xs font-medium transition-colors ${
-                !activeCategory
-                  ? 'border-primary bg-primary/10 text-primary'
-                  : 'border-border text-muted-foreground'
-              }`}
             >
               All
-            </button>
+            </Button>
             {categories.map((cat) => (
-              <button
+              <Button
                 key={cat}
+                variant={activeCategory === cat ? 'default' : 'outline'}
+                size="sm"
                 onClick={() => setActiveCategory(activeCategory === cat ? null : cat)}
-                className={`cursor-pointer rounded-md border px-3 py-1.5 text-xs font-medium capitalize transition-colors ${
-                  activeCategory === cat
-                    ? 'border-primary bg-primary/10 text-primary'
-                    : 'border-border text-muted-foreground'
-                }`}
+                className="capitalize"
               >
                 {cat}
-              </button>
+              </Button>
             ))}
           </div>
 
@@ -146,9 +150,9 @@ function BlogIndexPage() {
                     >
                       <div className="mb-3 flex items-center gap-2">
                         {post.category && (
-                          <span className="bg-primary text-primary-foreground rounded-md px-2 py-0.5 text-[10px] font-medium capitalize">
+                          <Badge variant="default" className="capitalize">
                             {post.category}
-                          </span>
+                          </Badge>
                         )}
                         <span className="text-muted-foreground flex items-center gap-1 text-xs">
                           <CalendarIcon size={12} />
@@ -168,12 +172,9 @@ function BlogIndexPage() {
                       {post.tags.length > 0 && (
                         <div className="flex flex-wrap gap-1.5">
                           {post.tags.map((tag) => (
-                            <span
-                              key={tag}
-                              className="border-border text-muted-foreground rounded border px-1.5 py-0.5 text-[10px]"
-                            >
+                            <Badge key={tag} variant="outline">
                               {tag}
-                            </span>
+                            </Badge>
                           ))}
                         </div>
                       )}
@@ -191,28 +192,24 @@ function BlogIndexPage() {
                     Categories
                   </h3>
                   <div className="flex flex-col gap-1">
-                    <button
+                    <Button
+                      variant="ghost"
+                      size="sm"
                       onClick={() => setActiveCategory(null)}
-                      className={`cursor-pointer rounded-md px-2.5 py-1.5 text-left text-[13px] font-medium transition-colors ${
-                        !activeCategory
-                          ? 'bg-primary/10 text-primary'
-                          : 'text-muted-foreground hover:text-foreground'
-                      }`}
+                      className={`justify-start ${!activeCategory ? 'bg-primary/10 text-primary' : 'text-muted-foreground'}`}
                     >
                       All posts
-                    </button>
+                    </Button>
                     {categories.map((cat) => (
-                      <button
+                      <Button
                         key={cat}
+                        variant="ghost"
+                        size="sm"
                         onClick={() => setActiveCategory(activeCategory === cat ? null : cat)}
-                        className={`cursor-pointer rounded-md px-2.5 py-1.5 text-left text-[13px] font-medium capitalize transition-colors ${
-                          activeCategory === cat
-                            ? 'bg-primary/10 text-primary'
-                            : 'text-muted-foreground hover:text-foreground'
-                        }`}
+                        className={`justify-start capitalize ${activeCategory === cat ? 'bg-primary/10 text-primary' : 'text-muted-foreground'}`}
                       >
                         {cat}
-                      </button>
+                      </Button>
                     ))}
                   </div>
                 </div>
@@ -225,17 +222,14 @@ function BlogIndexPage() {
                     </h3>
                     <div className="flex flex-wrap gap-1.5">
                       {allTags.map((tag) => (
-                        <button
+                        <Button
                           key={tag}
+                          variant={activeTags.includes(tag) ? 'default' : 'outline'}
+                          size="xs"
                           onClick={() => toggleTag(tag)}
-                          className={`cursor-pointer rounded-md border px-2 py-1 text-xs font-medium transition-colors ${
-                            activeTags.includes(tag)
-                              ? 'border-primary bg-primary/10 text-primary'
-                              : 'border-border text-muted-foreground hover:text-foreground'
-                          }`}
                         >
                           {tag}
-                        </button>
+                        </Button>
                       ))}
                     </div>
                   </div>

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -101,6 +101,20 @@ function BlogIndexPage() {
               </Button>
             ))}
           </div>
+          {allTags.length > 0 && (
+            <div className="mb-6 flex flex-wrap gap-1.5 md:hidden">
+              {allTags.map((tag) => (
+                <Button
+                  key={tag}
+                  variant={activeTags.includes(tag) ? 'default' : 'outline'}
+                  size="xs"
+                  onClick={() => toggleTag(tag)}
+                >
+                  {tag}
+                </Button>
+              ))}
+            </div>
+          )}
 
           <div className="flex gap-8">
             <div className="min-w-0 flex-1">

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -1,0 +1,251 @@
+import { useState } from 'react';
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { createServerFn } from '@tanstack/react-start';
+import { CalendarIcon, TagIcon, FunnelIcon } from '@phosphor-icons/react';
+import { blogSource } from '@/lib/blog-source';
+import { LandingHeader } from '@/components/landing/header';
+import { Footer } from '@/components/landing/footer';
+import { seo } from '@/lib/seo';
+import { appConfig } from '@/lib/shared';
+
+export const Route = createFileRoute('/blog/')({
+  component: BlogIndexPage,
+  loader: async () => {
+    return await serverLoader();
+  },
+  head: () => {
+    const title = `Blog — ${appConfig.name}`;
+    const description = 'Articles, guides, and updates from the Better-Notify team.';
+    const url = `${appConfig.baseUrl}/blog`;
+
+    const { meta, links } = seo({
+      title,
+      description,
+      url,
+      canonicalUrl: url,
+    });
+
+    return { meta, links };
+  },
+});
+
+type BlogPost = {
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  author: string;
+  tags: string[];
+  category: string | null;
+};
+
+const serverLoader = createServerFn({
+  method: 'GET',
+}).handler(async () => {
+  const pages = blogSource.getPages();
+
+  const posts: BlogPost[] = pages
+    .map((page) => {
+      const data = page.data as unknown as Record<string, unknown>;
+      const category = page.slugs.length > 1 ? page.slugs[0] : null;
+      const slug = page.slugs[page.slugs.length - 1];
+
+      return {
+        slug,
+        title: page.data.title,
+        description: (page.data.description as string) ?? '',
+        date: (data.date as string) ?? '',
+        author: (data.author as string) ?? 'Lucas Reis',
+        tags: (data.tags as string[]) ?? [],
+        category,
+      };
+    })
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+  const categories = [...new Set(posts.map((p) => p.category).filter(Boolean))] as string[];
+  const allTags = [...new Set(posts.flatMap((p) => p.tags))].sort();
+
+  return { posts, categories, allTags };
+});
+
+function BlogIndexPage() {
+  const { posts, categories, allTags } = Route.useLoaderData();
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
+  const [activeTags, setActiveTags] = useState<string[]>([]);
+
+  const filtered = posts.filter((post) => {
+    if (activeCategory && post.category !== activeCategory) return false;
+    if (activeTags.length > 0 && !activeTags.some((t) => post.tags.includes(t))) return false;
+    return true;
+  });
+
+  const toggleTag = (tag: string) => {
+    setActiveTags((prev) => (prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]));
+  };
+
+  return (
+    <>
+      <LandingHeader />
+      <main className="min-h-screen py-16 md:py-20">
+        <div className="mx-auto max-w-[1200px] px-5 md:px-8">
+          <div className="mb-12">
+            <p className="bn-eyebrow mb-3">Blog</p>
+            <h1
+              className="text-foreground mb-4 text-4xl font-bold tracking-tight"
+              style={{ lineHeight: 1.1 }}
+            >
+              Articles & Updates
+            </h1>
+            <p className="text-muted-foreground max-w-[620px] text-[17px] leading-relaxed">
+              Guides, integrations, and news from the Better-Notify project.
+            </p>
+          </div>
+
+          <div className="mb-6 flex flex-wrap gap-2 md:hidden">
+            <button
+              onClick={() => setActiveCategory(null)}
+              className={`cursor-pointer rounded-md border px-3 py-1.5 text-xs font-medium transition-colors ${
+                !activeCategory
+                  ? 'border-primary bg-primary/10 text-primary'
+                  : 'border-border text-muted-foreground'
+              }`}
+            >
+              All
+            </button>
+            {categories.map((cat) => (
+              <button
+                key={cat}
+                onClick={() => setActiveCategory(activeCategory === cat ? null : cat)}
+                className={`cursor-pointer rounded-md border px-3 py-1.5 text-xs font-medium capitalize transition-colors ${
+                  activeCategory === cat
+                    ? 'border-primary bg-primary/10 text-primary'
+                    : 'border-border text-muted-foreground'
+                }`}
+              >
+                {cat}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex gap-8">
+            <div className="min-w-0 flex-1">
+              {filtered.length === 0 ? (
+                <p className="text-muted-foreground py-12 text-center text-sm">
+                  No posts match the selected filters.
+                </p>
+              ) : (
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {filtered.map((post, i) => (
+                    <Link
+                      key={post.slug}
+                      to="/blog/$slug"
+                      params={{ slug: post.slug }}
+                      className={`border-border bg-card group block rounded-xl border p-5 no-underline transition-colors hover:bg-bn-slate-50 dark:hover:bg-bn-slate-900 ${
+                        i === 0 ? 'sm:col-span-2' : ''
+                      }`}
+                    >
+                      <div className="mb-3 flex items-center gap-2">
+                        {post.category && (
+                          <span className="bg-primary text-primary-foreground rounded-md px-2 py-0.5 text-[10px] font-medium capitalize">
+                            {post.category}
+                          </span>
+                        )}
+                        <span className="text-muted-foreground flex items-center gap-1 text-xs">
+                          <CalendarIcon size={12} />
+                          {new Date(post.date).toLocaleDateString('en-US', {
+                            year: 'numeric',
+                            month: 'short',
+                            day: 'numeric',
+                          })}
+                        </span>
+                      </div>
+                      <h2 className="text-foreground group-hover:text-primary mb-2 text-lg font-semibold tracking-tight transition-colors">
+                        {post.title}
+                      </h2>
+                      <p className="text-muted-foreground mb-3 text-sm leading-relaxed line-clamp-2">
+                        {post.description}
+                      </p>
+                      {post.tags.length > 0 && (
+                        <div className="flex flex-wrap gap-1.5">
+                          {post.tags.map((tag) => (
+                            <span
+                              key={tag}
+                              className="border-border text-muted-foreground rounded border px-1.5 py-0.5 text-[10px]"
+                            >
+                              {tag}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <aside className="hidden w-[220px] shrink-0 md:block">
+              <div className="sticky top-20">
+                <div className="mb-6">
+                  <h3 className="text-foreground mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide">
+                    <FunnelIcon size={14} />
+                    Categories
+                  </h3>
+                  <div className="flex flex-col gap-1">
+                    <button
+                      onClick={() => setActiveCategory(null)}
+                      className={`cursor-pointer rounded-md px-2.5 py-1.5 text-left text-[13px] font-medium transition-colors ${
+                        !activeCategory
+                          ? 'bg-primary/10 text-primary'
+                          : 'text-muted-foreground hover:text-foreground'
+                      }`}
+                    >
+                      All posts
+                    </button>
+                    {categories.map((cat) => (
+                      <button
+                        key={cat}
+                        onClick={() => setActiveCategory(activeCategory === cat ? null : cat)}
+                        className={`cursor-pointer rounded-md px-2.5 py-1.5 text-left text-[13px] font-medium capitalize transition-colors ${
+                          activeCategory === cat
+                            ? 'bg-primary/10 text-primary'
+                            : 'text-muted-foreground hover:text-foreground'
+                        }`}
+                      >
+                        {cat}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {allTags.length > 0 && (
+                  <div>
+                    <h3 className="text-foreground mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide">
+                      <TagIcon size={14} />
+                      Tags
+                    </h3>
+                    <div className="flex flex-wrap gap-1.5">
+                      {allTags.map((tag) => (
+                        <button
+                          key={tag}
+                          onClick={() => toggleTag(tag)}
+                          className={`cursor-pointer rounded-md border px-2 py-1 text-xs font-medium transition-colors ${
+                            activeTags.includes(tag)
+                              ? 'border-primary bg-primary/10 text-primary'
+                              : 'border-border text-muted-foreground hover:text-foreground'
+                          }`}
+                        >
+                          {tag}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </aside>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/apps/web/src/routes/docs/$.tsx
+++ b/apps/web/src/routes/docs/$.tsx
@@ -10,6 +10,7 @@ import { Suspense } from 'react';
 import { useMDXComponents } from '@/components/mdx';
 import { seo } from '@/lib/seo';
 import { appConfig } from '@/lib/shared';
+import { LandingHeader } from '@/components/landing/header';
 
 export const Route = createFileRoute('/docs/$')({
   component: Page,
@@ -80,8 +81,11 @@ function Page() {
   if (!data) return null;
 
   return (
-    <DocsLayout {...baseOptions()} tree={data.pageTree}>
-      <Suspense>{clientLoader.useContent(data.path)}</Suspense>
-    </DocsLayout>
+    <>
+      <LandingHeader />
+      <DocsLayout {...baseOptions()} tree={data.pageTree} nav={{ enabled: false }}>
+        <Suspense>{clientLoader.useContent(data.path)}</Suspense>
+      </DocsLayout>
+    </>
   );
 }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -13,7 +13,7 @@ import { Cta } from '@/components/landing/faq-cta';
 import { BlogAndAuthor } from '@/components/landing/author';
 import { Footer } from '@/components/landing/footer';
 import { Marquee } from '@/components/landing/marquee';
-import { blogSource } from '@/lib/blog-source';
+import { getLatestBlogPosts } from '@/lib/blog-source';
 
 export const Route = createFileRoute('/')({
   component: LandingPage,
@@ -25,27 +25,7 @@ export const Route = createFileRoute('/')({
 const getLatestPosts = createServerFn({
   method: 'GET',
 }).handler(async () => {
-  const pages = blogSource.getPages();
-
-  const posts = pages
-    .map((page) => {
-      const data = page.data as unknown as Record<string, unknown>;
-      const category = page.slugs.length > 1 ? page.slugs[0] : null;
-      const slug = page.slugs[page.slugs.length - 1];
-
-      return {
-        slug,
-        title: page.data.title,
-        description: (page.data.description as string) ?? '',
-        date: (data.date as string) ?? '',
-        category,
-        tags: (data.tags as string[]) ?? [],
-      };
-    })
-    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
-    .slice(0, 3);
-
-  return { latestPosts: posts };
+  return { latestPosts: getLatestBlogPosts(3) };
 });
 
 function LandingPage() {

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
 import { createFileRoute } from '@tanstack/react-router';
+import { createServerFn } from '@tanstack/react-start';
 
 import { LandingHeader } from '@/components/landing/header';
 import { Hero } from '@/components/landing/hero';
@@ -9,15 +10,47 @@ import { Pipeline } from '@/components/landing/pipeline';
 import { Comparison } from '@/components/landing/comparison';
 import { Install } from '@/components/landing/install';
 import { Cta } from '@/components/landing/faq-cta';
-import { Author } from '@/components/landing/author';
+import { BlogAndAuthor } from '@/components/landing/author';
 import { Footer } from '@/components/landing/footer';
 import { Marquee } from '@/components/landing/marquee';
+import { blogSource } from '@/lib/blog-source';
 
 export const Route = createFileRoute('/')({
   component: LandingPage,
+  loader: async () => {
+    return await getLatestPosts();
+  },
+});
+
+const getLatestPosts = createServerFn({
+  method: 'GET',
+}).handler(async () => {
+  const pages = blogSource.getPages();
+
+  const posts = pages
+    .map((page) => {
+      const data = page.data as unknown as Record<string, unknown>;
+      const category = page.slugs.length > 1 ? page.slugs[0] : null;
+      const slug = page.slugs[page.slugs.length - 1];
+
+      return {
+        slug,
+        title: page.data.title,
+        description: (page.data.description as string) ?? '',
+        date: (data.date as string) ?? '',
+        category,
+        tags: (data.tags as string[]) ?? [],
+      };
+    })
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+    .slice(0, 3);
+
+  return { latestPosts: posts };
 });
 
 function LandingPage() {
+  const { latestPosts } = Route.useLoaderData();
+
   return (
     <Suspense>
       <LandingHeader />
@@ -30,7 +63,7 @@ function LandingPage() {
         <Comparison />
         <Install />
         <Cta />
-        <Author />
+        <BlogAndAuthor posts={latestPosts} />
       </main>
       <Footer />
     </Suspense>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 'catalog:'
@@ -2571,6 +2574,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -8552,7 +8556,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)':
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.16)
       ajv: 8.20.0
@@ -8569,8 +8573,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
@@ -13111,7 +13115,7 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@dotenvx/dotenvx': 1.63.0
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@types/validate-npm-package-name': 4.0.2
       browserslist: 4.28.2
       commander: 14.0.3
@@ -13824,10 +13828,6 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
-
-  zod-to-json-schema@3.25.2(zod@4.3.6):
-    dependencies:
-      zod: 4.3.6
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
# Overview

Moves the blog out of the Fumadocs docs tree into a standalone blog system with dedicated routes, a preview on the landing page, and category/tag filtering. Closes BET-89.

# What's changed and why?

- **`apps/web/source.config.ts`** — Added `blogPosts` collection via `defineCollections` with custom frontmatter schema (date, tags, author, image)
- **`apps/web/src/lib/blog-source.ts`** — New blog source loader with `/blog` base URL
- **`apps/web/src/routes/blog/$slug.tsx`** — Standalone blog article page with breadcrumbs, article header, inline TOC, and full SEO/OG metadata
- **`apps/web/src/routes/blog/index.tsx`** — Blog index with bento grid, sidebar category/tag filters, zod search schema, shadcn Button/Badge components
- **`apps/web/src/routes/index.tsx`** — Landing page now loads latest blog posts via server function
- **`apps/web/src/components/landing/author.tsx`** — Evolved into `BlogAndAuthor` — blog preview cards on the left, author on the right (stacked on mobile)
- **`apps/web/src/components/landing/header.tsx`** — Added active nav state, anchor links hidden outside home page
- **`apps/web/src/components/landing/footer.tsx`** — Added Blog link to Developers column
- **`apps/web/src/components/landing/install.tsx`** — Added bootstrap CLI/Skill tabs as step 1 in Quick Start
- **`apps/web/src/components/landing/hero.tsx`** — Widened CLI preview container
- **`apps/web/src/routes/docs/$.tsx`** — Uses shared landing header, Fumadocs nav disabled
- **`apps/web/content/blog/announcements/introducing-betternotify.mdx`** — Migrated blog post with new frontmatter
- **`apps/web/content/docs/blog/`** — Removed old docs blog directory
- **`apps/web/content/docs/meta.json`** — Removed blog from docs pages list

# How to test

1. Run `pnpm dev` from `apps/web`
2. Visit `/` — blog preview cards appear in the Author section, Quick Start has CLI/Skill tabs
3. Visit `/blog` — bento grid with sidebar filters, click a category to filter
4. Visit `/blog/introducing-betternotify` — standalone article with breadcrumbs
5. Visit `/docs` — shared landing header with active "Docs" link, no anchor links
6. Check header nav shows active state on Blog and Docs pages

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full blog section: index with category/tag filters and individual post pages (breadcrumbs, TOC, article SEO)
  * Homepage now shows latest blog posts in a combined Blog & Author panel
  * Install flow adds a "Bootstrap your project" quick-start step

* **Updates**
  * Blog posts include author, date, description, and tags in metadata
  * Nav changes: Blog link added to footer/header; docs nav no longer lists the blog
  * Minor layout and spacing tweaks across landing, hero, and footer components
<!-- end of auto-generated comment: release notes by coderabbit.ai -->