### PR TITLE
feat(core): add fromLogger adapter for loggers without child method

### DIFF
--- a/examples/welcome-text/apps/cli/package.json
+++ b/examples/welcome-text/apps/cli/package.json
@@ -27,6 +27,7 @@
     "@betternotify/twilio": "workspace:*",
     "@betternotify/zapier": "workspace:*",
     "@t3-oss/env-core": "catalog:",
+    "evlog": "catalog:",
     "handlebars": "catalog:",
     "mjml": "catalog:",
     "react": "catalog:",

--- a/examples/welcome-text/apps/cli/src/examples/cloudflare-email-logger-evlog.ts
+++ b/examples/welcome-text/apps/cli/src/examples/cloudflare-email-logger-evlog.ts
@@ -1,0 +1,63 @@
+import { createClient, createNotify } from '@betternotify/core';
+import { env } from '../env';
+import { emailChannel } from '@betternotify/email';
+import z from 'zod';
+import { createLogger, initLogger, type RequestLogger } from 'evlog';
+import { fromLogger, type BaseLoggerLike } from '@betternotify/core/logger';
+import { cloudflareEmailTransport } from '@betternotify/cloudflare-email';
+import { reactEmail } from '@betternotify/react-email';
+import { Welcome } from '../templates/welcome';
+
+const toBaseLogger = (evlog: RequestLogger<Record<string, unknown>>): BaseLoggerLike => ({
+  debug: (message, payload) => evlog.info(message, payload),
+  info: (message, payload) => evlog.info(message, payload),
+  warn: (message, payload) => evlog.warn(message, payload),
+  error: (message, payload) => evlog.error(message, payload),
+});
+
+export const runCloudflareEmailLoggerEvlog = async (): Promise<void> => {
+  initLogger({ pretty: true });
+
+  const channel = emailChannel({
+    defaults: { from: { name: 'Better-Notify', email: env.CF_FROM_EMAIL } },
+  });
+
+  const rpc = createNotify({ channels: { email: channel } });
+
+  const catalog = rpc.catalog({
+    welcome: rpc
+      .email()
+      .input(z.object({ name: z.string(), verifyUrl: z.string().url() }))
+      .subject(({ input }) => `Welcome, ${input.name}!`)
+      .template(({ input }) => reactEmail(Welcome, input)),
+  });
+
+  const evlog = createLogger();
+  const logger = fromLogger(toBaseLogger(evlog));
+
+  const mail = createClient({
+    catalog,
+    channels: { email: channel },
+    transportsByChannel: {
+      email: cloudflareEmailTransport({
+        accountId: env.CF_ACCOUNT_ID,
+        apiToken: env.CF_API_TOKEN,
+      }),
+    },
+    logger,
+  });
+
+  const user = { id: '123', name: 'John Doe', email: env.CF_DESTINATION_EMAIL };
+
+  evlog.set({ context: 'welcome-text', user });
+
+  await mail.welcome.send({
+    input: {
+      name: user.name,
+      verifyUrl: 'https://example.com/verify?token=abc123',
+    },
+    to: user.email,
+  });
+
+  evlog.emit();
+};

--- a/examples/welcome-text/apps/cli/src/index.ts
+++ b/examples/welcome-text/apps/cli/src/index.ts
@@ -41,6 +41,7 @@ import { runEmailZapier } from './examples/email-zapier';
 import { runDiscordZapier } from './examples/discord-zapier';
 import { runEmailMailchimp } from './examples/email-mailchimp';
 import { runEmailSmtpFailover } from './examples/email-smtp-failover';
