### PR TITLE
chore(onesignal): add release-please config

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -16,6 +16,7 @@
   "packages/mailchimp": "1.0.0-beta.1",
   "packages/twilio": "1.0.0-beta.2",
   "packages/autosend": "1.0.0-beta.2",
+  "packages/onesignal": "0.1.0-alpha.1",
   "packages/create-better-notify": "1.0.0-beta.2",
   "apps/web": "1.1.0-beta.3"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -95,6 +95,12 @@
       "prerelease-type": "beta",
       "bootstrap-sha": "0a8e6c0b915533cc7082fa8e96b6f0165b479943"
     },
+    "packages/onesignal": {
+      "release-type": "node",
+      "component": "@betternotify/onesignal",
+      "prerelease-type": "beta",
+      "bootstrap-sha": "718f957fc28af4840ad33ebf0f9fe45dccfdd544"
+    },
     "packages/create-better-notify": {
       "release-type": "node",
       "component": "create-better-notify",


### PR DESCRIPTION
# Overview

Add the missing release-please configuration for the `@betternotify/onesignal` package.

# What's changed and why?

The OneSignal transport was merged in #111 but its release-please config was not included.

- **`release-please-config.json`** — added `packages/onesignal` entry with bootstrap SHA pointing to the merge commit
- **`.release-please-manifest.json`** — added `packages/onesignal` at `0.1.0-alpha.1`

# How to test

1. Verify the JSON files are valid
2. Confirm release-please picks up the new package on the next release PR

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added release management infrastructure for a new package to support automated releases and version management
  * Set initial package version to `0.1.0-alpha.1` with beta prerelease configuration
  * Configured bootstrap settings and component identity to enable integration with the automated release system for coordinated version management across packages

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-notify/better-notify/pull/112)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->