### PR TITLE
fix(web): remove conditional PostHogProvider to prevent layout flicker

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,7 +20,6 @@
     "@fontsource-variable/manrope": "^5.2.8",
     "@libs/ui": "workspace:*",
     "@phosphor-icons/react": "catalog:",
-    "@posthog/react": "1.9.0",
     "@takumi-rs/image-response": "catalog:",
     "@tanstack/react-router": "catalog:",
     "@tanstack/react-start": "catalog:",

--- a/apps/web/src/hooks/use-analytics.ts
+++ b/apps/web/src/hooks/use-analytics.ts
@@ -1,4 +1,4 @@
-import { usePostHog } from '@posthog/react';
+import posthog from 'posthog-js';
 
 export type ActionTypes =
   | 'accept'
@@ -58,15 +58,15 @@ export type ActionTypes =
   | 'write';
 
 export const useAnalytics = (component: string) => {
-  const ph = usePostHog();
-
   return {
     track: (track?: string) => ({
       action: (action: ActionTypes, data?: Record<string, unknown>) => {
+        if (!posthog.__loaded) return;
+
         const event =
           component && track ? `${component}.${track}.${action}` : `${component}.${action}`;
 
-        return ph?.capture(event, data);
+        return posthog.capture(event, data);
       },
     }),
   };

--- a/apps/web/src/hooks/use-analytics.ts
+++ b/apps/web/src/hooks/use-analytics.ts
@@ -1,5 +1,7 @@
 import posthog from 'posthog-js';
 
+import { isPosthogReady } from '@/hooks/use-posthog-client';
+
 export type ActionTypes =
   | 'accept'
   | 'add'
@@ -61,7 +63,7 @@ export const useAnalytics = (component: string) => {
   return {
     track: (track?: string) => ({
       action: (action: ActionTypes, data?: Record<string, unknown>) => {
-        if (!posthog.__loaded) return;
+        if (!isPosthogReady()) return;
 
         const event =
           component && track ? `${component}.${track}.${action}` : `${component}.${action}`;

--- a/apps/web/src/hooks/use-posthog-client.ts
+++ b/apps/web/src/hooks/use-posthog-client.ts
@@ -1,24 +1,13 @@
-import posthog, { PostHog } from 'posthog-js';
-import { useEffect, useState } from 'react';
+import posthog from 'posthog-js';
+import { useEffect } from 'react';
 
-export const usePosthogClient = () => {
-  const [client, setClient] = useState<PostHog | undefined>(() => {
-    if (typeof window === 'undefined') return undefined;
-    if (posthog.__loaded) return posthog;
-    return undefined;
-  });
-
+export function usePosthogInit() {
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
     const posthogKey = import.meta.env.VITE_PUBLIC_POSTHOG_PROJECT_TOKEN;
 
-    if (!posthogKey) return;
-
-    if (posthog.__loaded) {
-      setClient(posthog);
-      return;
-    }
+    if (!posthogKey || posthog.__loaded) return;
 
     posthog.init(posthogKey, {
       api_host: '/ph',
@@ -28,9 +17,6 @@ export const usePosthogClient = () => {
       capture_pageview: true,
       capture_pageleave: true,
       disable_session_recording: true,
-      loaded: (ph) => setClient(ph as PostHog),
     });
   }, []);
-
-  return { client };
-};
+}

--- a/apps/web/src/hooks/use-posthog-client.ts
+++ b/apps/web/src/hooks/use-posthog-client.ts
@@ -1,13 +1,19 @@
 import posthog from 'posthog-js';
 import { useEffect } from 'react';
 
+let initialized = false;
+
+export const isPosthogReady = () => initialized;
+
 export const usePosthogInit = () => {
   useEffect(() => {
-    if (typeof window === 'undefined') return;
+    if (typeof window === 'undefined' || initialized) return;
 
     const posthogKey = import.meta.env.VITE_PUBLIC_POSTHOG_PROJECT_TOKEN;
 
-    if (!posthogKey || posthog.__loaded) return;
+    if (!posthogKey) return;
+
+    initialized = true;
 
     posthog.init(posthogKey, {
       api_host: '/ph',

--- a/apps/web/src/hooks/use-posthog-client.ts
+++ b/apps/web/src/hooks/use-posthog-client.ts
@@ -1,7 +1,7 @@
 import posthog from 'posthog-js';
 import { useEffect } from 'react';
 
-export function usePosthogInit() {
+export const usePosthogInit = () => {
   useEffect(() => {
     if (typeof window === 'undefined') return;
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,29 +1,15 @@
 import type { ReactNode } from 'react';
 import { createRootRoute, HeadContent, Outlet, Scripts } from '@tanstack/react-router';
 import { RootProvider } from 'fumadocs-ui/provider/tanstack';
-import { PostHogProvider } from '@posthog/react';
 
 import appCss from '@/styles/app.css?url';
 import { appConfig, GOOGLE_ANALYTICS_ID } from '@/lib/shared';
 import { seo } from '@/lib/seo';
-import { usePosthogClient } from '@/hooks/use-posthog-client';
+import { usePosthogInit } from '@/hooks/use-posthog-client';
 
-function BaseProviders({ children }: { children: ReactNode }) {
+function Providers({ children }: { children: ReactNode }) {
+  usePosthogInit();
   return <RootProvider theme={{ disableTransitionOnChange: true }}>{children}</RootProvider>;
-}
-
-function AnalyticsProvider({ children }: { children: ReactNode }) {
-  const { client } = usePosthogClient();
-
-  if (!client) {
-    return <BaseProviders>{children}</BaseProviders>;
-  }
-
-  return (
-    <PostHogProvider client={client}>
-      <BaseProviders>{children}</BaseProviders>
-    </PostHogProvider>
-  );
 }
 
 export const Route = createRootRoute({
@@ -88,9 +74,9 @@ function RootComponent() {
         <HeadContent />
       </head>
       <body className="flex min-h-screen flex-col">
-        <AnalyticsProvider>
+        <Providers>
           <Outlet />
-        </AnalyticsProvider>
+        </Providers>
         <Scripts />
       </body>
     </html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,9 +182,6 @@ importers:
       '@phosphor-icons/react':
         specifier: 'catalog:'
         version: 2.1.10(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@posthog/react':
-        specifier: 1.9.0
-        version: 1.9.0(@types/react@19.2.14)(posthog-js@1.372.9)(react@19.2.5)
       '@takumi-rs/image-response':
         specifier: 'catalog:'
         version: 1.1.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -3031,16 +3028,6 @@ packages:
 
   '@posthog/core@1.28.3':
     resolution: {integrity: sha512-SOy0aphKawZzp8jxfeOpTcXPwi6ii0I2V6tX8YXnM+WbxKKR/R+BXLK0jS6LV8kZtW3H5YxmPAfuIbUP1UnGTw==}
-
-  '@posthog/react@1.9.0':
-    resolution: {integrity: sha512-lVdTsWT5+PtHBu44gSQ7QohbLjAYqHkFAIGAQ+HV8Eh9yj+OcnQ7mXCmyhaMlTBD3z7D0H1eWMp4vQaFnsIyWQ==}
-    peerDependencies:
-      '@types/react': '>=16.8.0'
-      posthog-js: '>=1.257.2'
-      react: '>=16.8.0'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
 
   '@posthog/types@1.372.9':
     resolution: {integrity: sha512-B7k9S+H9WUKHXxe1HOkQWbpWtMcrBvsodm5stZaLQ3pYxf9TowtwssdzTtX4hHjzSYqgrS1IpNnJX4vs1KgBzA==}
@@ -9161,13 +9148,6 @@ snapshots:
   '@posthog/core@1.28.3':
     dependencies:
       '@posthog/types': 1.372.9
-
-  '@posthog/react@1.9.0(@types/react@19.2.14)(posthog-js@1.372.9)(react@19.2.5)':
-    dependencies:
-      posthog-js: 1.372.9
-      react: 19.2.5
-    optionalDependencies:
-      '@types/react': 19.2.14
 
   '@posthog/types@1.372.9': {}
 


### PR DESCRIPTION
## Summary
- Removes `@posthog/react` provider wrapping that conditionally changed the React tree structure when PostHog loaded async, potentially causing a full tree remount
- Replaces `usePosthogClient` (stateful) with `usePosthogInit` (fire-and-forget effect) — no re-renders on init
- `useAnalytics` now uses the `posthog` singleton directly instead of the `usePostHog()` context hook
- Removes `@posthog/react` dependency entirely

## Test plan
- [ ] Deploy preview and verify landing page loads without content flicker
- [ ] Verify PostHog events still fire (check PostHog dashboard for pageview/click events)
- [ ] Check docs pages load without flicker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized analytics initialization and switched to the core analytics library for global setup; provider wiring is now handled at app root.
* **Chores**
  * Removed the previous React-specific analytics dependency.
* **Notes**
  * No changes to visible analytics behavior or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->