+import { runCloudflareEmailLoggerEvlog } from './examples/cloudflare-email-logger-evlog';
 
 const examples: Record<string, () => Promise<void>> = {
   single: runSingle,
@@ -67,6 +68,7 @@ const examples: Record<string, () => Promise<void>> = {
   'telegram-cross-transport': runTelegramCrossTransport,
   'cloudflare-email': runCloudflareEmail,
   'cloudflare-email-attachment': runCloudflareEmailAttachment,
+  'cloudflare-email-logger-evlog': runCloudflareEmailLoggerEvlog,
   resend: runResend,
   'resend-attachment': runResendAttachment,
   slack: runSlack,

--- a/packages/core/src/logger.test.ts
+++ b/packages/core/src/logger.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { consoleLogger, fromPino } from './logger.js';
+import { consoleLogger, fromLogger, fromPino } from './logger.js';
 
 const lineOf = (spy: { mock: { calls: unknown[][] } }): string => {
   const call = spy.mock.calls[0];
@@ -223,6 +223,106 @@ describe('fromPino', () => {
     const child = log.child({ x: 1 });
     expect(calls.some((c) => c.method === 'child' && (c.obj as any).x === 1)).toBe(true);
     expect(() => child.info('test')).not.toThrow();
+  });
+});
+
+const makeSimpleLogger = () => {
+  const calls: Array<{ method: string; msg: string; payload?: object }> = [];
+  const logger = {
+    debug: (msg: string, payload?: object) => calls.push({ method: 'debug', msg, payload }),
+    info: (msg: string, payload?: object) => calls.push({ method: 'info', msg, payload }),
+    warn: (msg: string, payload?: object) => calls.push({ method: 'warn', msg, payload }),
+    error: (msg: string, payload?: object) => calls.push({ method: 'error', msg, payload }),
+  };
+  return { logger, calls };
+};
+
+describe('fromLogger', () => {
+  it('forwards each level method to the underlying logger', () => {
+    const { logger, calls } = makeSimpleLogger();
+    const log = fromLogger(logger);
+    log.debug('d', { a: 1 });
+    log.info('i', { b: 2 });
+    log.warn('w', { c: 3 });
+    log.error('e', { d: 4 });
+    expect(calls).toHaveLength(4);
+    expect(calls[0]).toEqual({ method: 'debug', msg: 'd', payload: { a: 1 } });
+    expect(calls[1]).toEqual({ method: 'info', msg: 'i', payload: { b: 2 } });
+    expect(calls[2]).toEqual({ method: 'warn', msg: 'w', payload: { c: 3 } });
+    expect(calls[3]).toEqual({ method: 'error', msg: 'e', payload: { d: 4 } });
+  });
+
+  it('passes undefined payload when omitted and no bindings', () => {
+    const { logger, calls } = makeSimpleLogger();
+    fromLogger(logger).info('msg');
+    expect(calls[0]).toEqual({ method: 'info', msg: 'msg', payload: undefined });
+  });
+
+  it('child merges bindings into payload', () => {
+    const { logger, calls } = makeSimpleLogger();
+    const log = fromLogger(logger).child({ component: 'client' });
+    log.info('msg', { route: 'welcome' });
+    expect(calls[0]).toEqual({
+      method: 'info',
+      msg: 'msg',
+      payload: { component: 'client', route: 'welcome' },
+    });
+  });
+
+  it('child passes bindings as payload when no payload given', () => {
+    const { logger, calls } = makeSimpleLogger();
+    fromLogger(logger).child({ component: 'client' }).info('msg');
+    expect(calls[0]).toEqual({
+      method: 'info',
+      msg: 'msg',
+      payload: { component: 'client' },
+    });
+  });
+
+  it('nested child merges bindings cumulatively', () => {
+    const { logger, calls } = makeSimpleLogger();
+    const log = fromLogger(logger).child({ component: 'client' }).child({ route: 'welcome' });
+    log.info('msg', { messageId: '123' });
+    expect(calls[0]).toEqual({
+      method: 'info',
+      msg: 'msg',
+      payload: { component: 'client', route: 'welcome', messageId: '123' },
+    });
+  });
+
+  it('payload overrides bindings on key conflict', () => {
+    const { logger, calls } = makeSimpleLogger();
+    fromLogger(logger).child({ x: 'from-binding' }).info('msg', { x: 'from-payload' });
+    expect(calls[0]).toEqual({
+      method: 'info',
+      msg: 'msg',
+      payload: { x: 'from-payload' },
+    });
+  });
+
+  it('delegates to underlying child when available', () => {
+    const childCalls: Array<{ method: string; msg: string; payload?: object }> = [];
+    const logger = {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      child: (_bindings: object) => ({
+        debug: (msg: string, payload?: object) =>
+          childCalls.push({ method: 'debug', msg, payload }),
+        info: (msg: string, payload?: object) => childCalls.push({ method: 'info', msg, payload }),
+        warn: (msg: string, payload?: object) => childCalls.push({ method: 'warn', msg, payload }),
+        error: (msg: string, payload?: object) =>
+          childCalls.push({ method: 'error', msg, payload }),
+      }),
+    };
+    const log = fromLogger(logger).child({ component: 'client' });
+    log.info('msg', { route: 'welcome' });
+    expect(childCalls[0]).toEqual({
+      method: 'info',
+      msg: 'msg',
+      payload: { route: 'welcome' },
+    });
   });
 });
 

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -173,6 +173,44 @@ type PinoLike = {
   child(bindings: object): PinoLike;
 };
 
+export type BaseLoggerLike = {
+  debug(message: string, payload?: object): void;
+  info(message: string, payload?: object): void;
+  warn(message: string, payload?: object): void;
+  error(message: string, payload?: object): void;
+};
+
+export type BaseLoggerWithChild = BaseLoggerLike & {
+  child(bindings: object): BaseLoggerWithChild;
+};
+
+export const fromLogger = (logger: BaseLoggerLike | BaseLoggerWithChild): LoggerLike => {
+  const wrap = (
+    current: BaseLoggerLike | BaseLoggerWithChild,
+    bindings: Record<string, unknown>,
+  ): LoggerLike => {
+    const merge = (payload?: object): object | undefined => {
+      const hasBindings = Object.keys(bindings).length > 0;
+      if (!hasBindings) return payload;
+      if (!payload) return bindings;
+      return { ...bindings, ...(payload as Record<string, unknown>) };
+    };
+    return {
+      debug: (msg, payload) => current.debug(msg, merge(payload)),
+      info: (msg, payload) => current.info(msg, merge(payload)),
+      warn: (msg, payload) => current.warn(msg, merge(payload)),
+      error: (msg, payload) => current.error(msg, merge(payload)),
+      child: (extra) => {
+        if ('child' in current) {
+          return wrap(current.child(extra), {});
+        }
+        return wrap(current, { ...bindings, ...(extra as Record<string, unknown>) });
+      },
+    };
+  };
+  return wrap(logger, {});
+};
+
 export const fromPino = (pino: PinoLike): LoggerLike => ({
   debug: (msg, payload) => pino.debug(payload ?? {}, msg),
   info: (msg, payload) => pino.info(payload ?? {}, msg),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ catalogs:
     '@vitest/coverage-v8':
       specifier: 2.1.9
       version: 2.1.9
+    evlog:
+      specifier: 2.16.0
+      version: 2.16.0
     fumadocs-core:
       specifier: 16.8.8
       version: 16.8.8
@@ -332,6 +335,9 @@ importers:
       '@t3-oss/env-core':
         specifier: 'catalog:'
         version: 0.13.11(typescript@6.0.3)(zod@4.3.6)
+      evlog:
+        specifier: 'catalog:'
+        version: 2.16.0(@tanstack/start-client-core@1.167.20)(express@5.2.1)(hono@4.12.16)(react@19.2.5)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4))
       handlebars:
         specifier: 'catalog:'
         version: 4.7.9
@@ -5066,6 +5072,59 @@ packages:
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
+
+  evlog@2.16.0:
+    resolution: {integrity: sha512-qpIt+5+5hY8hxpca4vFTxR3x5jcnEC5DQh9OffR1mZWFfX2wui7ksh9I0AUUxRNP8ttlU/QN/JPVbSj5nepJ9w==}
+    peerDependencies:
+      '@nestjs/common': '>=11.1.19'
+      '@nuxt/kit': ^4.4.2
+      '@tanstack/start-client-core': ^1.167.20
+      ai: '>=6.0.168'
+      elysia: '>=1.4.28'
+      express: '>=5.2.1'
+      fastify: '>=5.8.5'
+      h3: ^1.15.11
+      hono: ''
+      next: '>=16.2.4'
+      nitro: ^3.0.260311-beta
+      nitropack: ^2.13.3
+      ofetch: ^1.5.1
+      react: '>=19.2.5'
+      react-router: '>=7.14.2'
+      vite: ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@nestjs/common':
+        optional: true
+      '@nuxt/kit':
+        optional: true
+      '@tanstack/start-client-core':
+        optional: true
+      ai:
+        optional: true
+      elysia:
+        optional: true
+      express:
+        optional: true
+      fastify:
+        optional: true
+      h3:
+        optional: true
+      hono:
+        optional: true
+      next:
+        optional: true
+      nitro:
+        optional: true
+      nitropack:
+        optional: true
+      ofetch:
+        optional: true
+      react:
+        optional: true
+      react-router:
+        optional: true
+      vite:
+        optional: true
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -11164,6 +11223,14 @@ snapshots:
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.0.8
+
+  evlog@2.16.0(@tanstack/start-client-core@1.167.20)(express@5.2.1)(hono@4.12.16)(react@19.2.5)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)):
+    optionalDependencies:
+      '@tanstack/start-client-core': 1.167.20
+      express: 5.2.1
+      hono: 4.12.16
+      react: 19.2.5
+      vite: 8.0.11(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.4)
 
   execa@5.1.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,7 @@ catalog:
   '@vitejs/plugin-react': 6.0.1
   '@vitest/coverage-v8': 2.1.9
   'bullmq': 5.0.0
