### PR TITLE
fix(web): fix docs content flicker and rename posthog proxy

### DIFF
--- a/apps/web/content/blog/announcements/introducing-betternotify.mdx
+++ b/apps/web/content/blog/announcements/introducing-betternotify.mdx
@@ -139,7 +139,6 @@ const catalog = rpc.catalog({
 - **Queue and worker** — BullMQ integration for async delivery with retry and dead-letter queues
 - **Webhook router** — receive provider webhooks (bounces, opens, clicks) with signature verification
 - **Batch optimizations** — coalesce sends to the same provider in a single API call
-- **More template adapters** — MJML, Handlebars, and plain-HTML string adapters
 
 ## Get Started
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
-    "@fontsource-variable/inter": "^5.2.8",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@fontsource-variable/manrope": "^5.2.8",
     "@libs/ui": "workspace:*",
     "@phosphor-icons/react": "catalog:",
     "@posthog/react": "1.9.0",

--- a/apps/web/src/components/code-editor.tsx
+++ b/apps/web/src/components/code-editor.tsx
@@ -1,0 +1,16 @@
+export const CodeEditor = ({ html, filename }: { html: string; filename?: string }) => (
+  <div className="overflow-hidden rounded-lg border border-border">
+    <div className="flex items-center gap-2 border-b border-border bg-fd-muted px-3 py-2">
+      <div className="flex gap-1.5">
+        <span className="size-2.5 rounded-full bg-[#ff5f57]" />
+        <span className="size-2.5 rounded-full bg-[#febc2e]" />
+        <span className="size-2.5 rounded-full bg-[#28c840]" />
+      </div>
+      {filename && <span className="text-muted-foreground ml-1 text-xs">{filename}</span>}
+    </div>
+    <div
+      className="not-fumadocs-codeblock overflow-x-auto text-sm leading-relaxed [&_pre]:m-0 [&_pre]:overflow-x-auto [&_pre]:px-3 [&_pre]:py-3 [&_code]:p-0"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  </div>
+);

--- a/apps/web/src/components/landing/author.tsx
+++ b/apps/web/src/components/landing/author.tsx
@@ -22,7 +22,7 @@ type BlogPreviewPost = {
 
 const author = {
   name: 'Lucas Reis',
-  bio: 'A brazilian full stack software engineer focused on developer experience and software quality.',
+  bio: 'A Brazilian full-stack software engineer focused on developer experience and software quality.',
   photo: '/lucas-reis.png',
   socials: [
     { icon: XLogoIcon, href: 'https://x.com/lucasreis', label: 'X' },

--- a/apps/web/src/components/landing/channels.tsx
+++ b/apps/web/src/components/landing/channels.tsx
@@ -17,21 +17,21 @@ const channels = [
     name: 'Email',
     pkg: '@betternotify/email',
     status: 'ready',
-    detail: 'SES · Resend · SMTP · React Email · Mailpit',
+    detail: 'Resend · Cloudflare · SMTP · Mailchimp · React Email',
   },
   {
     icon: ChatText,
     name: 'SMS',
     pkg: '@betternotify/sms',
     status: 'ready',
-    detail: 'Twilio · MessageBird · Vonage',
+    detail: 'Twilio',
   },
   {
     icon: Bell,
     name: 'Push',
     pkg: '@betternotify/push',
-    status: 'ready',
-    detail: 'APNs · FCM · Web Push · Expo',
+    status: 'soon',
+    detail: 'APNs · FCM · Web Push',
   },
   {
     icon: TelegramLogo,
@@ -104,7 +104,7 @@ export function Channels() {
             Same API. Any channel.
           </h2>
           <p className="text-muted-foreground max-w-[620px] text-[17px] leading-relaxed text-pretty">
-            Each channel is a package with its own slots and transport. Swap providers without
+            Each channel is a package with its own rendering and transport. Swap providers without
             touching route definitions. Build your own with{' '}
             <code className="bg-muted text-foreground rounded border px-1 py-0.5 font-mono text-xs">
               defineChannel()
@@ -126,8 +126,8 @@ export function Channels() {
               {primary.pkg}
             </code>
             <p className="text-muted-foreground mb-4 text-[13.5px] leading-relaxed">
-              The first channel shipping in v0.1. Typed templates with React Email, MJML, or plain
-              functions. Multi-provider failover out of the box.
+              Typed templates with React Email, MJML, or plain functions. Multi-provider failover
+              out of the box.
             </p>
             <p className="text-muted-foreground m-0 font-mono text-xs leading-relaxed">
               {primary.detail}

--- a/apps/web/src/components/landing/features.tsx
+++ b/apps/web/src/components/landing/features.tsx
@@ -13,7 +13,7 @@ import { K, F, P } from '@/components/landing/syntax';
 const anchor = {
   icon: StackIcon,
   title: 'End-to-end typed',
-  body: 'One catalog type drives your sender, queue worker, and webhook router. Refactor a route and every call site updates.',
+  body: 'One catalog types your sending across every channel. Refactor a route and every call site updates.',
 } as const;
 
 const supporting = [
@@ -30,7 +30,7 @@ const supporting = [
   {
     icon: PulseIcon,
     title: 'Provider failover',
-    body: 'multiTransport tries SES, then Resend, then SMTP. Health-checked, retry-aware.',
+    body: 'multiTransport tries Resend, then Cloudflare, then SMTP. Health-checked, retry-aware.',
   },
   {
     icon: ShieldIcon,

--- a/apps/web/src/components/landing/footer.tsx
+++ b/apps/web/src/components/landing/footer.tsx
@@ -8,6 +8,8 @@ const navColumns = [
     title: 'Product',
     links: [
       { label: 'Features', href: '#features' },
+      { label: 'Integrations', href: '/integrations' },
+      { label: 'Frameworks', href: '/for' },
       { label: 'Changelog', href: '/docs/changelog' },
     ],
   },
@@ -16,7 +18,7 @@ const navColumns = [
     links: [
       { label: 'Documentation', href: '/docs' },
       { label: 'Blog', href: '/blog' },
-      { label: 'Quick start', href: '/docs' },
+      { label: 'Quick start', href: '/docs/get-started/quick-start' },
       {
         label: 'GitHub',
         href: `https://github.com/${appConfig.git.user}/${appConfig.git.repo}`,

--- a/apps/web/src/components/landing/hero.tsx
+++ b/apps/web/src/components/landing/hero.tsx
@@ -57,8 +57,8 @@ export function Hero() {
               <code className="bg-muted text-foreground rounded border px-1.5 py-0.5 font-mono text-[0.85em]">
                 Catalog
               </code>{' '}
-              drives your typed sender, queue worker, and webhook router across email, SMS, push,
-              and Telegram.
+              drives your typed sender across email, SMS, Telegram, Slack, and Discord — via SMTP,
+              Resend, Cloudflare, or your own transport.
             </p>
 
             <div

--- a/apps/web/src/components/landing/hero.tsx
+++ b/apps/web/src/components/landing/hero.tsx
@@ -106,9 +106,9 @@ export function Hero() {
             >
               <span>ESM · Node ≥ 22</span>
               <span className="text-muted-foreground/30 hidden sm:inline">|</span>
-              <span>MIT licensed</span>
+              <span>Open source</span>
               <span className="text-muted-foreground/30 hidden sm:inline">|</span>
-              <span>Standard Schema</span>
+              <span>Zero vendor lock-in</span>
             </div>
           </div>
 

--- a/apps/web/src/components/landing/hero.tsx
+++ b/apps/web/src/components/landing/hero.tsx
@@ -57,7 +57,7 @@ export function Hero() {
               <code className="bg-muted text-foreground rounded border px-1.5 py-0.5 font-mono text-[0.85em]">
                 Catalog
               </code>{' '}
-              drives your typed sender across email, SMS, Telegram, Slack, and Discord — via SMTP,
+              drives typed sending across email, SMS, Telegram, Slack, and Discord — via SMTP,
               Resend, Cloudflare, or your own transport.
             </p>
 

--- a/apps/web/src/components/landing/install.tsx
+++ b/apps/web/src/components/landing/install.tsx
@@ -42,7 +42,7 @@ export function Install() {
             Install. Define. Send.
           </h2>
           <p className="text-muted-foreground max-w-[620px] text-[17px] leading-relaxed text-pretty">
-            Three packages, three minutes. Email, SMS, push, and Telegram channels are shipping
+            Three packages, three minutes. Email, SMS, Telegram, Slack, and Discord channels ship
             today.
           </p>
         </div>

--- a/apps/web/src/components/landing/pipeline.tsx
+++ b/apps/web/src/components/landing/pipeline.tsx
@@ -4,7 +4,7 @@ const phases = [
   { label: 'Validate', detail: 'Standard Schema' },
   { label: 'Render', detail: 'React Email · template' },
   { label: 'Middleware', detail: 'rate-limit · retry · log' },
-  { label: 'Transport', detail: 'SES · Resend · SMTP' },
+  { label: 'Transport', detail: 'Resend · Cloudflare · SMTP' },
   { label: 'Result', detail: 'messageId · attempts' },
 ] as const;
 

--- a/apps/web/src/components/package-install.tsx
+++ b/apps/web/src/components/package-install.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useState } from 'react';
+
+const managers = [
+  { id: 'npm', label: 'npm', cmd: (pkg: string) => `npm install ${pkg}` },
+  { id: 'pnpm', label: 'pnpm', cmd: (pkg: string) => `pnpm add ${pkg}` },
+  { id: 'yarn', label: 'yarn', cmd: (pkg: string) => `yarn add ${pkg}` },
+  { id: 'bun', label: 'bun', cmd: (pkg: string) => `bun add ${pkg}` },
+] as const;
+
+export const PackageInstall = ({ pkg }: { pkg: string }) => {
+  const [active, setActive] = useState<string>('npm');
+  const current = managers.find((m) => m.id === active) ?? managers[0];
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border">
+      <div className="flex border-b border-border bg-fd-muted">
+        {managers.map((m) => (
+          <button
+            key={m.id}
+            onClick={() => setActive(m.id)}
+            className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+              m.id === active
+                ? 'text-foreground border-b-2 border-foreground'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {m.label}
+          </button>
+        ))}
+      </div>
+      <pre className="overflow-x-auto px-3 py-3 text-sm">
+        <code>{current.cmd(pkg)}</code>
+      </pre>
+    </div>
+  );
+};

--- a/apps/web/src/hooks/use-posthog-client.ts
+++ b/apps/web/src/hooks/use-posthog-client.ts
@@ -21,7 +21,7 @@ export const usePosthogClient = () => {
     }
 
     posthog.init(posthogKey, {
-      api_host: '/ingest',
+      api_host: '/ph',
       ui_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST || 'https://eu.posthog.com',
       person_profiles: 'identified_only',
       autocapture: true,

--- a/apps/web/src/lib/highlight.ts
+++ b/apps/web/src/lib/highlight.ts
@@ -1,0 +1,25 @@
+import { createHighlighterCoreSync } from 'shiki/core';
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
+import githubLight from 'shiki/themes/github-light.mjs';
+import githubDark from 'shiki/themes/github-dark.mjs';
+import ts from 'shiki/langs/typescript.mjs';
+
+const highlighter = createHighlighterCoreSync({
+  themes: [githubLight, githubDark],
+  langs: [ts],
+  engine: createJavaScriptRegexEngine(),
+});
+
+export const highlightCode = (code: string, lang = 'typescript') => {
+  const match = code.match(/^\/\/\s*(.+)\n/);
+  const filename = match ? match[1].trim() : undefined;
+  const source = match ? code.slice(match[0].length) : code;
+
+  return {
+    html: highlighter.codeToHtml(source, {
+      lang,
+      themes: { light: 'github-light', dark: 'github-dark' },
+    }),
+    filename,
+  };
+};

--- a/apps/web/src/lib/integrations.ts
+++ b/apps/web/src/lib/integrations.ts
@@ -325,7 +325,7 @@ const catalog = rpc.catalog({
     .email()
     .input(z.object({ name: z.string() }))
     .subject(({ input }) => \`Welcome, \${input.name}\`)
-    .template(reactEmail(WelcomeEmail)),
+    .template(({ input }) => reactEmail(WelcomeEmail, { name: input.name })),
 });`,
     features: [
       'React components as email templates',
@@ -355,7 +355,15 @@ const catalog = rpc.catalog({
     .email()
     .input(z.object({ amount: z.number(), orderId: z.string() }))
     .subject(({ input }) => \`Receipt for order \${input.orderId}\`)
-    .template(mjmlTemplate('./emails/receipt.mjml')),
+    .template(mjmlTemplate(\`<mjml>
+  <mj-body>
+    <mj-section>
+      <mj-column>
+        <mj-text>Receipt for order {{orderId}} — \${{amount}}</mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>\`)),
 });`,
     features: [
       'MJML responsive email markup',
@@ -385,7 +393,7 @@ const catalog = rpc.catalog({
     .email()
     .input(z.object({ inviterName: z.string(), teamName: z.string() }))
     .subject(({ input }) => \`\${input.inviterName} invited you to \${input.teamName}\`)
-    .template(handlebarsTemplate('./emails/invite.hbs')),
+    .template(handlebarsTemplate('<h1>Welcome, {{inviterName}}</h1><p>Join {{teamName}} today.</p>')),
 });`,
     features: [
       'Handlebars template syntax',

--- a/apps/web/src/lib/integrations.ts
+++ b/apps/web/src/lib/integrations.ts
@@ -1,0 +1,406 @@
+export type Integration = {
+  slug: string;
+  name: string;
+  channel: string;
+  channelLabel: string;
+  tagline: string;
+  description: string;
+  package: string;
+  importStatement: string;
+  installCmd: string;
+  codeExample: string;
+  features: string[];
+  docsPath: string;
+  related: string[];
+};
+
+export const integrations: Integration[] = [
+  {
+    slug: 'smtp',
+    name: 'SMTP',
+    channel: 'email',
+    channelLabel: 'Email',
+    tagline: 'Send email through any SMTP server with Better-Notify',
+    description:
+      'Connect Better-Notify to any SMTP-compatible mail server — Gmail, Amazon SES, Postfix, or your own. Backed by Nodemailer with connection pooling, DKIM signing, and automatic error classification.',
+    package: '@betternotify/smtp',
+    importStatement: "import { smtpTransport } from '@betternotify/smtp';",
+    installCmd: 'pnpm add @betternotify/smtp',
+    codeExample: `import { createClient } from '@betternotify/core';
+import { emailChannel } from '@betternotify/email';
+import { smtpTransport } from '@betternotify/smtp';
+
+const mail = createClient({
+  catalog,
+  channels: { email: emailChannel({ defaults: { from: 'hello@example.com' } }) },
+  transportsByChannel: {
+    email: smtpTransport({
+      host: 'smtp.example.com',
+      port: 587,
+      auth: { user: 'user', pass: 'pass' },
+    }),
+  },
+});
+
+await mail.welcome.send({ to: 'user@example.com', input: { name: 'Alice' } });`,
+    features: [
+      'Works with any SMTP server',
+      'Connection pooling for high throughput',
+      'DKIM signing support',
+      'TLS/STARTTLS encryption',
+      'Automatic error classification',
+    ],
+    docsPath: '/docs/transports/smtp',
+    related: ['resend', 'cloudflare-email', 'mailchimp'],
+  },
+  {
+    slug: 'resend',
+    name: 'Resend',
+    channel: 'email',
+    channelLabel: 'Email',
+    tagline: 'Send email with Resend and Better-Notify',
+    description:
+      "Deliver transactional and marketing email through Resend's modern API. Better-Notify handles validation, rendering, and middleware — Resend handles delivery.",
+    package: '@betternotify/resend',
+    importStatement: "import { resendTransport } from '@betternotify/resend';",
+    installCmd: 'pnpm add @betternotify/resend',
+    codeExample: `import { createClient } from '@betternotify/core';
+import { emailChannel } from '@betternotify/email';
+import { resendTransport } from '@betternotify/resend';
+
+const mail = createClient({
+  catalog,
+  channels: { email: emailChannel({ defaults: { from: 'hello@example.com' } }) },
+  transportsByChannel: {
+    email: resendTransport({ apiKey: process.env.RESEND_API_KEY }),
+  },
+});
+
+await mail.welcome.send({ to: 'user@example.com', input: { name: 'Alice' } });`,
+    features: [
+      'Simple API key authentication',
+      'Tags and custom headers',
+      'Attachments and inline images',
+      'CC/BCC support',
+      'Automatic HTTP error classification',
+    ],
+    docsPath: '/docs/transports/resend',
+    related: ['smtp', 'cloudflare-email', 'mailchimp'],
+  },
+  {
+    slug: 'cloudflare-email',
+    name: 'Cloudflare Email',
+    channel: 'email',
+    channelLabel: 'Email',
+    tagline: 'Send email with Cloudflare Email Routing and Better-Notify',
+    description:
+      "Use Cloudflare's Email Routing Service to send transactional email at the edge. No SMTP servers to manage — just an API token and your Cloudflare account.",
+    package: '@betternotify/cloudflare-email',
+    importStatement: "import { cloudflareEmailTransport } from '@betternotify/cloudflare-email';",
+    installCmd: 'pnpm add @betternotify/cloudflare-email',
+    codeExample: `import { createClient } from '@betternotify/core';
+import { emailChannel } from '@betternotify/email';
+import { cloudflareEmailTransport } from '@betternotify/cloudflare-email';
+
+const mail = createClient({
+  catalog,
+  channels: { email: emailChannel({ defaults: { from: 'hello@example.com' } }) },
+  transportsByChannel: {
+    email: cloudflareEmailTransport({
+      accountId: process.env.CF_ACCOUNT_ID,
+      apiToken: process.env.CF_API_TOKEN,
+    }),
+  },
+});
+
+await mail.welcome.send({ to: 'user@example.com', input: { name: 'Alice' } });`,
+    features: [
+      'Edge-native email delivery',
+      'No SMTP infrastructure needed',
+      'Cloudflare API token auth',
+      'Attachments and CC/BCC',
+      'Comprehensive error code mapping',
+    ],
+    docsPath: '/docs/transports/cloudflare-email',
+    related: ['smtp', 'resend', 'mailchimp'],
+  },
+  {
+    slug: 'mailchimp',
+    name: 'Mailchimp',
+    channel: 'email',
+    channelLabel: 'Email',
+    tagline: 'Send transactional email with Mailchimp Mandrill and Better-Notify',
+    description:
+      "Deliver transactional email through Mailchimp's Mandrill API. Ideal if you already use Mailchimp for marketing — add typed transactional email without switching providers.",
+    package: '@betternotify/mailchimp',
+    importStatement: "import { mailchimpTransport } from '@betternotify/mailchimp';",
+    installCmd: 'pnpm add @betternotify/mailchimp',
+    codeExample: `import { createClient } from '@betternotify/core';
+import { emailChannel } from '@betternotify/email';
+import { mailchimpTransport } from '@betternotify/mailchimp';
+
+const mail = createClient({
+  catalog,
+  channels: { email: emailChannel({ defaults: { from: 'hello@example.com' } }) },
+  transportsByChannel: {
+    email: mailchimpTransport({ apiKey: process.env.MANDRILL_API_KEY }),
+  },
+});
+
+await mail.welcome.send({ to: 'user@example.com', input: { name: 'Alice' } });`,
+    features: [
+      'Mandrill transactional API',
+      'Inline images and tags',
+      'Attachments and CC/BCC',
+      'Rate limit detection',
+      'Auth and config error classification',
+    ],
+    docsPath: '/docs/transports/mailchimp',
+    related: ['resend', 'smtp', 'cloudflare-email'],
+  },
+  {
+    slug: 'twilio',
+    name: 'Twilio',
+    channel: 'sms',
+    channelLabel: 'SMS',
+    tagline: 'Send SMS with Twilio and Better-Notify',
+    description:
+      'Send typed SMS notifications through Twilio. Better-Notify validates input, runs middleware, and hands off a clean message — Twilio delivers it.',
+    package: '@betternotify/twilio',
+    importStatement: "import { twilioSmsTransport } from '@betternotify/twilio';",
+    installCmd: 'pnpm add @betternotify/twilio',
+    codeExample: `import { createClient } from '@betternotify/core';
+import { smsChannel } from '@betternotify/sms';
+import { twilioSmsTransport } from '@betternotify/twilio';
+
+const mail = createClient({
+  catalog,
+  channels: { sms: smsChannel() },
+  transportsByChannel: {
+    sms: twilioSmsTransport({
+      accountSid: process.env.TWILIO_SID,
+      authToken: process.env.TWILIO_TOKEN,
+      fromNumber: '+15551234567',
+    }),
+  },
+});
+
+await mail.verification.send({ to: '+15559876543', input: { code: '123456' } });`,
+    features: [
+      'Twilio Messaging API',
+      'Messaging Service SID support',
+      'Comprehensive error code mapping',
+      'Rate limit detection',
+      'Flexible sender configuration',
+    ],
+    docsPath: '/docs/transports/twilio',
+    related: ['slack', 'telegram', 'discord'],
+  },
+  {
+    slug: 'slack',
+    name: 'Slack',
+    channel: 'slack',
+    channelLabel: 'Slack',
+    tagline: 'Send Slack notifications with Better-Notify',
+    description:
+      'Post typed notifications to Slack channels using the Bot API. Supports Block Kit, file uploads, and threading — all type-safe from your catalog.',
+    package: '@betternotify/slack',
+    importStatement: "import { slackChannel, slackTransport } from '@betternotify/slack';",
+    installCmd: 'pnpm add @betternotify/slack',
+    codeExample: `import { createClient } from '@betternotify/core';
+import { slackChannel, slackTransport } from '@betternotify/slack';
+
+const mail = createClient({
+  catalog,
+  channels: { slack: slackChannel() },
+  transportsByChannel: {
+    slack: slackTransport({ token: process.env.SLACK_BOT_TOKEN }),
+  },
+});
+
+await mail.deployNotice.send({
+  to: '#engineering',
+  input: { service: 'api', version: '2.1.0' },
+});`,
+    features: [
+      'Slack Bot API integration',
+      'Block Kit message formatting',
+      'File uploads',
+      'Thread replies via threadTs',
+      'Permalink retrieval',
+    ],
+    docsPath: '/docs/transports/slack',
+    related: ['discord', 'telegram', 'twilio'],
+  },
+  {
+    slug: 'discord',
+    name: 'Discord',
+    channel: 'discord',
+    channelLabel: 'Discord',
+    tagline: 'Send Discord notifications with Better-Notify',
+    description:
+      'Post typed messages to Discord channels via webhooks. Rich embeds, attachments, and custom bot identity — all driven by your notification catalog.',
+    package: '@betternotify/discord',
+    importStatement: "import { discordChannel, discordTransport } from '@betternotify/discord';",
+    installCmd: 'pnpm add @betternotify/discord',
+    codeExample: `import { createClient } from '@betternotify/core';
+import { discordChannel, discordTransport } from '@betternotify/discord';
+
+const mail = createClient({
+  catalog,
+  channels: { discord: discordChannel() },
+  transportsByChannel: {
+    discord: discordTransport({
+      webhookUrl: process.env.DISCORD_WEBHOOK_URL,
+    }),
+  },
+});
+
+await mail.alert.send({
+  to: 'webhook',
+  input: { level: 'critical', message: 'Database latency spike' },
+});`,
+    features: [
+      'Discord Webhook API',
+      'Rich embeds with fields',
+      'File attachments',
+      'Custom username and avatar',
+      'Rate limit handling',
+    ],
+    docsPath: '/docs/transports/discord',
+    related: ['slack', 'telegram', 'twilio'],
+  },
+  {
+    slug: 'telegram',
+    name: 'Telegram',
+    channel: 'telegram',
+    channelLabel: 'Telegram',
+    tagline: 'Send Telegram messages with Better-Notify',
+    description:
+      'Send typed Telegram messages through the Bot API. Text, photos, documents, video, and audio — routed automatically based on your notification content.',
+    package: '@betternotify/telegram',
+    importStatement: "import { telegramChannel, telegramTransport } from '@betternotify/telegram';",
+    installCmd: 'pnpm add @betternotify/telegram',
+    codeExample: `import { createClient } from '@betternotify/core';
+import { telegramChannel, telegramTransport } from '@betternotify/telegram';
+
+const mail = createClient({
+  catalog,
+  channels: { telegram: telegramChannel() },
+  transportsByChannel: {
+    telegram: telegramTransport({ token: process.env.TELEGRAM_BOT_TOKEN }),
+  },
+});
+
+await mail.orderUpdate.send({
+  to: '123456789',
+  input: { orderId: 'ORD-42', status: 'shipped' },
+});`,
+    features: [
+      'Telegram Bot API',
+      'Markdown and HTML parse modes',
+      'Photo, document, video, audio',
+      'Automatic method routing by content type',
+      'Rate limit detection',
+    ],
+    docsPath: '/docs/transports/telegram',
+    related: ['slack', 'discord', 'twilio'],
+  },
+  {
+    slug: 'react-email',
+    name: 'React Email',
+    channel: 'template',
+    channelLabel: 'Template',
+    tagline: 'Build email templates with React Email and Better-Notify',
+    description:
+      'Write email templates as React components and render them through Better-Notify. Full TypeScript support — your template props are type-checked against your notification schema.',
+    package: '@betternotify/react-email',
+    importStatement: "import { reactEmail } from '@betternotify/react-email';",
+    installCmd: 'pnpm add @betternotify/react-email',
+    codeExample: `import { reactEmail } from '@betternotify/react-email';
+import { WelcomeEmail } from './emails/welcome';
+
+const catalog = rpc.catalog({
+  welcome: rpc
+    .email()
+    .input(z.object({ name: z.string() }))
+    .subject(({ input }) => \`Welcome, \${input.name}\`)
+    .template(reactEmail(WelcomeEmail)),
+});`,
+    features: [
+      'React components as email templates',
+      'Type-safe template props',
+      'Automatic HTML and plain text rendering',
+      'Pretty-print HTML option',
+      'Works with any email transport',
+    ],
+    docsPath: '/docs/templates/react-email',
+    related: ['mjml', 'handlebars'],
+  },
+  {
+    slug: 'mjml',
+    name: 'MJML',
+    channel: 'template',
+    channelLabel: 'Template',
+    tagline: 'Build responsive email templates with MJML and Better-Notify',
+    description:
+      'Write responsive email templates in MJML markup and render them through Better-Notify. MJML compiles to bulletproof HTML that works across every email client.',
+    package: '@betternotify/mjml',
+    importStatement: "import { mjmlTemplate } from '@betternotify/mjml';",
+    installCmd: 'pnpm add @betternotify/mjml',
+    codeExample: `import { mjmlTemplate } from '@betternotify/mjml';
+
+const catalog = rpc.catalog({
+  receipt: rpc
+    .email()
+    .input(z.object({ amount: z.number(), orderId: z.string() }))
+    .subject(({ input }) => \`Receipt for order \${input.orderId}\`)
+    .template(mjmlTemplate('./emails/receipt.mjml')),
+});`,
+    features: [
+      'MJML responsive email markup',
+      'Cross-client compatible output',
+      'Handlebars variable interpolation',
+      'Type-safe template bindings',
+      'Works with any email transport',
+    ],
+    docsPath: '/docs/templates/mjml',
+    related: ['react-email', 'handlebars'],
+  },
+  {
+    slug: 'handlebars',
+    name: 'Handlebars',
+    channel: 'template',
+    channelLabel: 'Template',
+    tagline: 'Build email templates with Handlebars and Better-Notify',
+    description:
+      'Use Handlebars templates for simple, logic-light email rendering. Great for teams that prefer HTML templates over component frameworks.',
+    package: '@betternotify/handlebars',
+    importStatement: "import { handlebarsTemplate } from '@betternotify/handlebars';",
+    installCmd: 'pnpm add @betternotify/handlebars',
+    codeExample: `import { handlebarsTemplate } from '@betternotify/handlebars';
+
+const catalog = rpc.catalog({
+  invite: rpc
+    .email()
+    .input(z.object({ inviterName: z.string(), teamName: z.string() }))
+    .subject(({ input }) => \`\${input.inviterName} invited you to \${input.teamName}\`)
+    .template(handlebarsTemplate('./emails/invite.hbs')),
+});`,
+    features: [
+      'Handlebars template syntax',
+      'Partials and helpers',
+      'HTML and plain text output',
+      'Type-safe template context',
+      'Works with any email transport',
+    ],
+    docsPath: '/docs/templates/handlebars',
+    related: ['react-email', 'mjml'],
+  },
+];
+
+export const getIntegration = (slug: string): Integration | undefined =>
+  integrations.find((i) => i.slug === slug);
+
+export const getRelatedIntegrations = (slugs: string[]): Integration[] =>
+  slugs.map((s) => integrations.find((i) => i.slug === s)).filter(Boolean) as Integration[];

--- a/apps/web/src/lib/personas.ts
+++ b/apps/web/src/lib/personas.ts
@@ -70,7 +70,7 @@ router.post('/signup', async (req, res) => {
     description:
       'Better-Notify works anywhere Hono does — Cloudflare Workers, Deno, Bun, or Node.js. Both libraries are ESM-first, TypeScript-native, and designed for edge runtimes.',
     whyFits: [
-      'ESM-only — matches Hono\'s module system',
+      "ESM-only — matches Hono's module system",
       'Runs on Cloudflare Workers, Deno, Bun, Node.js',
       'Lightweight — no heavy dependencies for edge',
       'Cloudflare Email transport for edge-native delivery',
@@ -132,8 +132,8 @@ export default {
       'Add typed notifications to Fastify with zero plugins. Better-Notify runs as a plain import — use it in route handlers, hooks, or background tasks.',
     whyFits: [
       'No Fastify plugin needed — just import',
-      'Matches Fastify\'s schema-first approach',
-      'Works with Fastify\'s TypeBox/Zod validation',
+      "Matches Fastify's schema-first approach",
+      "Works with Fastify's TypeBox/Zod validation",
       'Use in route handlers or lifecycle hooks',
     ],
     codeExample: `// routes/orders.ts

--- a/apps/web/src/lib/personas.ts
+++ b/apps/web/src/lib/personas.ts
@@ -1,0 +1,249 @@
+export type Persona = {
+  slug: string;
+  name: string;
+  tagline: string;
+  description: string;
+  whyFits: string[];
+  codeExample: string;
+  related: string[];
+};
+
+export const personas: Persona[] = [
+  {
+    slug: 'nextjs',
+    name: 'Next.js',
+    tagline: 'Type-safe notifications for Next.js apps',
+    description:
+      'Better-Notify integrates with Next.js API routes, server actions, and middleware. Define your notification catalog once and send from any server-side context — route handlers, server components, or background jobs.',
+    whyFits: [
+      'Works in API routes, server actions, and middleware',
+      'ESM-native — no CJS compatibility issues',
+      'Pairs with React Email for JSX templates',
+      'Deploy to Vercel, Cloudflare, or self-hosted',
+    ],
+    codeExample: `// app/api/invite/route.ts
+import { mail } from '@/lib/notifications';
+
+export async function POST(req: Request) {
+  const { email, teamName } = await req.json();
+
+  const result = await mail.teamInvite.send({
+    to: email,
+    input: { teamName },
+  });
+
+  return Response.json({ messageId: result.messageId });
+}`,
+    related: ['remix', 'express', 'cloudflare-workers'],
+  },
+  {
+    slug: 'express',
+    name: 'Express',
+    tagline: 'Type-safe notifications for Express.js APIs',
+    description:
+      'Add typed notifications to your Express API with zero config. Better-Notify runs as plain Node.js — import the client in any route handler and send.',
+    whyFits: [
+      'No framework middleware needed — just import and send',
+      'Works with Express 4 and 5',
+      'Use in route handlers, middleware, or background workers',
+      'Pairs with any template engine',
+    ],
+    codeExample: `// routes/auth.ts
+import { mail } from '../lib/notifications';
+
+router.post('/signup', async (req, res) => {
+  const user = await createUser(req.body);
+
+  await mail.welcome.send({
+    to: user.email,
+    input: { name: user.name },
+  });
+
+  res.json({ ok: true });
+});`,
+    related: ['fastify', 'hono', 'nestjs'],
+  },
+  {
+    slug: 'hono',
+    name: 'Hono',
+    tagline: 'Type-safe notifications for Hono apps',
+    description:
+      'Better-Notify works anywhere Hono does — Cloudflare Workers, Deno, Bun, or Node.js. Both libraries are ESM-first, TypeScript-native, and designed for edge runtimes.',
+    whyFits: [
+      'ESM-only — matches Hono\'s module system',
+      'Runs on Cloudflare Workers, Deno, Bun, Node.js',
+      'Lightweight — no heavy dependencies for edge',
+      'Cloudflare Email transport for edge-native delivery',
+    ],
+    codeExample: `// src/index.ts
+import { Hono } from 'hono';
+import { mail } from './lib/notifications';
+
+const app = new Hono();
+
+app.post('/contact', async (c) => {
+  const { email, message } = await c.req.json();
+
+  await mail.contactForm.send({
+    to: 'support@example.com',
+    input: { from: email, message },
+  });
+
+  return c.json({ sent: true });
+});
+
+export default app;`,
+    related: ['cloudflare-workers', 'express', 'fastify'],
+  },
+  {
+    slug: 'cloudflare-workers',
+    name: 'Cloudflare Workers',
+    tagline: 'Type-safe notifications at the edge with Cloudflare Workers',
+    description:
+      'Send notifications from Cloudflare Workers using Cloudflare Email Routing or any HTTP-based transport. Better-Notify is ESM-only and works natively in the Workers runtime.',
+    whyFits: [
+      'ESM-only — works in Workers without bundler hacks',
+      'Native Cloudflare Email transport',
+      'No SMTP or TCP sockets required',
+      'Works with Queues for async delivery',
+    ],
+    codeExample: `// src/worker.ts
+import { mail } from './lib/notifications';
+
+export default {
+  async fetch(req: Request): Promise<Response> {
+    const { to, orderId } = await req.json();
+
+    await mail.orderConfirmation.send({
+      to,
+      input: { orderId },
+    });
+
+    return new Response('sent');
+  },
+};`,
+    related: ['hono', 'nextjs', 'remix'],
+  },
+  {
+    slug: 'fastify',
+    name: 'Fastify',
+    tagline: 'Type-safe notifications for Fastify APIs',
+    description:
+      'Add typed notifications to Fastify with zero plugins. Better-Notify runs as a plain import — use it in route handlers, hooks, or background tasks.',
+    whyFits: [
+      'No Fastify plugin needed — just import',
+      'Matches Fastify\'s schema-first approach',
+      'Works with Fastify\'s TypeBox/Zod validation',
+      'Use in route handlers or lifecycle hooks',
+    ],
+    codeExample: `// routes/orders.ts
+import { mail } from '../lib/notifications';
+
+fastify.post('/orders', async (req, reply) => {
+  const order = await createOrder(req.body);
+
+  await mail.orderConfirmation.send({
+    to: order.customerEmail,
+    input: { orderId: order.id, total: order.total },
+  });
+
+  return { orderId: order.id };
+});`,
+    related: ['express', 'hono', 'nestjs'],
+  },
+  {
+    slug: 'nestjs',
+    name: 'NestJS',
+    tagline: 'Type-safe notifications for NestJS applications',
+    description:
+      'Use Better-Notify as a NestJS service. Inject the typed client into controllers, services, or guards — notification routes stay type-safe across your entire dependency tree.',
+    whyFits: [
+      'Works as an injectable service',
+      'Type-safe across the DI container',
+      'Use with NestJS guards and interceptors',
+      'Pairs with NestJS Bull queues for async delivery',
+    ],
+    codeExample: `// notifications.service.ts
+import { Injectable } from '@nestjs/common';
+import { mail } from './notifications.client';
+
+@Injectable()
+export class NotificationsService {
+  async sendWelcome(email: string, name: string) {
+    return mail.welcome.send({
+      to: email,
+      input: { name },
+    });
+  }
+}`,
+    related: ['express', 'fastify'],
+  },
+  {
+    slug: 'trpc',
+    name: 'tRPC',
+    tagline: 'Type-safe notifications for tRPC APIs',
+    description:
+      'Better-Notify follows the same philosophy as tRPC — define a typed contract, consume it everywhere. Use the notification client in any tRPC procedure with full end-to-end type safety.',
+    whyFits: [
+      'Same mental model — typed contracts drive the API',
+      'Use in any tRPC procedure or middleware',
+      'Shares Zod schemas between tRPC and Better-Notify',
+      'End-to-end type safety from router to transport',
+    ],
+    codeExample: `// server/routers/auth.ts
+import { mail } from '../notifications';
+
+export const authRouter = router({
+  signup: publicProcedure
+    .input(z.object({ email: z.string().email(), name: z.string() }))
+    .mutation(async ({ input }) => {
+      const user = await createUser(input);
+
+      await mail.welcome.send({
+        to: user.email,
+        input: { name: user.name },
+      });
+
+      return { userId: user.id };
+    }),
+});`,
+    related: ['nextjs', 'express', 'fastify'],
+  },
+  {
+    slug: 'remix',
+    name: 'Remix',
+    tagline: 'Type-safe notifications for Remix apps',
+    description:
+      'Send notifications from Remix loaders and actions. Better-Notify works in any server-side context — action handlers, resource routes, or background jobs triggered from your Remix app.',
+    whyFits: [
+      'Works in loaders, actions, and resource routes',
+      'ESM-native — no import issues',
+      'Deploy to any Remix-supported platform',
+      'Use React Email for JSX templates',
+    ],
+    codeExample: `// app/routes/contact.tsx
+import { mail } from '~/lib/notifications';
+import type { ActionFunctionArgs } from '@remix-run/node';
+
+export async function action({ request }: ActionFunctionArgs) {
+  const form = await request.formData();
+
+  await mail.contactForm.send({
+    to: 'support@example.com',
+    input: {
+      name: String(form.get('name')),
+      message: String(form.get('message')),
+    },
+  });
+
+  return { sent: true };
+}`,
+    related: ['nextjs', 'express', 'cloudflare-workers'],
+  },
+];
+
+export const getPersona = (slug: string): Persona | undefined =>
+  personas.find((p) => p.slug === slug);
+
+export const getRelatedPersonas = (slugs: string[]): Persona[] =>
+  slugs.map((s) => personas.find((p) => p.slug === s)).filter(Boolean) as Persona[];

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -15,13 +15,9 @@ type SEOParams = {
   image?: string;
   url?: string;
   type?: 'website' | 'article';
-  locale?: string;
   canonicalUrl?: string;
   article?: ArticleParams;
   noIndex?: boolean;
-  noFollow?: boolean;
-  newsKeywords?: string;
-  isNews?: boolean;
 };
 
 type SeoAssetAttributes = Record<string, string | boolean | undefined>;
@@ -48,13 +44,9 @@ export const seo = ({
   image,
   url,
   type = 'website',
-  locale = appConfig.locale.openGraph,
   canonicalUrl,
   article,
   noIndex = false,
-  noFollow = false,
-  newsKeywords,
-  isNews = false,
 }: SEOParams): SeoResult => {
   const safeTitle = truncateTitle(title);
   const safeDescription = truncateDescription(description);
@@ -68,33 +60,20 @@ export const seo = ({
     type === 'article' && article
       ? [
           ...(article.publishedTime
-            ? [
-                {
-                  property: 'article:published_time',
-                  content: article.publishedTime,
-                },
-              ]
+            ? [{ property: 'article:published_time', content: article.publishedTime }]
             : []),
           ...(article.modifiedTime
-            ? [
-                {
-                  property: 'article:modified_time',
-                  content: article.modifiedTime,
-                },
-              ]
+            ? [{ property: 'article:modified_time', content: article.modifiedTime }]
             : []),
           ...(article.author ? [{ property: 'article:author', content: article.author }] : []),
           ...(article.section ? [{ property: 'article:section', content: article.section }] : []),
-          ...(article.tags?.map((tag) => ({
-            property: 'article:tag',
-            content: tag,
-          })) ?? []),
+          ...(article.tags?.map((tag) => ({ property: 'article:tag', content: tag })) ?? []),
         ]
       : [];
 
   const robotsContent = [
     noIndex ? 'noindex' : 'index',
-    noFollow ? 'nofollow' : 'follow',
+    'follow',
     'max-image-preview:large',
     'max-snippet:-1',
     'max-video-preview:-1',
@@ -109,10 +88,8 @@ export const seo = ({
     { property: 'og:site_name', content: appConfig.name },
     { property: 'og:title', content: safeTitle },
     { property: 'og:description', content: safeDescription },
-    { property: 'og:locale', content: locale },
-    { property: 'og:locale:alternate', content: appConfig.locale.openGraph },
+    { property: 'og:locale', content: appConfig.locale.openGraph },
     { property: 'og:image', content: absoluteImage },
-    { property: 'og:image:secure_url', content: absoluteImage },
     { property: 'og:image:alt', content: safeTitle },
     { property: 'og:image:width', content: '1200' },
     { property: 'og:image:height', content: '630' },
@@ -125,49 +102,26 @@ export const seo = ({
     { name: 'twitter:creator', content: appConfig.twitterHandle },
     { name: 'twitter:title', content: safeTitle },
     { name: 'twitter:description', content: safeDescription },
-    { name: 'twitter:domain', content: 'csbot.app' },
+    { name: 'twitter:domain', content: new URL(appConfig.baseUrl).hostname },
     { name: 'twitter:image', content: absoluteImage },
     { name: 'twitter:image:alt', content: safeTitle },
 
     { name: 'robots', content: robotsContent },
-    { name: 'googlebot', content: robotsContent },
-    { name: 'googlebot-news', content: isNews ? 'index, follow' : 'noindex' },
-    { name: 'bingbot', content: noIndex ? 'noindex' : 'index, follow' },
-    ...(newsKeywords ? [{ name: 'news_keywords', content: newsKeywords }] : []),
-    ...(isNews
-      ? [
-          { name: 'syndication-source', content: url ?? appConfig.baseUrl },
-          { name: 'original-source', content: url ?? appConfig.baseUrl },
-        ]
-      : []),
     { name: 'author', content: article?.author ?? appConfig.name },
-    { name: 'creator', content: appConfig.name },
-    { name: 'publisher', content: appConfig.name },
-    {
-      name: 'viewport',
-      content: 'width=device-width, initial-scale=1, viewport-fit=cover',
-    },
     { name: 'theme-color', content: appConfig.themeColor },
-    { name: 'format-detection', content: 'telephone=no' },
-    { name: 'mobile-web-app-capable', content: 'yes' },
-    { name: 'apple-mobile-web-app-capable', content: 'yes' },
-    {
-      name: 'apple-mobile-web-app-status-bar-style',
-      content: 'black-translucent',
-    },
-    { name: 'apple-mobile-web-app-title', content: appConfig.name },
-    { name: 'generator', content: 'TanStack Start' },
-    { name: 'referrer', content: 'origin-when-cross-origin' },
     { name: 'color-scheme', content: 'dark light' },
-    { name: 'rating', content: 'general' },
-    { name: 'revisit-after', content: '1 day' },
-    { httpEquiv: 'x-ua-compatible', content: 'IE=edge' },
-    { httpEquiv: 'content-language', content: appConfig.locale.bcp47 },
+    { name: 'referrer', content: 'origin-when-cross-origin' },
   ];
 
   const canonicalHref: string | undefined = canonicalUrl ?? url;
   const links: SeoAssetAttributes[] = [
-    ...(canonicalHref ? [{ rel: 'canonical', href: canonicalHref }] : []),
+    ...(canonicalHref
+      ? [
+          { rel: 'canonical', href: canonicalHref },
+          { rel: 'alternate', hrefLang: appConfig.locale.bcp47, href: canonicalHref },
+          { rel: 'alternate', hrefLang: 'x-default', href: canonicalHref },
+        ]
+      : []),
     { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
     {
       rel: 'preconnect',
@@ -176,18 +130,6 @@ export const seo = ({
     },
     { rel: 'dns-prefetch', href: 'https://fonts.googleapis.com' },
     { rel: 'dns-prefetch', href: 'https://fonts.gstatic.com' },
-    { rel: 'preconnect', href: 'https://www.googletagmanager.com' },
-    { rel: 'dns-prefetch', href: 'https://www.googletagmanager.com' },
-    {
-      rel: 'alternate',
-      hrefLang: appConfig.locale.bcp47,
-      href: canonicalHref ?? appConfig.baseUrl,
-    },
-    {
-      rel: 'alternate',
-      hrefLang: 'x-default',
-      href: canonicalHref ?? appConfig.baseUrl,
-    },
   ];
 
   return { meta, links };

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,9 +14,13 @@ import { Route as RobotsDottxtRouteImport } from './routes/robots[.]txt'
 import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
 import { Route as LlmsFullDottxtRouteImport } from './routes/llms-full[.]txt'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as IntegrationsIndexRouteImport } from './routes/integrations/index'
+import { Route as ForIndexRouteImport } from './routes/for/index'
 import { Route as BlogIndexRouteImport } from './routes/blog/index'
 import { Route as PhSplatRouteImport } from './routes/ph.$'
 import { Route as OgSplatRouteImport } from './routes/og.$'
+import { Route as IntegrationsSlugRouteImport } from './routes/integrations/$slug'
+import { Route as ForSlugRouteImport } from './routes/for/$slug'
 import { Route as DocsSplatRouteImport } from './routes/docs/$'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 import { Route as ApiSearchRouteImport } from './routes/api/search'
@@ -47,6 +51,16 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const IntegrationsIndexRoute = IntegrationsIndexRouteImport.update({
+  id: '/integrations/',
+  path: '/integrations/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ForIndexRoute = ForIndexRouteImport.update({
+  id: '/for/',
+  path: '/for/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const BlogIndexRoute = BlogIndexRouteImport.update({
   id: '/blog/',
   path: '/blog/',
@@ -60,6 +74,16 @@ const PhSplatRoute = PhSplatRouteImport.update({
 const OgSplatRoute = OgSplatRouteImport.update({
   id: '/og/$',
   path: '/og/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const IntegrationsSlugRoute = IntegrationsSlugRouteImport.update({
+  id: '/integrations/$slug',
+  path: '/integrations/$slug',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ForSlugRoute = ForSlugRouteImport.update({
+  id: '/for/$slug',
+  path: '/for/$slug',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DocsSplatRoute = DocsSplatRouteImport.update({
@@ -92,9 +116,13 @@ export interface FileRoutesByFullPath {
   '/api/search': typeof ApiSearchRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
+  '/for/$slug': typeof ForSlugRoute
+  '/integrations/$slug': typeof IntegrationsSlugRoute
   '/og/$': typeof OgSplatRoute
   '/ph/$': typeof PhSplatRoute
   '/blog/': typeof BlogIndexRoute
+  '/for/': typeof ForIndexRoute
+  '/integrations/': typeof IntegrationsIndexRoute
   '/llms.mdx/docs/$': typeof LlmsDotmdxDocsSplatRoute
 }
 export interface FileRoutesByTo {
@@ -106,9 +134,13 @@ export interface FileRoutesByTo {
   '/api/search': typeof ApiSearchRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
+  '/for/$slug': typeof ForSlugRoute
+  '/integrations/$slug': typeof IntegrationsSlugRoute
   '/og/$': typeof OgSplatRoute
   '/ph/$': typeof PhSplatRoute
   '/blog': typeof BlogIndexRoute
+  '/for': typeof ForIndexRoute
+  '/integrations': typeof IntegrationsIndexRoute
   '/llms.mdx/docs/$': typeof LlmsDotmdxDocsSplatRoute
 }
 export interface FileRoutesById {
@@ -121,9 +153,13 @@ export interface FileRoutesById {
   '/api/search': typeof ApiSearchRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
+  '/for/$slug': typeof ForSlugRoute
+  '/integrations/$slug': typeof IntegrationsSlugRoute
   '/og/$': typeof OgSplatRoute
   '/ph/$': typeof PhSplatRoute
   '/blog/': typeof BlogIndexRoute
+  '/for/': typeof ForIndexRoute
+  '/integrations/': typeof IntegrationsIndexRoute
   '/llms.mdx/docs/$': typeof LlmsDotmdxDocsSplatRoute
 }
 export interface FileRouteTypes {
@@ -137,9 +173,13 @@ export interface FileRouteTypes {
     | '/api/search'
     | '/blog/$slug'
     | '/docs/$'
+    | '/for/$slug'
+    | '/integrations/$slug'
     | '/og/$'
     | '/ph/$'
     | '/blog/'
+    | '/for/'
+    | '/integrations/'
     | '/llms.mdx/docs/$'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -151,9 +191,13 @@ export interface FileRouteTypes {
     | '/api/search'
     | '/blog/$slug'
     | '/docs/$'
+    | '/for/$slug'
+    | '/integrations/$slug'
     | '/og/$'
     | '/ph/$'
     | '/blog'
+    | '/for'
+    | '/integrations'
     | '/llms.mdx/docs/$'
   id:
     | '__root__'
@@ -165,9 +209,13 @@ export interface FileRouteTypes {
     | '/api/search'
     | '/blog/$slug'
     | '/docs/$'
+    | '/for/$slug'
+    | '/integrations/$slug'
     | '/og/$'
     | '/ph/$'
     | '/blog/'
+    | '/for/'
+    | '/integrations/'
     | '/llms.mdx/docs/$'
   fileRoutesById: FileRoutesById
 }
@@ -180,9 +228,13 @@ export interface RootRouteChildren {
   ApiSearchRoute: typeof ApiSearchRoute
   BlogSlugRoute: typeof BlogSlugRoute
   DocsSplatRoute: typeof DocsSplatRoute
+  ForSlugRoute: typeof ForSlugRoute
+  IntegrationsSlugRoute: typeof IntegrationsSlugRoute
   OgSplatRoute: typeof OgSplatRoute
   PhSplatRoute: typeof PhSplatRoute
   BlogIndexRoute: typeof BlogIndexRoute
+  ForIndexRoute: typeof ForIndexRoute
+  IntegrationsIndexRoute: typeof IntegrationsIndexRoute
   LlmsDotmdxDocsSplatRoute: typeof LlmsDotmdxDocsSplatRoute
 }
 
@@ -223,6 +275,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/integrations/': {
+      id: '/integrations/'
+      path: '/integrations'
+      fullPath: '/integrations/'
+      preLoaderRoute: typeof IntegrationsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/for/': {
+      id: '/for/'
+      path: '/for'
+      fullPath: '/for/'
+      preLoaderRoute: typeof ForIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/blog/': {
       id: '/blog/'
       path: '/blog'
@@ -242,6 +308,20 @@ declare module '@tanstack/react-router' {
       path: '/og/$'
       fullPath: '/og/$'
       preLoaderRoute: typeof OgSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/integrations/$slug': {
+      id: '/integrations/$slug'
+      path: '/integrations/$slug'
+      fullPath: '/integrations/$slug'
+      preLoaderRoute: typeof IntegrationsSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/for/$slug': {
+      id: '/for/$slug'
+      path: '/for/$slug'
+      fullPath: '/for/$slug'
+      preLoaderRoute: typeof ForSlugRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/docs/$': {
@@ -284,9 +364,13 @@ const rootRouteChildren: RootRouteChildren = {
   ApiSearchRoute: ApiSearchRoute,
   BlogSlugRoute: BlogSlugRoute,
   DocsSplatRoute: DocsSplatRoute,
+  ForSlugRoute: ForSlugRoute,
+  IntegrationsSlugRoute: IntegrationsSlugRoute,
   OgSplatRoute: OgSplatRoute,
   PhSplatRoute: PhSplatRoute,
   BlogIndexRoute: BlogIndexRoute,
+  ForIndexRoute: ForIndexRoute,
+  IntegrationsIndexRoute: IntegrationsIndexRoute,
   LlmsDotmdxDocsSplatRoute: LlmsDotmdxDocsSplatRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -15,8 +15,8 @@ import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
 import { Route as LlmsFullDottxtRouteImport } from './routes/llms-full[.]txt'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as BlogIndexRouteImport } from './routes/blog/index'
+import { Route as PhSplatRouteImport } from './routes/ph.$'
 import { Route as OgSplatRouteImport } from './routes/og.$'
-import { Route as IngestSplatRouteImport } from './routes/ingest.$'
 import { Route as DocsSplatRouteImport } from './routes/docs/$'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 import { Route as ApiSearchRouteImport } from './routes/api/search'
@@ -52,14 +52,14 @@ const BlogIndexRoute = BlogIndexRouteImport.update({
   path: '/blog/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const PhSplatRoute = PhSplatRouteImport.update({
+  id: '/ph/$',
+  path: '/ph/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const OgSplatRoute = OgSplatRouteImport.update({
   id: '/og/$',
   path: '/og/$',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const IngestSplatRoute = IngestSplatRouteImport.update({
-  id: '/ingest/$',
-  path: '/ingest/$',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DocsSplatRoute = DocsSplatRouteImport.update({
@@ -92,8 +92,8 @@ export interface FileRoutesByFullPath {
   '/api/search': typeof ApiSearchRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
-  '/ingest/$': typeof IngestSplatRoute
   '/og/$': typeof OgSplatRoute
+  '/ph/$': typeof PhSplatRoute
   '/blog/': typeof BlogIndexRoute
   '/llms.mdx/docs/$': typeof LlmsDotmdxDocsSplatRoute
 }
@@ -106,8 +106,8 @@ export interface FileRoutesByTo {
   '/api/search': typeof ApiSearchRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
-  '/ingest/$': typeof IngestSplatRoute
   '/og/$': typeof OgSplatRoute
+  '/ph/$': typeof PhSplatRoute
   '/blog': typeof BlogIndexRoute
   '/llms.mdx/docs/$': typeof LlmsDotmdxDocsSplatRoute
 }
@@ -121,8 +121,8 @@ export interface FileRoutesById {
   '/api/search': typeof ApiSearchRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
-  '/ingest/$': typeof IngestSplatRoute
   '/og/$': typeof OgSplatRoute
+  '/ph/$': typeof PhSplatRoute
   '/blog/': typeof BlogIndexRoute
   '/llms.mdx/docs/$': typeof LlmsDotmdxDocsSplatRoute
 }
@@ -137,8 +137,8 @@ export interface FileRouteTypes {
     | '/api/search'
     | '/blog/$slug'
     | '/docs/$'
-    | '/ingest/$'
     | '/og/$'
+    | '/ph/$'
     | '/blog/'
     | '/llms.mdx/docs/$'
   fileRoutesByTo: FileRoutesByTo
@@ -151,8 +151,8 @@ export interface FileRouteTypes {
     | '/api/search'
     | '/blog/$slug'
     | '/docs/$'
-    | '/ingest/$'
     | '/og/$'
+    | '/ph/$'
     | '/blog'
     | '/llms.mdx/docs/$'
   id:
@@ -165,8 +165,8 @@ export interface FileRouteTypes {
     | '/api/search'
     | '/blog/$slug'
     | '/docs/$'
-    | '/ingest/$'
     | '/og/$'
+    | '/ph/$'
     | '/blog/'
     | '/llms.mdx/docs/$'
   fileRoutesById: FileRoutesById
@@ -180,8 +180,8 @@ export interface RootRouteChildren {
   ApiSearchRoute: typeof ApiSearchRoute
   BlogSlugRoute: typeof BlogSlugRoute
   DocsSplatRoute: typeof DocsSplatRoute
-  IngestSplatRoute: typeof IngestSplatRoute
   OgSplatRoute: typeof OgSplatRoute
+  PhSplatRoute: typeof PhSplatRoute
   BlogIndexRoute: typeof BlogIndexRoute
   LlmsDotmdxDocsSplatRoute: typeof LlmsDotmdxDocsSplatRoute
 }
@@ -230,18 +230,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof BlogIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/ph/$': {
+      id: '/ph/$'
+      path: '/ph/$'
+      fullPath: '/ph/$'
+      preLoaderRoute: typeof PhSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/og/$': {
       id: '/og/$'
       path: '/og/$'
       fullPath: '/og/$'
       preLoaderRoute: typeof OgSplatRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/ingest/$': {
-      id: '/ingest/$'
-      path: '/ingest/$'
-      fullPath: '/ingest/$'
-      preLoaderRoute: typeof IngestSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/docs/$': {
@@ -284,8 +284,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiSearchRoute: ApiSearchRoute,
   BlogSlugRoute: BlogSlugRoute,
   DocsSplatRoute: DocsSplatRoute,
-  IngestSplatRoute: IngestSplatRoute,
   OgSplatRoute: OgSplatRoute,
+  PhSplatRoute: PhSplatRoute,
   BlogIndexRoute: BlogIndexRoute,
   LlmsDotmdxDocsSplatRoute: LlmsDotmdxDocsSplatRoute,
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -9,7 +9,7 @@ import { seo } from '@/lib/seo';
 import { usePosthogClient } from '@/hooks/use-posthog-client';
 
 function BaseProviders({ children }: { children: ReactNode }) {
-  return <RootProvider theme={{ disableTransitionOnChange: false }}>{children}</RootProvider>;
+  return <RootProvider theme={{ disableTransitionOnChange: true }}>{children}</RootProvider>;
 }
 
 function AnalyticsProvider({ children }: { children: ReactNode }) {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -35,13 +35,12 @@ export const Route = createRootRoute({
       keywords:
         'notifications, email, node.js, typescript, type-safe, email infrastructure, transactional email, zapier, cloudflare, better-notify, cloudflare emails, telegram, twilio, push notifications',
       image: `${appConfig.baseUrl}/og/image.png`,
-      url: appConfig.baseUrl,
-      canonicalUrl: appConfig.baseUrl,
     });
 
     return {
       meta: [
         { charSet: 'utf-8' },
+        { name: 'viewport', content: 'width=device-width, initial-scale=1, viewport-fit=cover' },
         { name: 'application-name', content: appConfig.name },
         ...seoMeta,
       ],

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -31,7 +31,7 @@ export const Route = createRootRoute({
     const { meta: seoMeta, links: seoLinks } = seo({
       title: `${appConfig.name}: Typed Notifications for Node.js`,
       description:
-        'Type-safe email, SMS, and push notification infrastructure for Node.js. Define once, send everywhere with full TypeScript support.',
+        'Type-safe notification infrastructure for Node.js. Send email, SMS, Telegram, Slack, and Discord from one typed catalog with full TypeScript support.',
       keywords:
         'notifications, email, node.js, typescript, type-safe, email infrastructure, transactional email, zapier, cloudflare, better-notify, cloudflare emails, telegram, twilio, push notifications',
       image: `${appConfig.baseUrl}/og/image.png`,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -33,7 +33,7 @@ export const Route = createRootRoute({
       description:
         'Type-safe notification infrastructure for Node.js. Send email, SMS, Telegram, Slack, and Discord from one typed catalog with full TypeScript support.',
       keywords:
-        'notifications, email, node.js, typescript, type-safe, email infrastructure, transactional email, zapier, cloudflare, better-notify, cloudflare emails, telegram, twilio, push notifications',
+        'better-notify, betternotify, typed notifications, notification library nodejs, notification infrastructure, transactional email nodejs, send email nodejs, sms nodejs, telegram bot nodejs, slack notifications, discord webhooks, multi-channel notifications, typescript notifications, notification sdk, smtp nodejs, resend, cloudflare email, twilio sms, mailchimp transactional, type-safe api, notification catalog',
       image: `${appConfig.baseUrl}/og/image.png`,
     });
 

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -16,7 +16,7 @@ export const Route = createFileRoute('/blog/$slug')({
   component: BlogArticlePage,
   loader: async ({ params }) => {
     const data = await serverLoader({ data: params.slug });
-    await clientLoader.preload(data.path);
+    if (typeof window !== 'undefined') await clientLoader.preload(data.path);
     return data;
   },
   head: ({ loaderData }) => {
@@ -169,7 +169,19 @@ function BlogArticlePage() {
               </div>
             )}
           </header>
-          <Suspense>{clientLoader.useContent(loaderData.path)}</Suspense>
+          <Suspense
+            fallback={
+              <div className="animate-pulse space-y-4">
+                <div className="h-4 w-full rounded bg-fd-muted" />
+                <div className="h-4 w-5/6 rounded bg-fd-muted" />
+                <div className="h-4 w-4/6 rounded bg-fd-muted" />
+                <div className="mt-6 h-4 w-full rounded bg-fd-muted" />
+                <div className="h-4 w-3/4 rounded bg-fd-muted" />
+              </div>
+            }
+          >
+            {clientLoader.useContent(loaderData.path)}
+          </Suspense>
         </article>
       </main>
       <Footer />

--- a/apps/web/src/routes/docs/$.tsx
+++ b/apps/web/src/routes/docs/$.tsx
@@ -19,7 +19,7 @@ export const Route = createFileRoute('/docs/$')({
   loader: async ({ params }) => {
     const slugs = params._splat?.split('/') ?? [];
     const data = await serverLoader({ data: slugs });
-    await clientLoader.preload(data.path);
+    if (typeof window !== 'undefined') await clientLoader.preload(data.path);
     return data;
   },
   head: ({ loaderData }) => {
@@ -125,7 +125,25 @@ function Page() {
           style: { '--fd-banner-height': 'var(--landing-header-height, 0px)' } as React.CSSProperties,
         }}
       >
-        <Suspense>{clientLoader.useContent(data.path)}</Suspense>
+        <Suspense
+          fallback={
+            <div className="w-full max-w-[860px] animate-pulse space-y-6 px-6 pt-8">
+              <div className="h-9 w-2/3 rounded bg-fd-muted" />
+              <div className="h-4 w-1/3 rounded bg-fd-muted" />
+              <div className="mt-6 space-y-3">
+                <div className="h-4 w-full rounded bg-fd-muted" />
+                <div className="h-4 w-5/6 rounded bg-fd-muted" />
+                <div className="h-4 w-4/6 rounded bg-fd-muted" />
+              </div>
+              <div className="mt-4 space-y-3">
+                <div className="h-4 w-full rounded bg-fd-muted" />
+                <div className="h-4 w-3/4 rounded bg-fd-muted" />
+              </div>
+            </div>
+          }
+        >
+          {clientLoader.useContent(data.path)}
+        </Suspense>
       </DocsLayout>
     </>
   );

--- a/apps/web/src/routes/docs/$.tsx
+++ b/apps/web/src/routes/docs/$.tsx
@@ -127,15 +127,14 @@ function Page() {
       >
         <Suspense
           fallback={
-            <div className="w-full max-w-[860px] animate-pulse space-y-6 px-6 pt-8">
-              <div className="h-9 w-2/3 rounded bg-fd-muted" />
-              <div className="h-4 w-1/3 rounded bg-fd-muted" />
-              <div className="mt-6 space-y-3">
+            <div className="w-full max-w-[860px] space-y-6 px-6 pt-8">
+              <h1 className="text-3xl font-bold text-fd-foreground">{pageTitle}</h1>
+              <div className="animate-pulse space-y-3">
                 <div className="h-4 w-full rounded bg-fd-muted" />
                 <div className="h-4 w-5/6 rounded bg-fd-muted" />
                 <div className="h-4 w-4/6 rounded bg-fd-muted" />
               </div>
-              <div className="mt-4 space-y-3">
+              <div className="animate-pulse space-y-3">
                 <div className="h-4 w-full rounded bg-fd-muted" />
                 <div className="h-4 w-3/4 rounded bg-fd-muted" />
               </div>

--- a/apps/web/src/routes/for/$slug.tsx
+++ b/apps/web/src/routes/for/$slug.tsx
@@ -1,0 +1,144 @@
+import { createFileRoute, Link, notFound } from '@tanstack/react-router';
+import { createServerFn } from '@tanstack/react-start';
+import { LandingHeader } from '@/components/landing/header';
+import { Footer } from '@/components/landing/footer';
+import { seo } from '@/lib/seo';
+import { appConfig } from '@/lib/shared';
+import { getPersona, getRelatedPersonas } from '@/lib/personas';
+import { CaretRightIcon, CheckCircleIcon, ArrowRightIcon } from '@phosphor-icons/react';
+
+export const Route = createFileRoute('/for/$slug')({
+  component: PersonaPage,
+  loader: async ({ params }) => {
+    return await serverLoader({ data: params.slug });
+  },
+  head: ({ loaderData }) => {
+    if (!loaderData) return { meta: [], links: [] };
+    const url = `${appConfig.baseUrl}/for/${loaderData.slug}`;
+    const { meta, links } = seo({
+      title: `${appConfig.name} for ${loaderData.name} — Type-safe Notifications`,
+      description: loaderData.tagline,
+      url,
+      canonicalUrl: url,
+      keywords: `${loaderData.name.toLowerCase()} notifications, ${loaderData.name.toLowerCase()} email, ${loaderData.name.toLowerCase()} sms, better-notify ${loaderData.name.toLowerCase()}`,
+    });
+    return {
+      meta,
+      links,
+      scripts: [
+        {
+          type: 'application/ld+json',
+          children: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'WebPage',
+            name: `${appConfig.name} for ${loaderData.name}`,
+            url,
+            description: loaderData.tagline,
+            about: {
+              '@type': 'SoftwareApplication',
+              name: appConfig.name,
+              applicationCategory: 'DeveloperApplication',
+            },
+          }),
+        },
+      ],
+    };
+  },
+});
+
+const serverLoader = createServerFn({ method: 'GET' })
+  .inputValidator((slug: string) => slug)
+  .handler(({ data: slug }) => {
+    const persona = getPersona(slug);
+    if (!persona) throw notFound();
+    const related = getRelatedPersonas(persona.related);
+    return { ...persona, relatedPersonas: related };
+  });
+
+function PersonaPage() {
+  const data = Route.useLoaderData();
+
+  return (
+    <>
+      <LandingHeader />
+      <main className="mx-auto w-full max-w-[860px] px-5 py-12 md:px-8">
+        <nav aria-label="Breadcrumb" className="mb-8">
+          <ol className="text-muted-foreground flex list-none items-center gap-1.5 p-0 text-sm">
+            <li>
+              <Link to="/for" className="hover:text-foreground no-underline transition-colors">
+                Frameworks
+              </Link>
+            </li>
+            <li aria-hidden="true">
+              <CaretRightIcon size={12} className="text-border" />
+            </li>
+            <li className="text-foreground font-medium">{data.name}</li>
+          </ol>
+        </nav>
+
+        <header className="mb-10">
+          <h1 className="text-foreground mb-3 text-3xl font-bold tracking-tight md:text-4xl">
+            {appConfig.name} for {data.name}
+          </h1>
+          <p className="text-muted-foreground text-lg leading-relaxed">{data.description}</p>
+        </header>
+
+        <section className="mb-12">
+          <h2 className="text-foreground mb-4 text-xl font-semibold">Why it fits</h2>
+          <ul className="space-y-2">
+            {data.whyFits.map((reason) => (
+              <li key={reason} className="text-muted-foreground flex items-start gap-2 text-sm">
+                <CheckCircleIcon size={16} weight="fill" className="text-foreground mt-0.5 shrink-0" />
+                {reason}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-foreground mb-4 text-xl font-semibold">Example</h2>
+          <pre className="overflow-x-auto rounded-lg bg-fd-muted p-4 text-sm leading-relaxed">
+            <code>{data.codeExample}</code>
+          </pre>
+        </section>
+
+        <div className="mb-12 flex flex-wrap gap-3">
+          <a
+            href="/docs/get-started/quick-start"
+            className="bg-foreground text-background inline-flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium no-underline transition-colors hover:opacity-90"
+          >
+            Get started
+            <ArrowRightIcon size={14} />
+          </a>
+          <a
+            href="/integrations"
+            className="border-border text-foreground inline-flex items-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-medium no-underline transition-colors hover:bg-fd-muted"
+          >
+            Browse integrations
+            <ArrowRightIcon size={14} />
+          </a>
+        </div>
+
+        {data.relatedPersonas.length > 0 && (
+          <section className="border-border border-t pt-10">
+            <h2 className="text-foreground mb-4 text-lg font-semibold">Also works with</h2>
+            <div className="grid gap-3 sm:grid-cols-3">
+              {data.relatedPersonas.map((r) => (
+                <Link
+                  key={r.slug}
+                  to="/for/$slug"
+                  params={{ slug: r.slug }}
+                  className="border-border hover:border-foreground/20 rounded-lg border p-4 no-underline transition-colors"
+                >
+                  <span className="text-foreground text-sm font-semibold">{r.name}</span>
+                  <span className="text-muted-foreground mt-1 block text-xs">{r.tagline}</span>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/apps/web/src/routes/for/$slug.tsx
+++ b/apps/web/src/routes/for/$slug.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link, notFound } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
+import { z } from 'zod';
 import { LandingHeader } from '@/components/landing/header';
 import { Footer } from '@/components/landing/footer';
 import { seo } from '@/lib/seo';
@@ -47,7 +48,7 @@ export const Route = createFileRoute('/for/$slug')({
 });
 
 const serverLoader = createServerFn({ method: 'GET' })
-  .inputValidator((slug: string) => slug)
+  .validator(z.string().min(1))
   .handler(({ data: slug }) => {
     const persona = getPersona(slug);
     if (!persona) throw notFound();
@@ -88,7 +89,11 @@ function PersonaPage() {
           <ul className="space-y-2">
             {data.whyFits.map((reason) => (
               <li key={reason} className="text-muted-foreground flex items-start gap-2 text-sm">
-                <CheckCircleIcon size={16} weight="fill" className="text-foreground mt-0.5 shrink-0" />
+                <CheckCircleIcon
+                  size={16}
+                  weight="fill"
+                  className="text-foreground mt-0.5 shrink-0"
+                />
                 {reason}
               </li>
             ))}

--- a/apps/web/src/routes/for/$slug.tsx
+++ b/apps/web/src/routes/for/$slug.tsx
@@ -6,6 +6,9 @@ import { Footer } from '@/components/landing/footer';
 import { seo } from '@/lib/seo';
 import { appConfig } from '@/lib/shared';
 import { getPersona, getRelatedPersonas } from '@/lib/personas';
+import { highlightCode } from '@/lib/highlight';
+import { CodeEditor } from '@/components/code-editor';
+import { Button } from '@/components/ui/button';
 import { CaretRightIcon, CheckCircleIcon, ArrowRightIcon } from '@phosphor-icons/react';
 
 export const Route = createFileRoute('/for/$slug')({
@@ -21,7 +24,7 @@ export const Route = createFileRoute('/for/$slug')({
       description: loaderData.tagline,
       url,
       canonicalUrl: url,
-      keywords: `${loaderData.name.toLowerCase()} notifications, ${loaderData.name.toLowerCase()} email, ${loaderData.name.toLowerCase()} sms, better-notify ${loaderData.name.toLowerCase()}`,
+      keywords: `${loaderData.name.toLowerCase()} notifications, ${loaderData.name.toLowerCase()} send email, ${loaderData.name.toLowerCase()} sms, ${loaderData.name.toLowerCase()} notification library, better-notify ${loaderData.name.toLowerCase()}, typed notifications ${loaderData.name.toLowerCase()}`,
     });
     return {
       meta,
@@ -48,12 +51,13 @@ export const Route = createFileRoute('/for/$slug')({
 });
 
 const serverLoader = createServerFn({ method: 'GET' })
-  .validator(z.string().min(1))
+  .inputValidator(z.string().min(1))
   .handler(({ data: slug }) => {
     const persona = getPersona(slug);
     if (!persona) throw notFound();
     const related = getRelatedPersonas(persona.related);
-    return { ...persona, relatedPersonas: related };
+    const highlighted = highlightCode(persona.codeExample);
+    return { ...persona, relatedPersonas: related, highlighted };
   });
 
 function PersonaPage() {
@@ -102,9 +106,7 @@ function PersonaPage() {
 
         <section className="mb-12">
           <h2 className="text-foreground mb-4 text-xl font-semibold">Example</h2>
-          <pre className="overflow-x-auto rounded-lg bg-fd-muted p-4 text-sm leading-relaxed">
-            <code>{data.codeExample}</code>
-          </pre>
+          <CodeEditor html={data.highlighted.html} filename={data.highlighted.filename} />
         </section>
 
         <div className="mb-12 flex flex-wrap gap-3">

--- a/apps/web/src/routes/for/index.tsx
+++ b/apps/web/src/routes/for/index.tsx
@@ -16,7 +16,7 @@ export const Route = createFileRoute('/for/')({
       url,
       canonicalUrl: url,
       keywords:
-        'nodejs notifications, nextjs email, express notifications, hono email, cloudflare workers email, fastify notifications, nestjs notifications',
+        'nodejs notification library, notification sdk nodejs, nextjs send email, express notifications, hono notifications, cloudflare workers email, fastify email, nestjs notifications, trpc notifications, remix email, typed notifications framework',
     });
     return { meta, links };
   },

--- a/apps/web/src/routes/for/index.tsx
+++ b/apps/web/src/routes/for/index.tsx
@@ -1,0 +1,56 @@
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { LandingHeader } from '@/components/landing/header';
+import { Footer } from '@/components/landing/footer';
+import { seo } from '@/lib/seo';
+import { appConfig } from '@/lib/shared';
+import { personas } from '@/lib/personas';
+
+export const Route = createFileRoute('/for/')({
+  component: PersonasPage,
+  head: () => {
+    const url = `${appConfig.baseUrl}/for`;
+    const { meta, links } = seo({
+      title: `Better-Notify for your stack — ${appConfig.name}`,
+      description:
+        'Type-safe notifications for Next.js, Express, Hono, Cloudflare Workers, Fastify, NestJS, tRPC, and Remix. See how Better-Notify fits your framework.',
+      url,
+      canonicalUrl: url,
+      keywords:
+        'nodejs notifications, nextjs email, express notifications, hono email, cloudflare workers email, fastify notifications, nestjs notifications',
+    });
+    return { meta, links };
+  },
+});
+
+function PersonasPage() {
+  return (
+    <>
+      <LandingHeader />
+      <main className="mx-auto w-full max-w-[1200px] px-5 py-16 md:px-8">
+        <header className="mb-16 text-center">
+          <h1 className="text-foreground mb-4 text-4xl font-bold tracking-tight md:text-5xl">
+            Better-Notify for your stack
+          </h1>
+          <p className="text-muted-foreground mx-auto max-w-[560px] text-lg leading-relaxed">
+            One library, any framework. See how Better-Notify fits the tools you already use.
+          </p>
+        </header>
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {personas.map((persona) => (
+            <Link
+              key={persona.slug}
+              to="/for/$slug"
+              params={{ slug: persona.slug }}
+              className="border-border hover:border-foreground/20 group rounded-lg border p-5 no-underline transition-colors"
+            >
+              <h2 className="text-foreground mb-2 text-base font-semibold">{persona.name}</h2>
+              <p className="text-muted-foreground text-sm leading-relaxed">{persona.tagline}</p>
+            </Link>
+          ))}
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute('/')({
     const { meta, links } = seo({
       title: `${appConfig.name}: Typed Notifications for Node.js`,
       description:
-        'Type-safe email, SMS, and push notification infrastructure for Node.js. Define once, send everywhere with full TypeScript support.',
+        'Type-safe notification infrastructure for Node.js. Send email, SMS, Telegram, Slack, and Discord from one typed catalog with full TypeScript support.',
       url: appConfig.baseUrl,
       canonicalUrl: appConfig.baseUrl,
     });

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -14,11 +14,47 @@ import { BlogAndAuthor } from '@/components/landing/author';
 import { Footer } from '@/components/landing/footer';
 import { Marquee } from '@/components/landing/marquee';
 import { getLatestBlogPosts } from '@/lib/blog-source';
+import { seo } from '@/lib/seo';
+import { appConfig } from '@/lib/shared';
 
 export const Route = createFileRoute('/')({
   component: LandingPage,
   loader: async () => {
     return await getLatestPosts();
+  },
+  head: () => {
+    const { meta, links } = seo({
+      title: `${appConfig.name}: Typed Notifications for Node.js`,
+      description:
+        'Type-safe email, SMS, and push notification infrastructure for Node.js. Define once, send everywhere with full TypeScript support.',
+      url: appConfig.baseUrl,
+      canonicalUrl: appConfig.baseUrl,
+    });
+    return {
+      meta,
+      links,
+      scripts: [
+        {
+          type: 'application/ld+json',
+          children: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'SoftwareApplication',
+            name: appConfig.name,
+            url: appConfig.baseUrl,
+            applicationCategory: 'DeveloperApplication',
+            operatingSystem: 'Node.js',
+            description:
+              'Type-safe notification infrastructure for Node.js. Define once, send everywhere with full TypeScript support.',
+            offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+            author: {
+              '@type': 'Organization',
+              name: appConfig.name,
+              url: appConfig.baseUrl,
+            },
+          }),
+        },
+      ],
+    };
   },
 });
 

--- a/apps/web/src/routes/integrations/$slug.tsx
+++ b/apps/web/src/routes/integrations/$slug.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link, notFound } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
+import { z } from 'zod';
 import { LandingHeader } from '@/components/landing/header';
 import { Footer } from '@/components/landing/footer';
 import { seo } from '@/lib/seo';
@@ -45,7 +46,7 @@ export const Route = createFileRoute('/integrations/$slug')({
 });
 
 const serverLoader = createServerFn({ method: 'GET' })
-  .inputValidator((slug: string) => slug)
+  .validator(z.string().min(1))
   .handler(({ data: slug }) => {
     const integration = getIntegration(slug);
     if (!integration) throw notFound();
@@ -63,7 +64,10 @@ function IntegrationPage() {
         <nav aria-label="Breadcrumb" className="mb-8">
           <ol className="text-muted-foreground flex list-none items-center gap-1.5 p-0 text-sm">
             <li>
-              <Link to="/integrations" className="hover:text-foreground no-underline transition-colors">
+              <Link
+                to="/integrations"
+                className="hover:text-foreground no-underline transition-colors"
+              >
                 Integrations
               </Link>
             </li>
@@ -103,7 +107,11 @@ function IntegrationPage() {
           <ul className="space-y-2">
             {data.features.map((feature) => (
               <li key={feature} className="text-muted-foreground flex items-start gap-2 text-sm">
-                <CheckCircleIcon size={16} weight="fill" className="text-foreground mt-0.5 shrink-0" />
+                <CheckCircleIcon
+                  size={16}
+                  weight="fill"
+                  className="text-foreground mt-0.5 shrink-0"
+                />
                 {feature}
               </li>
             ))}

--- a/apps/web/src/routes/integrations/$slug.tsx
+++ b/apps/web/src/routes/integrations/$slug.tsx
@@ -6,6 +6,10 @@ import { Footer } from '@/components/landing/footer';
 import { seo } from '@/lib/seo';
 import { appConfig } from '@/lib/shared';
 import { getIntegration, getRelatedIntegrations } from '@/lib/integrations';
+import { highlightCode } from '@/lib/highlight';
+import { CodeEditor } from '@/components/code-editor';
+import { PackageInstall } from '@/components/package-install';
+import { Button } from '@/components/ui/button';
 import { CaretRightIcon, CheckCircleIcon, ArrowRightIcon } from '@phosphor-icons/react';
 
 export const Route = createFileRoute('/integrations/$slug')({
@@ -21,7 +25,7 @@ export const Route = createFileRoute('/integrations/$slug')({
       description: loaderData.tagline,
       url,
       canonicalUrl: url,
-      keywords: `${loaderData.name.toLowerCase()} nodejs, ${loaderData.name.toLowerCase()} notifications, better-notify ${loaderData.name.toLowerCase()}`,
+      keywords: `${loaderData.name.toLowerCase()} nodejs, ${loaderData.name.toLowerCase()} notifications, ${loaderData.name.toLowerCase()} typescript, better-notify ${loaderData.name.toLowerCase()}, send ${loaderData.channelLabel.toLowerCase()} ${loaderData.name.toLowerCase()}, ${loaderData.name.toLowerCase()} integration`,
     });
     return {
       meta,
@@ -46,12 +50,13 @@ export const Route = createFileRoute('/integrations/$slug')({
 });
 
 const serverLoader = createServerFn({ method: 'GET' })
-  .validator(z.string().min(1))
+  .inputValidator(z.string().min(1))
   .handler(({ data: slug }) => {
     const integration = getIntegration(slug);
     if (!integration) throw notFound();
     const related = getRelatedIntegrations(integration.related);
-    return { ...integration, relatedIntegrations: related };
+    const highlighted = highlightCode(integration.codeExample);
+    return { ...integration, relatedIntegrations: related, highlighted };
   });
 
 function IntegrationPage() {
@@ -90,16 +95,12 @@ function IntegrationPage() {
 
         <section className="mb-12">
           <h2 className="text-foreground mb-4 text-xl font-semibold">Install</h2>
-          <pre className="overflow-x-auto rounded-lg bg-fd-muted p-4 text-sm">
-            <code>{data.installCmd}</code>
-          </pre>
+          <PackageInstall pkg={data.package} />
         </section>
 
         <section className="mb-12">
           <h2 className="text-foreground mb-4 text-xl font-semibold">Quick start</h2>
-          <pre className="overflow-x-auto rounded-lg bg-fd-muted p-4 text-sm leading-relaxed">
-            <code>{data.codeExample}</code>
-          </pre>
+          <CodeEditor html={data.highlighted.html} filename={data.highlighted.filename} />
         </section>
 
         <section className="mb-12">

--- a/apps/web/src/routes/integrations/$slug.tsx
+++ b/apps/web/src/routes/integrations/$slug.tsx
@@ -1,0 +1,152 @@
+import { createFileRoute, Link, notFound } from '@tanstack/react-router';
+import { createServerFn } from '@tanstack/react-start';
+import { LandingHeader } from '@/components/landing/header';
+import { Footer } from '@/components/landing/footer';
+import { seo } from '@/lib/seo';
+import { appConfig } from '@/lib/shared';
+import { getIntegration, getRelatedIntegrations } from '@/lib/integrations';
+import { CaretRightIcon, CheckCircleIcon, ArrowRightIcon } from '@phosphor-icons/react';
+
+export const Route = createFileRoute('/integrations/$slug')({
+  component: IntegrationPage,
+  loader: async ({ params }) => {
+    return await serverLoader({ data: params.slug });
+  },
+  head: ({ loaderData }) => {
+    if (!loaderData) return { meta: [], links: [] };
+    const url = `${appConfig.baseUrl}/integrations/${loaderData.slug}`;
+    const { meta, links } = seo({
+      title: `${loaderData.name} Integration — ${appConfig.name}`,
+      description: loaderData.tagline,
+      url,
+      canonicalUrl: url,
+      keywords: `${loaderData.name.toLowerCase()} nodejs, ${loaderData.name.toLowerCase()} notifications, better-notify ${loaderData.name.toLowerCase()}`,
+    });
+    return {
+      meta,
+      links,
+      scripts: [
+        {
+          type: 'application/ld+json',
+          children: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'SoftwareApplication',
+            name: `${appConfig.name} ${loaderData.name} Integration`,
+            url,
+            applicationCategory: 'DeveloperApplication',
+            operatingSystem: 'Node.js',
+            description: loaderData.tagline,
+            offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+          }),
+        },
+      ],
+    };
+  },
+});
+
+const serverLoader = createServerFn({ method: 'GET' })
+  .inputValidator((slug: string) => slug)
+  .handler(({ data: slug }) => {
+    const integration = getIntegration(slug);
+    if (!integration) throw notFound();
+    const related = getRelatedIntegrations(integration.related);
+    return { ...integration, relatedIntegrations: related };
+  });
+
+function IntegrationPage() {
+  const data = Route.useLoaderData();
+
+  return (
+    <>
+      <LandingHeader />
+      <main className="mx-auto w-full max-w-[860px] px-5 py-12 md:px-8">
+        <nav aria-label="Breadcrumb" className="mb-8">
+          <ol className="text-muted-foreground flex list-none items-center gap-1.5 p-0 text-sm">
+            <li>
+              <Link to="/integrations" className="hover:text-foreground no-underline transition-colors">
+                Integrations
+              </Link>
+            </li>
+            <li aria-hidden="true">
+              <CaretRightIcon size={12} className="text-border" />
+            </li>
+            <li className="text-foreground font-medium">{data.name}</li>
+          </ol>
+        </nav>
+
+        <header className="mb-10">
+          <span className="text-muted-foreground mb-2 inline-block rounded-md bg-fd-muted px-2.5 py-1 text-xs font-medium">
+            {data.channelLabel}
+          </span>
+          <h1 className="text-foreground mb-3 text-3xl font-bold tracking-tight md:text-4xl">
+            {data.name} + {appConfig.name}
+          </h1>
+          <p className="text-muted-foreground text-lg leading-relaxed">{data.description}</p>
+        </header>
+
+        <section className="mb-12">
+          <h2 className="text-foreground mb-4 text-xl font-semibold">Install</h2>
+          <pre className="overflow-x-auto rounded-lg bg-fd-muted p-4 text-sm">
+            <code>{data.installCmd}</code>
+          </pre>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-foreground mb-4 text-xl font-semibold">Quick start</h2>
+          <pre className="overflow-x-auto rounded-lg bg-fd-muted p-4 text-sm leading-relaxed">
+            <code>{data.codeExample}</code>
+          </pre>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-foreground mb-4 text-xl font-semibold">Features</h2>
+          <ul className="space-y-2">
+            {data.features.map((feature) => (
+              <li key={feature} className="text-muted-foreground flex items-start gap-2 text-sm">
+                <CheckCircleIcon size={16} weight="fill" className="text-foreground mt-0.5 shrink-0" />
+                {feature}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <div className="mb-12 flex flex-wrap gap-3">
+          <a
+            href={data.docsPath}
+            className="border-border text-foreground inline-flex items-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-medium no-underline transition-colors hover:bg-fd-muted"
+          >
+            Read the docs
+            <ArrowRightIcon size={14} />
+          </a>
+          <a
+            href="/docs/get-started/quick-start"
+            className="bg-foreground text-background inline-flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium no-underline transition-colors hover:opacity-90"
+          >
+            Get started
+            <ArrowRightIcon size={14} />
+          </a>
+        </div>
+
+        {data.relatedIntegrations.length > 0 && (
+          <section className="border-border border-t pt-10">
+            <h2 className="text-foreground mb-4 text-lg font-semibold">Related integrations</h2>
+            <div className="grid gap-3 sm:grid-cols-3">
+              {data.relatedIntegrations.map((r) => (
+                <Link
+                  key={r.slug}
+                  to="/integrations/$slug"
+                  params={{ slug: r.slug }}
+                  className="border-border hover:border-foreground/20 rounded-lg border p-4 no-underline transition-colors"
+                >
+                  <span className="text-foreground text-sm font-semibold">{r.name}</span>
+                  <span className="text-muted-foreground mt-1 block text-xs">{r.channelLabel}</span>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/apps/web/src/routes/integrations/index.tsx
+++ b/apps/web/src/routes/integrations/index.tsx
@@ -1,0 +1,83 @@
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { LandingHeader } from '@/components/landing/header';
+import { Footer } from '@/components/landing/footer';
+import { seo } from '@/lib/seo';
+import { appConfig } from '@/lib/shared';
+import { integrations } from '@/lib/integrations';
+
+export const Route = createFileRoute('/integrations/')({
+  component: IntegrationsPage,
+  head: () => {
+    const url = `${appConfig.baseUrl}/integrations`;
+    const { meta, links } = seo({
+      title: `Integrations — ${appConfig.name}`,
+      description:
+        'Connect Better-Notify to SMTP, Resend, Cloudflare Email, Twilio, Slack, Discord, Telegram, and more. Type-safe notifications with any provider.',
+      url,
+      canonicalUrl: url,
+      keywords:
+        'better-notify integrations, email api nodejs, sms api nodejs, slack notifications, discord webhooks, telegram bot nodejs',
+    });
+    return { meta, links };
+  },
+});
+
+const channelGroups = [
+  { label: 'Email', channel: 'email' },
+  { label: 'SMS', channel: 'sms' },
+  { label: 'Messaging', channel: 'slack' },
+  { label: 'Templates', channel: 'template' },
+] as const;
+
+function IntegrationsPage() {
+  return (
+    <>
+      <LandingHeader />
+      <main className="mx-auto w-full max-w-[1200px] px-5 py-16 md:px-8">
+        <header className="mb-16 text-center">
+          <h1 className="text-foreground mb-4 text-4xl font-bold tracking-tight md:text-5xl">
+            Integrations
+          </h1>
+          <p className="text-muted-foreground mx-auto max-w-[560px] text-lg leading-relaxed">
+            Connect Better-Notify to the providers you already use. One catalog, any transport.
+          </p>
+        </header>
+
+        {channelGroups.map((group) => {
+          const items = integrations.filter((i) =>
+            group.channel === 'slack'
+              ? ['slack', 'discord', 'telegram'].includes(i.channel)
+              : i.channel === group.channel,
+          );
+          if (items.length === 0) return null;
+          return (
+            <section key={group.channel} className="mb-14">
+              <h2 className="text-foreground mb-6 text-2xl font-semibold">{group.label}</h2>
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {items.map((integration) => (
+                  <Link
+                    key={integration.slug}
+                    to="/integrations/$slug"
+                    params={{ slug: integration.slug }}
+                    className="border-border hover:border-foreground/20 group rounded-lg border p-5 no-underline transition-colors"
+                  >
+                    <h3 className="text-foreground mb-1 text-base font-semibold">
+                      {integration.name}
+                    </h3>
+                    <span className="text-muted-foreground mb-3 inline-block rounded-md bg-fd-muted px-2 py-0.5 text-xs">
+                      {integration.channelLabel}
+                    </span>
+                    <p className="text-muted-foreground text-sm leading-relaxed">
+                      {integration.tagline}
+                    </p>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          );
+        })}
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/apps/web/src/routes/integrations/index.tsx
+++ b/apps/web/src/routes/integrations/index.tsx
@@ -16,7 +16,7 @@ export const Route = createFileRoute('/integrations/')({
       url,
       canonicalUrl: url,
       keywords:
-        'better-notify integrations, email api nodejs, sms api nodejs, slack notifications, discord webhooks, telegram bot nodejs',
+        'better-notify integrations, notification providers nodejs, email api nodejs, sms api nodejs, slack bot nodejs, discord webhook nodejs, telegram bot api nodejs, smtp transport, resend api, cloudflare email routing',
     });
     return { meta, links };
   },

--- a/apps/web/src/routes/ph.$.ts
+++ b/apps/web/src/routes/ph.$.ts
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 
-const POSTHOG_HOST = 'https://eu.posthog.com';
+const POSTHOG_HOST = 'https://eu.i.posthog.com';
 
 const proxy = async (request: Request): Promise<Response> => {
   const url = new URL(request.url);

--- a/apps/web/src/routes/ph.$.ts
+++ b/apps/web/src/routes/ph.$.ts
@@ -4,7 +4,7 @@ const POSTHOG_HOST = 'https://eu.posthog.com';
 
 const proxy = async (request: Request): Promise<Response> => {
   const url = new URL(request.url);
-  const path = url.pathname.replace(/^\/ingest/, '');
+  const path = url.pathname.replace(/^\/ph/, '');
   const target = `${POSTHOG_HOST}${path}${url.search}`;
 
   const headers = new Headers(request.headers);
@@ -30,7 +30,7 @@ const proxy = async (request: Request): Promise<Response> => {
   }
 };
 
-export const Route = createFileRoute('/ingest/$')({
+export const Route = createFileRoute('/ph/$')({
   server: {
     handlers: {
       GET: ({ request }) => proxy(request),

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -2,6 +2,8 @@ import { createFileRoute } from '@tanstack/react-router';
 
 import { appConfig } from '@/lib/shared';
 import { source } from '@/lib/source';
+import { integrations } from '@/lib/integrations';
+import { personas } from '@/lib/personas';
 
 export const Route = createFileRoute('/sitemap.xml')({
   server: {
@@ -16,6 +18,18 @@ export const Route = createFileRoute('/sitemap.xml')({
             loc: `${appConfig.baseUrl}${page.url}`,
             changefreq: 'weekly',
             priority: '0.7',
+          })),
+          { loc: `${appConfig.baseUrl}/integrations`, changefreq: 'weekly', priority: '0.8' },
+          ...integrations.map((i) => ({
+            loc: `${appConfig.baseUrl}/integrations/${i.slug}`,
+            changefreq: 'monthly',
+            priority: '0.6',
+          })),
+          { loc: `${appConfig.baseUrl}/for`, changefreq: 'weekly', priority: '0.8' },
+          ...personas.map((p) => ({
+            loc: `${appConfig.baseUrl}/for/${p.slug}`,
+            changefreq: 'monthly',
+            priority: '0.6',
           })),
         ];
 

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -49,9 +49,9 @@
   --color-bn-warning-500: oklch(75% 0.16 85);
   --color-bn-warning-700: oklch(58% 0.14 85);
 
-  --font-sans: 'Manrope', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --font-sans: 'Manrope', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', 'Roboto', sans-serif;
   --font-mono:
-    'JetBrains Mono', ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace;
+    'JetBrains Mono', ui-monospace, 'SF Mono', 'Cascadia Code', 'Menlo', 'Consolas', monospace;
   --font-display: 'Manrope', ui-sans-serif, system-ui, sans-serif;
 
   --shadow-bn-xs: 0 1px 1px 0 oklch(20% 0.02 258 / 0.04);

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -230,6 +230,14 @@
   --sidebar-ring: var(--color-bn-navy-500);
 }
 
+.dark .shiki,
+[data-theme='dark'] .shiki,
+.dark .shiki span,
+[data-theme='dark'] .shiki span {
+  color: var(--shiki-dark) !important;
+  background-color: var(--shiki-dark-bg) !important;
+}
+
 .dark,
 [data-theme='dark'] {
   --hero-fade: var(--color-bn-slate-950);

--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -1,10 +1,10 @@
-@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap');
+@import '@fontsource-variable/manrope';
+@import '@fontsource-variable/jetbrains-mono';
 @import 'tailwindcss';
 @import 'fumadocs-ui/css/neutral.css';
 @import 'fumadocs-ui/css/preset.css';
 @import 'tw-animate-css';
 @import 'shadcn/tailwind.css';
-@import '@fontsource-variable/inter';
 
 @custom-variant dark (&:where(.dark, .dark *));
 
@@ -49,10 +49,10 @@
   --color-bn-warning-500: oklch(75% 0.16 85);
   --color-bn-warning-700: oklch(58% 0.14 85);
 
-  --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --font-sans: 'Manrope', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   --font-mono:
     'JetBrains Mono', ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace;
-  --font-display: 'Inter', ui-sans-serif, system-ui, sans-serif;
+  --font-display: 'Manrope', ui-sans-serif, system-ui, sans-serif;
 
   --shadow-bn-xs: 0 1px 1px 0 oklch(20% 0.02 258 / 0.04);
   --shadow-bn-sm: 0 1px 2px 0 oklch(20% 0.02 258 / 0.06), 0 1px 1px 0 oklch(20% 0.02 258 / 0.04);

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -9,20 +9,20 @@ export default defineConfig({
   server: {
     port: 4265,
     proxy: {
-      '/ingest/static': {
+      '/ph/static': {
         target: 'https://eu-assets.i.posthog.com',
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/ingest/, ''),
+        rewrite: (path) => path.replace(/^\/ph/, ''),
       },
-      '/ingest/array': {
+      '/ph/array': {
         target: 'https://eu-assets.i.posthog.com',
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/ingest/, ''),
+        rewrite: (path) => path.replace(/^\/ph/, ''),
       },
-      '/ingest': {
+      '/ph': {
         target: 'https://eu.i.posthog.com',
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/ingest/, ''),
+        rewrite: (path) => path.replace(/^\/ph/, ''),
       },
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,7 +170,10 @@ importers:
       '@base-ui/react':
         specifier: ^1.4.1
         version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@fontsource-variable/inter':
+      '@fontsource-variable/jetbrains-mono':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource-variable/manrope':
         specifier: ^5.2.8
         version: 5.2.8
       '@libs/ui':
@@ -2202,8 +2205,11 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@fontsource-variable/inter@5.2.8':
-    resolution: {integrity: sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==}
+  '@fontsource-variable/jetbrains-mono@5.2.8':
+    resolution: {integrity: sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==}
+
+  '@fontsource-variable/manrope@5.2.8':
+    resolution: {integrity: sha512-nc9lOuCRz73UHnovDE2bwXUdghE2SEOc7Aii0qGe3CLyE03W1a7VnY5Z6euRiapiKbCkGS+eXbY3s/kvWeGeSw==}
 
   '@fumadocs/tailwind@0.0.5':
     resolution: {integrity: sha512-ENKPWUDRmriccsrUDE4bDBq3FNr/ms3BP2rWlsAEMV1yP23pcCaan+ceGfeBUsAQjw7sj9Q3R4Kl3g/TCStPzQ==}
@@ -8499,7 +8505,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@fontsource-variable/inter@5.2.8': {}
+  '@fontsource-variable/jetbrains-mono@5.2.8': {}
+
+  '@fontsource-variable/manrope@5.2.8': {}
 
   '@fumadocs/tailwind@0.0.5(@tailwindcss/oxide@4.2.4)(tailwindcss@4.2.4)':
     optionalDependencies:


### PR DESCRIPTION
# Overview

Fix content flickering on docs/blog pages and rename the PostHog analytics proxy route from `/ingest` to `/ph`.

# What's changed and why?

- **`apps/web/src/routes/docs/$.tsx`** — Added Suspense skeleton fallback and guarded `clientLoader.preload()` to client-only (fixes SSR stream timeout and content flash)
- **`apps/web/src/routes/blog/$slug.tsx`** — Same Suspense fallback and client-only preload guard
- **`apps/web/src/routes/__root.tsx`** — Set `disableTransitionOnChange: true` to prevent theme hydration flash
- **`apps/web/src/routes/ingest.$.ts` → `ph.$.ts`** — Renamed PostHog proxy route from `/ingest` to `/ph`
- **`apps/web/src/hooks/use-posthog-client.ts`** — Updated PostHog `api_host` to `/ph`
- **`apps/web/vite.config.ts`** — Updated dev proxy entries from `/ingest` to `/ph`
- **`apps/web/src/styles/app.css`** — Switched font from Inter to Manrope
- **`apps/web/content/blog/.../introducing-betternotify.mdx`** — Removed shipped template adapters from roadmap
- **`apps/web/src/routeTree.gen.ts`** — Auto-regenerated by TanStack Router

# How to test

1. Run `pnpm dev` and open `/docs` — content should show a skeleton loader instead of a blank flash
2. Navigate between doc pages — no flicker
3. Verify PostHog events still fire (check Network tab for `/ph/` requests)

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Better-Notify roadmap: queue/worker support, webhook router, and batch send optimizations.
  * Added Integrations and Personas catalog and detail pages with install guides, examples, related links, and sitemap entries.
  * Landing and content pages now emit structured data and show animated skeletons while loading.

* **Bug Fixes / Platform**
  * PostHog proxy and client ingestion endpoint moved to /ph.

* **Style**
  * Typography switched to Manrope + JetBrains Mono; viewport meta added and theme transition behavior reduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->