### PR TITLE
fix(create-better-notify): extract version injection into testable module

### DIFF
--- a/packages/create-better-notify/scripts/copy-templates.ts
+++ b/packages/create-better-notify/scripts/copy-templates.ts
@@ -1,45 +1,7 @@
-import { cpSync, readFileSync, writeFileSync, readdirSync } from 'node:fs';
-import { resolve, dirname, join } from 'node:path';
+import { cpSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-const resolveWorkspaceVersions = (packagesDir: string): Record<string, string> => {
-  const result: Record<string, string> = {};
-  const dirs = readdirSync(packagesDir);
-  for (const dir of dirs) {
-    const pkgPath = join(packagesDir, dir, 'package.json');
-    try {
-      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-      if (pkg.name && pkg.version) {
-        result[pkg.name] = pkg.version;
-      }
-    } catch {
-      continue;
-    }
-  }
-  return result;
-};
-
-const injectVersions = (templatesDir: string, versions: Record<string, string>): void => {
-  const templates = readdirSync(templatesDir);
-  for (const template of templates) {
-    const pkgPath = join(templatesDir, template, 'package.json');
-    try {
-      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-      for (const depType of ['dependencies', 'devDependencies'] as const) {
-        const deps = pkg[depType];
-        if (!deps) continue;
-        for (const [name, version] of Object.entries(deps)) {
-          if (version === '0.0.0-inject' && versions[name]) {
-            deps[name] = versions[name];
-          }
-        }
-      }
-      writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
-    } catch {
-      continue;
-    }
-  }
-};
+import { resolveWorkspaceVersions, injectVersions } from '../src/inject-versions';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '../../..');

--- a/packages/create-better-notify/src/inject-versions.test.ts
+++ b/packages/create-better-notify/src/inject-versions.test.ts
@@ -76,6 +76,13 @@ describe('resolveWorkspaceVersions', () => {
 
     expect(versions['@betternotify/core']).toBe('1.0.0-beta.2');
   });
+
+  it('throws on malformed package.json', () => {
+    mkdirSync(join(packagesDir, 'bad'));
+    writeFileSync(join(packagesDir, 'bad', 'package.json'), '{invalid json}');
+
+    expect(() => resolveWorkspaceVersions(packagesDir)).toThrow(SyntaxError);
+  });
 });
 
 describe('injectVersions', () => {
@@ -195,5 +202,14 @@ describe('injectVersions', () => {
 
     const pkg = JSON.parse(readFileSync(join(templatesDir, 'valid', 'package.json'), 'utf-8'));
     expect(pkg.dependencies['@betternotify/core']).toBe('1.0.0-beta.2');
+  });
+
+  it('throws on malformed package.json', () => {
+    mkdirSync(join(templatesDir, 'bad'));
+    writeFileSync(join(templatesDir, 'bad', 'package.json'), '{invalid json}');
+
+    expect(() => injectVersions(templatesDir, { '@betternotify/core': '1.0.0' })).toThrow(
+      SyntaxError,
+    );
   });
 });

