### PR TITLE
fix(web): add trailing slashes to canonical URLs and sitemap

### DIFF
--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -24,7 +24,7 @@ export const Route = createFileRoute('/blog/$slug')({
 
     const title = `${loaderData.pageTitle} — ${appConfig.name} Blog`;
     const description = loaderData.pageDescription ?? 'Better-Notify blog.';
-    const url = `${appConfig.baseUrl}/blog/${loaderData.slug}`;
+    const url = `${appConfig.baseUrl}/blog/${loaderData.slug}/`;
     const image = loaderData.pageImage ?? `${appConfig.baseUrl}/og/image.png`;
 
     const { meta, links } = seo({

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -24,7 +24,7 @@ export const Route = createFileRoute('/blog/')({
   head: () => {
     const title = `Blog — ${appConfig.name}`;
     const description = 'Articles, guides, and updates from the Better-Notify team.';
-    const url = `${appConfig.baseUrl}/blog`;
+    const url = `${appConfig.baseUrl}/blog/`;
 
     const { meta, links } = seo({
       title,

--- a/apps/web/src/routes/docs/$.tsx
+++ b/apps/web/src/routes/docs/$.tsx
@@ -27,7 +27,7 @@ export const Route = createFileRoute('/docs/$')({
 
     const title = `${loaderData.pageTitle} — ${appConfig.name} Docs`;
     const description = loaderData.pageDescription ?? 'Better-Notify documentation and guides.';
-    const url = `${appConfig.baseUrl}/docs/${loaderData.slugs.join('/')}`;
+    const url = `${appConfig.baseUrl}/docs/${loaderData.slugs.join('/')}/`;
     const image = `${appConfig.baseUrl}/og/docs/${loaderData.slugs.join('/')}/image.png`;
 
     const { meta, links } = seo({

--- a/apps/web/src/routes/for/$slug.tsx
+++ b/apps/web/src/routes/for/$slug.tsx
@@ -18,7 +18,7 @@ export const Route = createFileRoute('/for/$slug')({
   },
   head: ({ loaderData }) => {
     if (!loaderData) return { meta: [], links: [] };
-    const url = `${appConfig.baseUrl}/for/${loaderData.slug}`;
+    const url = `${appConfig.baseUrl}/for/${loaderData.slug}/`;
     const { meta, links } = seo({
       title: `${appConfig.name} for ${loaderData.name} — Type-safe Notifications`,
       description: loaderData.tagline,

--- a/apps/web/src/routes/for/index.tsx
+++ b/apps/web/src/routes/for/index.tsx
@@ -8,7 +8,7 @@ import { personas } from '@/lib/personas';
 export const Route = createFileRoute('/for/')({
   component: PersonasPage,
   head: () => {
-    const url = `${appConfig.baseUrl}/for`;
+    const url = `${appConfig.baseUrl}/for/`;
     const { meta, links } = seo({
       title: `Better-Notify for your stack — ${appConfig.name}`,
       description:

--- a/apps/web/src/routes/integrations/$slug.tsx
+++ b/apps/web/src/routes/integrations/$slug.tsx
@@ -19,7 +19,7 @@ export const Route = createFileRoute('/integrations/$slug')({
   },
   head: ({ loaderData }) => {
     if (!loaderData) return { meta: [], links: [] };
-    const url = `${appConfig.baseUrl}/integrations/${loaderData.slug}`;
+    const url = `${appConfig.baseUrl}/integrations/${loaderData.slug}/`;
     const { meta, links } = seo({
       title: `${loaderData.name} Integration — ${appConfig.name}`,
       description: loaderData.tagline,

--- a/apps/web/src/routes/integrations/index.tsx
+++ b/apps/web/src/routes/integrations/index.tsx
@@ -8,7 +8,7 @@ import { integrations } from '@/lib/integrations';
 export const Route = createFileRoute('/integrations/')({
   component: IntegrationsPage,
   head: () => {
-    const url = `${appConfig.baseUrl}/integrations`;
+    const url = `${appConfig.baseUrl}/integrations/`;
     const { meta, links } = seo({
       title: `Integrations — ${appConfig.name}`,
       description:

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -13,21 +13,21 @@ export const Route = createFileRoute('/sitemap.xml')({
         const pages = source.getPages();
 
         const urls = [
-          { loc: appConfig.baseUrl, changefreq: 'daily', priority: '1.0' },
+          { loc: `${appConfig.baseUrl}/`, changefreq: 'daily', priority: '1.0' },
           ...pages.map((page) => ({
-            loc: `${appConfig.baseUrl}${page.url}`,
+            loc: `${appConfig.baseUrl}${page.url}/`,
             changefreq: 'weekly',
             priority: '0.7',
           })),
-          { loc: `${appConfig.baseUrl}/integrations`, changefreq: 'weekly', priority: '0.8' },
+          { loc: `${appConfig.baseUrl}/integrations/`, changefreq: 'weekly', priority: '0.8' },
           ...integrations.map((i) => ({
-            loc: `${appConfig.baseUrl}/integrations/${i.slug}`,
+            loc: `${appConfig.baseUrl}/integrations/${i.slug}/`,
             changefreq: 'monthly',
             priority: '0.6',
           })),
-          { loc: `${appConfig.baseUrl}/for`, changefreq: 'weekly', priority: '0.8' },
+          { loc: `${appConfig.baseUrl}/for/`, changefreq: 'weekly', priority: '0.8' },
           ...personas.map((p) => ({
-            loc: `${appConfig.baseUrl}/for/${p.slug}`,
+            loc: `${appConfig.baseUrl}/for/${p.slug}/`,
             changefreq: 'monthly',
             priority: '0.6',
           })),


### PR DESCRIPTION
# Overview

Fix "Duplicate without user-selected canonical" SEO issue reported by Google Search Console.

# What's changed and why?

The server 307-redirects all non-trailing-slash URLs to trailing-slash versions, but canonical tags, `og:url`, and sitemap entries were generated without trailing slashes. This mismatch caused Google to flag pages as duplicates.

- `routes/docs/$.tsx` — trailing slash on docs canonical/og URLs
- `routes/blog/$slug.tsx` — trailing slash on blog post canonical/og URLs
- `routes/blog/index.tsx` — trailing slash on blog index canonical/og URLs
- `routes/integrations/$slug.tsx` — trailing slash on integration canonical/og URLs
- `routes/integrations/index.tsx` — trailing slash on integrations index canonical/og URLs
- `routes/for/$slug.tsx` — trailing slash on persona canonical/og URLs
- `routes/for/index.tsx` — trailing slash on personas index canonical/og URLs
- `routes/sitemap[.]xml.ts` — trailing slash on all sitemap entries

# How to test

1. Deploy to canary
2. `curl -s https://canary.better-notify.com/docs/middlewares/with-rate-limit/ | grep canonical` — should show URL with trailing slash
3. `curl -s https://canary.better-notify.com/sitemap.xml | head -20` — all `<loc>` entries should have trailing slashes

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<details>
<summary>Preview docs</summary>

| Site | URL |
| --- | --- |
| Docs | [https://pr-109-better-notify.reis.workers.dev](https://pr-109-better-notify.reis.workers.dev) |

</details>
<!-- end Preview docs URL -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated URLs across blog, documentation, personas, and integrations pages to consistently include trailing slashes in SEO metadata, canonical references, and sitemap entries for proper URL standardization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-notify/better-notify/pull/109)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->