### PR TITLE
docs(web): refactor get-started docs and update hero CTA

### DIFF
--- a/apps/web/content/blog/announcements/introducing-betternotify.mdx
+++ b/apps/web/content/blog/announcements/introducing-betternotify.mdx
@@ -154,6 +154,6 @@ Or add Better-Notify to an existing project:
 @betternotify/core @betternotify/email @betternotify/smtp zod
 ```
 
-Read the [quick start guide](/docs/get-started/quick-start) to send your first notification in under five minutes.
+Read [Your First Email](/docs/get-started/quick-start) to send your first notification in under five minutes.
 
 The full source is on [GitHub](https://github.com/better-notify/better-notify) — issues, PRs, and feedback welcome.

--- a/apps/web/content/docs/concepts/catalog-and-procedures.mdx
+++ b/apps/web/content/docs/concepts/catalog-and-procedures.mdx
@@ -334,5 +334,5 @@ const rpc = createNotify({ channels: { email } })
 After `.use()`, the `Ctx` type parameter narrows. Every procedure in the catalog can access `ctx.tenantId`, and the type system enforces that the middleware provides it. Multiple `.use()` calls chain — each one merges its additions into the context type.
 
 <Callout>
-For a full walkthrough of building procedures, merging catalogs, and a working client from scratch, see the [Quick Start](/docs/get-started/quick-start).
+For a full walkthrough of building procedures, merging catalogs, and a working client from scratch, see [Your First Email](/docs/get-started/quick-start).
 </Callout>

--- a/apps/web/content/docs/get-started/installation.mdx
+++ b/apps/web/content/docs/get-started/installation.mdx
@@ -12,8 +12,8 @@ Better-Notify is ESM-only and requires Node `>= 22`.
 
 The CLI scaffolds a project with channels, routes, a typed client, and a working transport — ready to send.
 
-```package-install
-create-better-notify@latest
+```sh
+npx create-better-notify@latest
 ```
 
 The CLI walks you through channel selection (email, SMS, push), transport provider, and schema library. When it finishes, you get a project with this structure:

--- a/apps/web/content/docs/get-started/installation.mdx
+++ b/apps/web/content/docs/get-started/installation.mdx
@@ -6,11 +6,39 @@ description: Install Better-Notify and its dependencies
 
 import { Step, Steps } from 'fumadocs-ui/components/steps';
 
-Use this page to install Better-Notify for the channel you want to start with.
-
 Better-Notify is ESM-only and requires Node `>= 22`.
 
-## Choose a channel
+## Scaffold with the CLI
+
+The CLI scaffolds a project with channels, routes, a typed client, and a working transport — ready to send.
+
+```package-install
+create-better-notify@latest
+```
+
+The CLI walks you through channel selection (email, SMS, push), transport provider, and schema library. When it finishes, you get a project with this structure:
+
+```
+src/
+  notifications/
+    channel.ts     # channel definition with defaults
+    routes.ts      # routes grouped into sub-catalogs
+    client.ts      # typed client wired to your transport
+  index.ts         # entry point — sends a test notification
+.env               # provider credentials
+```
+
+Run the generated project to send your first notification:
+
+```sh
+npx tsx src/index.ts
+```
+
+The [Your First Email](/docs/get-started/quick-start) walkthrough explains what each file does.
+
+## Manual setup
+
+To install manually, follow the steps below.
 
 <Tabs items={['Email', 'SMS', 'Push']} defaultIndex={0}>
   <Tab value="email">
@@ -20,9 +48,9 @@ Better-Notify is ESM-only and requires Node `>= 22`.
 
 ### Confirm your runtime
 
-Make sure your app is running on Node `22` or newer.
+Use Node `22` or newer.
 
-If you are starting from scratch, your `package.json` should also use ESM:
+For new projects, set ESM in `package.json`:
 
 ```json
 {
@@ -35,50 +63,84 @@ If you are starting from scratch, your `package.json` should also use ESM:
 
 ### Install the packages
 
-If you are following the email + SMTP path from the intro and quick start, install these packages:
-
 ```package-install
 @betternotify/core @betternotify/email @betternotify/smtp zod
 ```
 
-`@betternotify/core` gives you `createNotify()` and `createClient()`. `@betternotify/email` gives you the email channel. `@betternotify/smtp` gives you the SMTP transport. `zod` defines the route input schemas used throughout the docs examples.
+`@betternotify/core` exports `createNotify()` and `createClient()`. `@betternotify/email` adds the email channel. `@betternotify/smtp` adds the SMTP transport. `zod` defines route input schemas used throughout these docs.
 
   </Step>
   <Step>
 
 ### Add SMTP credentials
 
-The examples assume you will provide SMTP credentials through environment variables:
+Create a `.env` file with your SMTP credentials:
 
-```sh
+```sh title=".env"
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
 SMTP_USER=mailer@example.com
 SMTP_PASS=your-password
 ```
 
