### PR TITLE
fix(web): use appConfig for OG image domain and add missing aria-label

### DIFF
--- a/apps/web/src/components/landing/install.tsx
+++ b/apps/web/src/components/landing/install.tsx
@@ -81,6 +81,8 @@ export function Install() {
                 {cmd}
               </span>
               <button
+                type="button"
+                aria-label={copied ? 'Copied' : 'Copy command'}
                 onClick={handleCopy}
                 className={`flex cursor-pointer border-0 bg-transparent ${copied ? 'text-bn-success-700 dark:text-bn-success-300' : 'text-bn-slate-400 dark:text-bn-slate-500'}`}
               >

--- a/apps/web/src/routes/og.$.tsx
+++ b/apps/web/src/routes/og.$.tsx
@@ -205,7 +205,7 @@ function ogLayout(title: string, description?: string) {
               letterSpacing: '0.02em',
             },
           },
-          'better-notify.com',
+          new URL(appConfig.baseUrl).hostname,
         ),
       ),
     ),


### PR DESCRIPTION
## Summary
- OG image footer had a hardcoded `'better-notify.com'` domain instead of deriving it from `appConfig.baseUrl` — now uses `new URL(appConfig.baseUrl).hostname`
- Install section copy button was missing `aria-label` and `type="button"` that the identical `cli-preview.tsx` pattern already had

## Test plan
- [ ] Verify OG image renders correctly with the domain from appConfig
- [ ] Verify install copy button is accessible via screen reader

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility of the Copy button with proper button type and aria-label attributes.

* **Refactor**
  * Site host in metadata is now dynamically rendered from application configuration instead of using hardcoded values.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-notify/better-notify/pull/97)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->