--- a/packages/create-better-notify/src/inject-versions.test.ts
+++ b/packages/create-better-notify/src/inject-versions.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { resolveWorkspaceVersions, injectVersions } from './inject-versions';
+
+describe('resolveWorkspaceVersions', () => {
+  let packagesDir: string;
+
+  beforeEach(() => {
+    packagesDir = mkdtempSync(join(tmpdir(), 'bn-versions-'));
+  });
+
+  afterEach(() => {
+    rmSync(packagesDir, { recursive: true, force: true });
+  });
+
+  it('reads name and version from each package directory', () => {
+    mkdirSync(join(packagesDir, 'core'));
+    writeFileSync(
+      join(packagesDir, 'core', 'package.json'),
+      JSON.stringify({ name: '@betternotify/core', version: '1.0.0-beta.2' }),
+    );
+    mkdirSync(join(packagesDir, 'smtp'));
+    writeFileSync(
+      join(packagesDir, 'smtp', 'package.json'),
+      JSON.stringify({ name: '@betternotify/smtp', version: '1.0.0-beta.1' }),
+    );
+
+    const versions = resolveWorkspaceVersions(packagesDir);
+
+    expect(versions).toEqual({
+      '@betternotify/core': '1.0.0-beta.2',
+      '@betternotify/smtp': '1.0.0-beta.1',
+    });
+  });
+
+  it('skips directories without a package.json', () => {
+    mkdirSync(join(packagesDir, 'no-pkg'));
+    mkdirSync(join(packagesDir, 'core'));
+    writeFileSync(
+      join(packagesDir, 'core', 'package.json'),
+      JSON.stringify({ name: '@betternotify/core', version: '2.0.0' }),
+    );
+
+    const versions = resolveWorkspaceVersions(packagesDir);
+
+    expect(versions).toEqual({ '@betternotify/core': '2.0.0' });
+  });
+
+  it('skips packages missing name or version', () => {
+    mkdirSync(join(packagesDir, 'no-name'));
+    writeFileSync(
+      join(packagesDir, 'no-name', 'package.json'),
+      JSON.stringify({ version: '1.0.0' }),
+    );
+    mkdirSync(join(packagesDir, 'no-version'));
+    writeFileSync(
+      join(packagesDir, 'no-version', 'package.json'),
+      JSON.stringify({ name: '@betternotify/foo' }),
+    );
+
+    const versions = resolveWorkspaceVersions(packagesDir);
+
+    expect(versions).toEqual({});
+  });
+
+  it('handles prerelease versions correctly', () => {
+    mkdirSync(join(packagesDir, 'core'));
+    writeFileSync(
+      join(packagesDir, 'core', 'package.json'),
+      JSON.stringify({ name: '@betternotify/core', version: '1.0.0-beta.2' }),
+    );
+
+    const versions = resolveWorkspaceVersions(packagesDir);
+
+    expect(versions['@betternotify/core']).toBe('1.0.0-beta.2');
+  });
+});
+
+describe('injectVersions', () => {
+  let templatesDir: string;
+
+  beforeEach(() => {
+    templatesDir = mkdtempSync(join(tmpdir(), 'bn-templates-'));
+  });
+
+  afterEach(() => {
+    rmSync(templatesDir, { recursive: true, force: true });
+  });
+
+  it('replaces 0.0.0-inject with the matching version', () => {
+    mkdirSync(join(templatesDir, 'hono-orpc'));
+    writeFileSync(
+      join(templatesDir, 'hono-orpc', 'package.json'),
+      JSON.stringify({
+        dependencies: {
+          '@betternotify/core': '0.0.0-inject',
+          '@betternotify/smtp': '0.0.0-inject',
+        },
+      }),
+    );
+
+    injectVersions(templatesDir, {
+      '@betternotify/core': '1.0.0-beta.2',
+      '@betternotify/smtp': '1.0.0-beta.1',
+    });
+
+    const pkg = JSON.parse(readFileSync(join(templatesDir, 'hono-orpc', 'package.json'), 'utf-8'));
+    expect(pkg.dependencies['@betternotify/core']).toBe('1.0.0-beta.2');
+    expect(pkg.dependencies['@betternotify/smtp']).toBe('1.0.0-beta.1');
+  });
+
+  it('does not modify non-inject versions', () => {
+    mkdirSync(join(templatesDir, 'hono-orpc'));
+    writeFileSync(
+      join(templatesDir, 'hono-orpc', 'package.json'),
+      JSON.stringify({
+        dependencies: {
+          '@betternotify/core': '0.0.0-inject',
+          hono: '4.12.18',
+        },
+      }),
+    );
+
+    injectVersions(templatesDir, { '@betternotify/core': '1.0.0-beta.2' });
+
+    const pkg = JSON.parse(readFileSync(join(templatesDir, 'hono-orpc', 'package.json'), 'utf-8'));
+    expect(pkg.dependencies.hono).toBe('4.12.18');
+  });
+
+  it('leaves inject placeholder unchanged when no matching version exists', () => {
+    mkdirSync(join(templatesDir, 'hono-orpc'));
+    writeFileSync(
+      join(templatesDir, 'hono-orpc', 'package.json'),
+      JSON.stringify({
+        dependencies: {
+          '@betternotify/unknown': '0.0.0-inject',
+        },
+      }),
+    );
+
+    injectVersions(templatesDir, { '@betternotify/core': '1.0.0-beta.2' });
+
+    const pkg = JSON.parse(readFileSync(join(templatesDir, 'hono-orpc', 'package.json'), 'utf-8'));
+    expect(pkg.dependencies['@betternotify/unknown']).toBe('0.0.0-inject');
+  });
+
+  it('injects into devDependencies as well', () => {
+    mkdirSync(join(templatesDir, 'hono-orpc'));
+    writeFileSync(
+      join(templatesDir, 'hono-orpc', 'package.json'),
+      JSON.stringify({
+        devDependencies: {
+          '@betternotify/core': '0.0.0-inject',
+        },
+      }),
+    );
+
+    injectVersions(templatesDir, { '@betternotify/core': '1.0.0-beta.2' });
+
+    const pkg = JSON.parse(readFileSync(join(templatesDir, 'hono-orpc', 'package.json'), 'utf-8'));
+    expect(pkg.devDependencies['@betternotify/core']).toBe('1.0.0-beta.2');
+  });
+
+  it('handles multiple templates', () => {
+    mkdirSync(join(templatesDir, 'hono-orpc'));
+    mkdirSync(join(templatesDir, 'elysia'));
+    writeFileSync(
+      join(templatesDir, 'hono-orpc', 'package.json'),
+      JSON.stringify({ dependencies: { '@betternotify/core': '0.0.0-inject' } }),
+    );
+    writeFileSync(
+      join(templatesDir, 'elysia', 'package.json'),
+      JSON.stringify({ dependencies: { '@betternotify/core': '0.0.0-inject' } }),
+    );
+
+    injectVersions(templatesDir, { '@betternotify/core': '1.0.0-beta.2' });
+
+    const pkg1 = JSON.parse(readFileSync(join(templatesDir, 'hono-orpc', 'package.json'), 'utf-8'));
+    const pkg2 = JSON.parse(readFileSync(join(templatesDir, 'elysia', 'package.json'), 'utf-8'));
+    expect(pkg1.dependencies['@betternotify/core']).toBe('1.0.0-beta.2');
+    expect(pkg2.dependencies['@betternotify/core']).toBe('1.0.0-beta.2');
+  });
+});