-You will usually also want provider-specific values such as host and port:
-
-```sh
-SMTP_HOST=smtp.example.com
-SMTP_PORT=587
-```
-
-The exact variable names are up to your app. The important part is that your `smtpTransport(...)` call can read valid credentials at runtime.
+The variable names are up to your app. Your `smtpTransport(...)` call must read valid credentials at runtime.
 
   </Step>
   <Step>
 
-### Verify the install
+### Define a channel and send
 
-Before writing your first route, make sure the imports resolve cleanly:
+Create a minimal setup to verify that the transport connects and delivers:
 
-```ts
+```ts title="src/index.ts"
 import { createNotify, createClient } from '@betternotify/core';
 import { emailChannel } from '@betternotify/email';
 import { smtpTransport } from '@betternotify/smtp';
 import { z } from 'zod';
+
+const email = emailChannel({
+  defaults: { from: { name: 'My App', email: process.env.SMTP_USER! } },
+});
+
+const rpc = createNotify({ channels: { email } });
+
+const catalog = rpc.catalog({
+  welcome: rpc
+    .email()
+    .input(z.object({ name: z.string() }))
+    .subject(({ input }) => `Welcome, ${input.name}!`)
+    .template({
+      render: async ({ input }) => ({
+        text: `Welcome, ${input.name}!`,
+        html: `<h1>Welcome, ${input.name}!</h1>`,
+      }),
+    }),
+});
+
+const mail = createClient({
+  catalog,
+  channels: { email },
+  transportsByChannel: {
+    email: smtpTransport({
+      host: process.env.SMTP_HOST!,
+      port: Number(process.env.SMTP_PORT!),
+      auth: {
+        user: process.env.SMTP_USER!,
+        pass: process.env.SMTP_PASS!,
+      },
+    }),
+  },
+});
+
+const result = await mail.welcome.send({
+  to: 'you@example.com',
+  input: { name: 'Ada Lovelace' },
+});
+
+console.log('sent!', result.messageId);
 ```
 
-If that typechecks, the installation step is done.
+A delivered email confirms your setup.
 
   </Step>
 </Steps>
@@ -88,39 +150,37 @@ If that typechecks, the installation step is done.
 
 SMS installation docs are `TBD`.
 
-For now, start with the email path unless you are writing the SMS docs in parallel.
+Start with the email path above.
 
   </Tab>
   <Tab value="push">
 
 Push installation docs are `TBD`.
 
-For now, start with the email path unless you are writing the push docs in parallel.
+Start with the email path above.
 
   </Tab>
 </Tabs>
 
 ## What you have now
 
-At this point, your project is ready for the first email route:
+You can now write notification routes:
 
 - Node `>= 22` and ESM are in place.
-- Better-Notify core, email, SMTP, and `zod` are installed.
-- Your app knows where to read SMTP credentials.
-- The imports resolve cleanly, so you can start writing routes.
+- Better-Notify core, a channel adapter, and a transport are installed.
+- Your app knows where to read provider credentials.
 
-The next docs build on that setup in two different ways:
+## Where to go next
 
-- [Quick Start](/docs/get-started/quick-start) builds a working setup with routes, sub-catalogs, and sends a real email through Gmail SMTP.
-- [Advanced: Failover and Middleware](/docs/advanced/failover-and-middleware) keeps the same email shape and adds provider failover, tracing, event logging, and rate limiting.
+- [Your First Email](/docs/get-started/quick-start) breaks down how channels, routes, sub-catalogs, and the typed client work together — useful whether you scaffolded with the CLI or installed manually.
+- [Channels](/docs/concepts/channels) explains how email, SMS, push, and custom channels are defined.
+- [Transports](/docs/transports) covers provider adapters, multi-transport composition, and failover.
 
 ## Other packages
 
-You do not need these for the first email + SMTP example, but they are the next common additions:
+These are the next common additions after the email + SMTP example:
 
 - `@betternotify/sms` for SMS routes.
 - `@betternotify/push` for push notification routes.
-- `@betternotify/react-email` if you want React Email templates.
-- `@betternotify/resend` if you prefer Resend over SMTP.
-
-Continue to [Quick Start](/docs/get-started/quick-start) to wire the first route and send the first message.
+- `@betternotify/react-email` for React Email templates.
+- `@betternotify/resend` for Resend as a transport instead of SMTP.

--- a/apps/web/content/docs/get-started/quick-start.mdx
+++ b/apps/web/content/docs/get-started/quick-start.mdx
@@ -1,22 +1,24 @@
 ---
-title: Quick Start
+title: Your First Email
 icon: Lightning
-description: Send your first typed email in minutes
+description: Build a working email setup with channels, routes, sub-catalogs, and a typed client
 ---
 
 import { Mermaid } from '@/components/mermaid';
 import { File, Folder, Files } from 'fumadocs-ui/components/files';
 import { Step, Steps } from 'fumadocs-ui/components/steps';
 
-This guide walks you through building a working Better-Notify setup and sending a real email through Gmail SMTP. You will define an email channel, create three routes organized into sub-catalogs, and send a welcome email to your own inbox.
+This guide walks you through the moving parts of a Better-Notify project: channels, routes, sub-catalogs, and the typed client.
 
-By the end, you will have a typed client where `mail.transactional.welcome.send(...)` only compiles if the route exists and the input matches its schema.
+By the end, you will understand why `mail.transactional.welcome.send(...)` only compiles when the route exists and the input matches its schema.
 
 <Callout>
-This guide assumes you have already installed the packages. If not, start with [Installation](/docs/get-started/installation).
+If you have not installed yet, start with [Installation](/docs/get-started/installation).
 </Callout>
 
-## What you will build
+## The big picture
+
+A Better-Notify project has four layers: a **channel** defines message shape, **routes** declare individual notifications, a **catalog** organizes routes into a tree, and a **client** ties the catalog to transports for delivery.
 
 <Mermaid
   code={`
