### PR TITLE
fix: replace release-as with auto-bump in release-please config

### DIFF
--- a/apps/web/src/components/landing/footer.tsx
+++ b/apps/web/src/components/landing/footer.tsx
@@ -7,7 +7,6 @@ const navColumns = [
   {
     title: 'Product',
     links: [
-      { label: 'Features', href: '#features' },
       { label: 'Integrations', href: '/integrations' },
       { label: 'Frameworks', href: '/for' },
       { label: 'Changelog', href: '/docs/changelog' },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-as": "1.0.0-beta.1",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "prerelease": true,
   "include-component-in-tag": true,
   "separate-pull-requests": false,


### PR DESCRIPTION
# Overview

Fix duplicate release tag error caused by `release-as` pinning every release to `1.0.0-beta.1`.

# What's changed and why?

- **`release-please-config.json`**: Removed `release-as: 1.0.0-beta.1` (one-shot override that was never cleaned up after the initial beta release) and restored `bump-minor-pre-major` + `bump-patch-for-minor-pre-major` so versions auto-increment.

# How to test

1. Merge this PR
2. Push a conventional commit to `main`
3. Verify release-please creates a release PR with `beta.2` (not `beta.1`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Removed the "Features" navigation link from the landing page footer. Integrations now appears as the primary Product navigation option.

* **Chores**
  * Updated release versioning configuration to enable additional automated version bump behaviors for improved release management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->