--- a/packages/create-better-notify/src/inject-versions.test.ts
+++ b/packages/create-better-notify/src/inject-versions.test.ts
@@ -182,4 +182,18 @@ describe('injectVersions', () => {
     expect(pkg1.dependencies['@betternotify/core']).toBe('1.0.0-beta.2');
     expect(pkg2.dependencies['@betternotify/core']).toBe('1.0.0-beta.2');
   });
+
+  it('skips template directories without a package.json', () => {
+    mkdirSync(join(templatesDir, 'valid'));
+    mkdirSync(join(templatesDir, 'no-pkg'));
+    writeFileSync(
+      join(templatesDir, 'valid', 'package.json'),
+      JSON.stringify({ dependencies: { '@betternotify/core': '0.0.0-inject' } }),
+    );
+
+    injectVersions(templatesDir, { '@betternotify/core': '1.0.0-beta.2' });
+
+    const pkg = JSON.parse(readFileSync(join(templatesDir, 'valid', 'package.json'), 'utf-8'));
+    expect(pkg.dependencies['@betternotify/core']).toBe('1.0.0-beta.2');
+  });
 });

--- a/packages/create-better-notify/src/inject-versions.ts
+++ b/packages/create-better-notify/src/inject-versions.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
+/** Reads workspace package manifests and returns a map of package name to version. */
 export const resolveWorkspaceVersions = (packagesDir: string): Record<string, string> => {
   const result: Record<string, string> = {};
   const dirs = readdirSync(packagesDir);
@@ -11,13 +12,16 @@ export const resolveWorkspaceVersions = (packagesDir: string): Record<string, st
       if (pkg.name && pkg.version) {
         result[pkg.name] = pkg.version;
       }
-    } catch {
-      continue;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT' || code === 'ENOTDIR') continue;
+      throw error;
     }
   }
   return result;
 };
 
+/** Replaces `0.0.0-inject` placeholders in template package manifests. */
 export const injectVersions = (templatesDir: string, versions: Record<string, string>): void => {
   const templates = readdirSync(templatesDir);
   for (const template of templates) {
@@ -34,8 +38,10 @@ export const injectVersions = (templatesDir: string, versions: Record<string, st
         }
       }
       writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
-    } catch {
-      continue;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT' || code === 'ENOTDIR') continue;
+      throw error;
     }
   }
 };

--- a/packages/create-better-notify/src/inject-versions.ts
+++ b/packages/create-better-notify/src/inject-versions.ts
@@ -1,0 +1,41 @@
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const resolveWorkspaceVersions = (packagesDir: string): Record<string, string> => {
+  const result: Record<string, string> = {};
+  const dirs = readdirSync(packagesDir);
+  for (const dir of dirs) {
+    const pkgPath = join(packagesDir, dir, 'package.json');
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+      if (pkg.name && pkg.version) {
+        result[pkg.name] = pkg.version;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return result;
+};
+
+export const injectVersions = (templatesDir: string, versions: Record<string, string>): void => {
+  const templates = readdirSync(templatesDir);
+  for (const template of templates) {
+    const pkgPath = join(templatesDir, template, 'package.json');
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+      for (const depType of ['dependencies', 'devDependencies'] as const) {
+        const deps = pkg[depType];
+        if (!deps) continue;
+        for (const [name, version] of Object.entries(deps)) {
+          if (version === '0.0.0-inject' && versions[name]) {
+            deps[name] = versions[name];
+          }
+        }
+      }
+      writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+    } catch {
+      continue;
+    }
+  }
+};


### PR DESCRIPTION
# Overview

Extracts the version resolution and injection logic from `copy-templates.ts` into a standalone module with full test coverage.

# What's changed and why?

The `copy-templates` build script had `resolveWorkspaceVersions` and `injectVersions` inlined, making them impossible to test. This PR moves them into their own module so the bootstrap versioning logic is covered and reliable.

- **`packages/create-better-notify/src/inject-versions.ts`** — new module exporting `resolveWorkspaceVersions` and `injectVersions`
- **`packages/create-better-notify/src/inject-versions.test.ts`** — tests covering version resolution, injection across deps/devDeps, multiple templates, missing packages, and edge cases
- **`packages/create-better-notify/scripts/copy-templates.ts`** — cleaned up to import from the new module instead of inlining the logic

# How to test

1. `pnpm --filter create-better-notify exec vitest run src/inject-versions.test.ts`
2. `pnpm build` — verify the copy-templates script still works end-to-end

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved workspace version resolution and injection into a shared utility; the template-copying flow now only copies templates and applies resolved versions.

* **Tests**
  * Added comprehensive tests for workspace version discovery and dependency-version injection, covering placeholders, non-placeholder preservation, malformed/missing manifests, and multi-template scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-notify/better-notify/pull/105)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->