@@ -47,7 +49,7 @@ flowchart LR
   `}
 />
 
-Three routes, two sub-catalogs, one typed client sending real emails through Gmail. The file structure will look like this:
+The file structure for this walkthrough:
 
 <Files>
   <Folder name="src" defaultOpen>
@@ -63,7 +65,7 @@ Three routes, two sub-catalogs, one typed client sending real emails through Gma
 
 ## Set up Gmail SMTP
 
-Before writing any code, you need a Gmail app password. Gmail does not allow regular passwords for SMTP — you need to generate a dedicated app password.
+Before writing any code, you need a Gmail app password. Gmail requires a dedicated app password for SMTP.
 
 <Steps>
 <Step>
@@ -102,7 +104,7 @@ Never commit `.env` files to version control. Add `.env` to your `.gitignore`.
 
 ## Define the email channel
 
-The channel sets shared defaults for every email route. Use your Gmail address as the `from`:
+The channel sets shared defaults for every email route.
 
 ```ts title="src/notifications/channel.ts"
 import { emailChannel } from '@betternotify/email';
@@ -237,7 +239,7 @@ export const mail = createClient({
 });
 ```
 
-`mail` is now a fully typed client. Autocomplete shows `mail.transactional.welcome`, `mail.transactional.passwordReset`, and `mail.marketing.newsletter` — nothing more, nothing less.
+`mail` is now a typed client. Autocomplete shows `mail.transactional.welcome`, `mail.transactional.passwordReset`, and `mail.marketing.newsletter` — nothing more, nothing less.
 
 ## Send your first email
 
@@ -261,7 +263,7 @@ Run it and check your inbox. You should see a styled welcome email from your own
 
 ## Send across sub-catalogs
 
-Now send from both sub-catalogs to see the full typed surface in action:
+Now send from both sub-catalogs:
 
 ```ts title="src/index.ts"
 import { mail } from './notifications/client';
@@ -317,11 +319,11 @@ await mail.transactional.welcome.send({
 });
 ```
 
-The first two are caught at compile time. The third is caught at runtime by the Zod schema. The catalog enforces both layers.
+TypeScript catches the first two at compile time. Zod catches the third at runtime. The catalog enforces both layers.
 
 ## Use a mock transport for tests
 
-When you do not want to send real emails — in tests or CI — swap the transport without touching routes or the catalog:
+To skip real sends in tests or CI, swap the transport without touching routes or the catalog:
 
 ```ts title="src/notifications/client.test.ts"
 import { createClient } from '@betternotify/core';

--- a/apps/web/content/docs/get-started/why-betternotify.mdx
+++ b/apps/web/content/docs/get-started/why-betternotify.mdx
@@ -145,6 +145,6 @@ Better-Notify is not the right tool for every situation:
 
 ## Where to go next
 
