### PR TITLE
fix(release): use correct config key for prerelease versioning

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
-  "versioning-strategy": "prerelease",
+  "versioning": "prerelease",
   "prerelease": true,
   "include-component-in-tag": true,
   "separate-pull-requests": false,


### PR DESCRIPTION
# Overview

Fixes wrong config key in `release-please-config.json` that caused `@betternotify/core` to bump from `1.0.0-beta.1` to `1.1.0-beta.1` instead of `1.0.0-beta.2`.

# What's changed and why?

- **`release-please-config.json`** — renamed `versioning-strategy` to `versioning`. The release-please library expects `versioning` as the config key; the old key was silently ignored, causing it to fall back to the `default` strategy instead of `prerelease`.

# How to test

1. Merge this PR
2. Close PR #102 and delete its branch
3. Re-trigger the release workflow — core should bump to `1.0.0-beta.2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-notify/better-notify/pull/103)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->