+  'evlog': 2.16.0
   'fumadocs-core': 16.8.8
   'fumadocs-mdx': 14.3.2
   'fumadocs-openapi': 10.8.1


### PR DESCRIPTION
# Overview

Adds a `fromLogger` adapter that wraps any logger into a `LoggerLike`-compatible instance, synthesizing `child()` when the underlying logger doesn't have one.

# What's changed and why?

- **`packages/core/src/logger.ts`** — Added `BaseLoggerLike`, `BaseLoggerWithChild` types and `fromLogger` adapter. Accepts loggers with or without `child`, delegates when available, synthesizes via binding merge otherwise.
- **`packages/core/src/logger.test.ts`** — Added 7 tests covering forwarding, binding merge, nested child, key conflict, and child delegation.
- **`examples/welcome-text/apps/cli/src/examples/cloudflare-email-logger-evlog.ts`** — New example showing evlog integration with `fromLogger`.
- **`examples/welcome-text/apps/cli/src/index.ts`** — Registered the new example.
- **`pnpm-workspace.yaml` / `pnpm-lock.yaml`** — Added `evlog` to catalog.

# How to test

1. `pnpm --filter @betternotify/core test src/logger.test.ts`
2. `pnpm --filter @welcome-text/cli start cloudflare-email-logger-evlog`

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added logger wrapper enabling easier integration with standard logging libraries, with improved binding and payload propagation across nested logger instances.

* **Tests**
  * Enhanced test coverage for logger functionality.

* **Chores**
  * Updated dependency catalog.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-notify/better-notify/pull/99)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->