-- Start with [Installation](/docs/get-started/installation) and [Quick Start](/docs/get-started/quick-start) to see Better-Notify in action.
+- Start with [Installation](/docs/get-started/installation) and [Your First Email](/docs/get-started/quick-start) to see Better-Notify in action.
 - Read [Transports Overview](/docs/transports) to understand how provider composition works.
 - Read [Middleware](/docs/concepts/middleware) to see how cross-cutting concerns plug in.

--- a/apps/web/content/docs/index.mdx
+++ b/apps/web/content/docs/index.mdx
@@ -54,8 +54,8 @@ The separation is the point. You can swap providers without touching routes. You
   <Card href="/docs/get-started/installation" title="Installation">
     Install Better-Notify and set up your first channel.
   </Card>
-  <Card href="/docs/get-started/quick-start" title="Quick Start">
-    Build a working notification setup with routes, sub-catalogs, and a mock transport.
+  <Card href="/docs/get-started/quick-start" title="Your First Email">
+    Build a working email setup with channels, routes, sub-catalogs, and a typed client.
   </Card>
   <Card href="/docs/concepts/channels" title="Channels">
     Understand email, SMS, push, and custom channel definitions.

--- a/apps/web/src/components/landing/footer.tsx
+++ b/apps/web/src/components/landing/footer.tsx
@@ -17,7 +17,7 @@ const navColumns = [
     links: [
       { label: 'Documentation', href: '/docs' },
       { label: 'Blog', href: '/blog' },
-      { label: 'Quick start', href: '/docs/get-started/quick-start' },
+      { label: 'Your First Email', href: '/docs/get-started/quick-start' },
       {
         label: 'GitHub',
         href: `https://github.com/${appConfig.git.user}/${appConfig.git.repo}`,

--- a/apps/web/src/components/landing/hero.tsx
+++ b/apps/web/src/components/landing/hero.tsx
@@ -66,8 +66,12 @@ export function Hero() {
               style={{ animationDelay: '160ms' }}
             >
               <a
-                href="/docs"
-                onClick={() => analytics.track('cta').action('click', { destination: '/docs' })}
+                href="/docs/get-started/installation"
+                onClick={() =>
+                  analytics
+                    .track('cta')
+                    .action('click', { destination: '/docs/get-started/installation' })
+                }
                 className="bg-primary text-primary-foreground hover:bg-primary/90 group inline-flex items-center gap-2 rounded-lg px-5 py-3 text-sm font-semibold no-underline transition-colors"
               >
                 Get started

--- a/apps/web/src/hooks/use-posthog-client.ts
+++ b/apps/web/src/hooks/use-posthog-client.ts
@@ -25,4 +25,4 @@ export const usePosthogInit = () => {
       disable_session_recording: true,
     });
   }, []);
-}
+};


### PR DESCRIPTION
# Overview

Refactor the get-started documentation flow: point users directly to installation from the homepage, add CLI scaffolding to installation, and rename "Quick Start" to "Your First Email".

# What's changed and why?

- **`hero.tsx`** — "Get started" CTA now links to `/docs/get-started/installation` instead of `/docs`
- **`installation.mdx`** — Added CLI scaffolding section (`npx create-better-notify@latest`) with project structure and a full working code snippet for manual setup
- **`quick-start.mdx`** — Renamed to "Your First Email", updated description and intro to reflect its role as a guided walkthrough
- **`footer.tsx`** — Updated nav label from "Quick start" to "Your First Email"
- **`index.mdx`** — Updated docs index card title and description
- **`catalog-and-procedures.mdx`, `why-betternotify.mdx`, `introducing-betternotify.mdx`** — Updated cross-references to use new page title
- **`use-posthog-client.ts`** — Minor fix (linter)

# How to test

1. Run `pnpm dev` and visit the homepage — click "Get started" and confirm it goes to `/docs/get-started/installation`
2. Check the installation page has both CLI and manual setup sections
3. Navigate to "Your First Email" and confirm the title and content render correctly
4. Verify footer link label says "Your First Email"

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced installation guide with ESM requirement, Node >= 22, CLI scaffold, and clearer manual setup
  * Reframed Quick Start as “Your First Email” and updated related guides, callouts, and nav cards
  * Consolidated “Where to go next” guidance and clarified examples across get-started content

* **Chores**
  * Updated site entry points and footer/CTA labels and links (adjusted analytics destination)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-notify/better-notify/pull/96)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->