### PR TITLE
feat(selligent): add Selligent transport

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -17,5 +17,6 @@
   "packages/twilio": "1.0.0-beta.2",
   "packages/autosend": "1.0.0-beta.2",
   "packages/create-better-notify": "1.0.0-beta.2",
-  "apps/web": "1.1.0-beta.3"
+  "apps/web": "1.1.0-beta.3",
+  "packages/selligent": "1.0.0-beta.1"
 }

--- a/apps/web/content/docs/transports/index.mdx
+++ b/apps/web/content/docs/transports/index.mdx
@@ -93,6 +93,11 @@ Return `{ ok: true, data }` on success with whatever provider-specific data you 
     <Badge variant="outline">provider</Badge>
     <Badge variant="secondary">email</Badge>
   </a>
+  <a href="/docs/transports/selligent" className="hover:bg-fd-accent/50 flex items-center gap-2 px-4 py-3 no-underline transition-colors">
+    <span className="text-fd-foreground flex-1 text-sm font-medium">Selligent (Marigold Engage)</span>
+    <Badge variant="outline">provider</Badge>
+    <Badge variant="secondary">email</Badge>
+  </a>
   <a href="/docs/transports/discord" className="hover:bg-fd-accent/50 flex items-center gap-2 px-4 py-3 no-underline transition-colors">
     <span className="text-fd-foreground flex-1 text-sm font-medium">Discord</span>
     <Badge variant="outline">provider</Badge>

--- a/apps/web/content/docs/transports/meta.json
+++ b/apps/web/content/docs/transports/meta.json
@@ -12,6 +12,7 @@
     "mock",
     "onesignal",
     "resend",
+    "selligent",
     "ses",
     "slack",
     "smtp",

--- a/apps/web/content/docs/transports/selligent.mdx
+++ b/apps/web/content/docs/transports/selligent.mdx
@@ -13,8 +13,11 @@ Unlike API-key-based transports, Selligent uses **OAuth 2.0 client credentials**
 
 ## Getting your credentials
 
-1. Contact your Selligent / Marigold Engage account manager to obtain OAuth credentials.
-2. You will receive a **client ID** (number), **client secret**, and **account ID**.
+1. Log in to Selligent / Marigold Engage.
+2. Navigate to **Admin Config → Access Management → Service Accounts**.
+3. Add a new Service Account — enter an account name, select type **Custom**, and click **Save**.
+4. Copy the generated **client ID**, **client secret**, and **account ID**.
+5. Provide the correct endpoint access to the credentials.
 
 Store them as environment variables:
 

--- a/apps/web/content/docs/transports/selligent.mdx
+++ b/apps/web/content/docs/transports/selligent.mdx
@@ -1,0 +1,221 @@
+---
+title: Selligent
+icon: Envelope
+description: Send transactional emails via the Selligent (Marigold Engage) SDC API
+---
+
+import { TypeTable } from 'fumadocs-ui/components/type-table';
+import { Callout } from 'fumadocs-ui/components/callout';
+
+The Selligent transport is an official Better-Notify package that sends transactional email through the [Selligent Delivery Cloud (SDC)](https://www.marigold.com/products/marigold-engage) HTTP API. It uses plain `fetch()` with zero external dependencies, so it works in Node.js, Cloudflare Workers, and any runtime with a global `fetch`.
+
+Unlike API-key-based transports, Selligent uses **OAuth 2.0 client credentials**. The transport handles token management automatically — fetching, caching, and refreshing tokens as needed.
+
+## Getting your credentials
+
+1. Contact your Selligent / Marigold Engage account manager to obtain OAuth credentials.
+2. You will receive a **client ID** (number), **client secret**, and **account ID**.
+
+Store them as environment variables:
+
+```sh
+SELLIGENT_CLIENT_ID=12345
+SELLIGENT_CLIENT_SECRET=your_client_secret
+SELLIGENT_ACCOUNT_ID=your_account_id
+```
+
+## Install
+
+```package-install
+@betternotify/selligent @betternotify/core @betternotify/email
+```
+
+## Usage
+
+```ts
+import { createNotify, createClient } from '@betternotify/core';
+import { emailChannel } from '@betternotify/email';
+import { selligentTransport } from '@betternotify/selligent';
+
+const email = emailChannel({
+  defaults: { from: { name: 'My App', email: 'noreply@example.com' } },
+});
+
+const rpc = createNotify({ channels: { email } });
+const catalog = rpc.catalog({
+  /* routes */
+});
+
+const mail = createClient({
+  catalog,
+  channels: { email },
+  transportsByChannel: {
+    email: selligentTransport({
+      clientId: Number(process.env.SELLIGENT_CLIENT_ID!),
+      clientSecret: process.env.SELLIGENT_CLIENT_SECRET!,
+      accountId: process.env.SELLIGENT_ACCOUNT_ID!,
+    }),
+  },
+});
+```
+
+### Custom token provider
+
+If you already manage OAuth tokens externally, pass `getAccessToken` instead of credentials:
+
+```ts
+selligentTransport({
+  getAccessToken: () => myTokenManager.getToken(),
+});
+```
+
+### Verifying credentials
+
+Use `verify()` to test credentials without sending an email. It attempts to fetch an OAuth token and returns `{ ok: true }` on success:
+
+```ts
+const transport = selligentTransport({ /* ... */ });
+const result = await transport.verify();
+if (!result.ok) {
+  console.error('Credential check failed:', result.details);
+}
+```
+
+## Options
+
+<TypeTable
+  type={{
+    clientId: {
+      description: 'Selligent OAuth client ID (number). Required unless using `getAccessToken`.',
+      type: 'number',
+    },
+    clientSecret: {
+      description: 'Selligent OAuth client secret. Required unless using `getAccessToken`.',
+      type: 'string',
+    },
+    accountId: {
+      description: 'Selligent account ID. Required unless using `getAccessToken`.',
+      type: 'string',
+    },
+    getAccessToken: {
+      description: 'Provide your own token manager. Mutually exclusive with OAuth credentials.',
+      type: '() => Promise<string>',
+    },
+    baseUrl: {
+      description: 'Override the SDC API base URL. Change this for non-EU regions.',
+      type: 'string',
+      default: '"https://sdc.slgnt.eu"',
+    },
+    authUrl: {
+      description: 'Override the OAuth token endpoint.',
+      type: 'string',
+      default: '"https://auth.slgnt.eu/oauth/token"',
+    },
+    audience: {
+      description: 'Override the OAuth audience. Should match the SDC base URL.',
+      type: 'string',
+      default: '"https://sdc.slgnt.eu"',
+    },
+    logger: {
+      description: 'Override the default logger.',
+      type: 'LoggerLike',
+    },
+    http: {
+      description: 'HTTP client options — timeout, retry, and request lifecycle hooks. See [HTTP configuration](/docs/transports#http-configuration).',
+      type: 'HttpClientBehaviorOptions',
+    },
+  }}
+/>
+
+## Per-send overrides
+
+Pass Selligent-specific fields per-send via the `transport` key in `.send()`:
+
+```ts
+await mail.welcome.send({
+  to: 'user@example.com',
+  input: { name: 'Jane' },
+  transport: {
+    selligent: {
+      profile: 'crm-id-123',
+      tags: ['campaign-spring'],
+      metadata: '{"ref": 123}',
+      list_unsubscribe: '<https://example.com/unsub>',
+      custom_send_time: '2025-09-02T12:00:00',
+      time_to_live: 'P2D',
+    },
+  },
+});
+```
+
+<TypeTable
+  type={{
+    profile: {
+      description: 'Recipient identifier in your CRM. Defaults to the recipient email address.',
+      type: 'string',
+    },
+    tags: {
+      description: 'Tags for message categorization and reporting.',
+      type: 'string[]',
+    },
+    metadata: {
+      description: 'Custom JSON-serialized metadata attached to the message.',
+      type: 'string',
+    },
+    reference: {
+      description: 'Unique tracking reference echoed in webhooks. Defaults to `messageId-index`.',
+      type: 'string',
+    },
+    list_unsubscribe: {
+      description: 'RFC 2369 List-Unsubscribe header value.',
+      type: 'string',
+    },
+    custom_send_time: {
+      description: 'Schedule send time (UTC datetime), max 24 hours in the future.',
+      type: 'string',
+    },
+    time_to_live: {
+      description: 'Message TTL as ISO 8601 duration, max 2 days (`P2D`).',
+      type: 'string',
+    },
+  }}
+/>
+
+## Multiple recipients
+
+When you send to multiple `to` addresses, the transport creates one SDC message item per recipient in a single HTTP request (SDC accepts a JSON array). Each item gets its own `reference` (`messageId-0`, `messageId-1`, etc.) and `context.profile` (defaults to the recipient email).
+
+## Authentication flow
+
+The transport uses the **OAuth 2.0 client credentials** grant:
+
+1. Before the first send, it `POST`s to the token endpoint with your `clientId`, `clientSecret`, `accountId`, and `audience`.
+2. The returned JWT is cached in-process and reused for subsequent sends.
+3. When the token is within 60 seconds of expiry, the next send triggers a fresh token fetch.
+
+Token endpoint failures during send return a `CONFIG` error (non-retriable for 4xx, retriable for 5xx).
+
+<Callout type="info">
+SDC sends message content without any modifications — it does not inject tracking pixels or rewrite links. Open/click tracking must be implemented by the sender.
+</Callout>
+
+## Error handling
+
+The transport maps HTTP status codes to Better-Notify error codes using the shared `mapHttpStatus` utility:
+
+| HTTP status | Better-Notify code | Retriable |
+| --- | --- | --- |
+| 400 | `VALIDATION` | No |
+| 422 | `VALIDATION` | No |
+| 401 | `CONFIG` | No |
+| 403 | `CONFIG` | No |
+| 429 | `RATE_LIMITED` | Yes |
+| 5xx | `PROVIDER` | Yes |
+
+Network failures are wrapped as `PROVIDER` errors and timeouts as `TIMEOUT` errors.
+
+OAuth token failures are surfaced as `CONFIG` errors with the HTTP status from the token endpoint.
+
+## Dropped fields
+
+The following `RenderedMessage` fields are not part of SDC's send schema and are silently dropped: `cc`, `bcc`, custom `headers`, `tags`, `priority`, and `inlineAssets`. If you need them, prefer a dedicated email provider transport (e.g. [Resend](/docs/transports/resend), [SMTP](/docs/transports/smtp)).

--- a/apps/web/content/docs/transports/selligent.mdx
+++ b/apps/web/content/docs/transports/selligent.mdx
@@ -17,7 +17,7 @@ Unlike API-key-based transports, Selligent uses **OAuth 2.0 client credentials**
 2. Navigate to **Admin Config → Access Management → Service Accounts**.
 3. Add a new Service Account — enter an account name, select type **Custom**, and click **Save**.
 4. Copy the generated **client ID**, **client secret**, and **account ID**.
-5. Provide the correct endpoint access to the credentials.
+5. Under the service account's endpoint access, enable the **SDC transactional email** (`/email/v1/messages/send`) and **OAuth token** (`/oauth/token`) endpoints.
 
 Store them as environment variables:
 

--- a/apps/web/src/components/landing/marquee.tsx
+++ b/apps/web/src/components/landing/marquee.tsx
@@ -202,6 +202,10 @@ const providers: { name: string; icon: ReactNode }[] = [
       </svg>
     ),
   },
+  {
+    name: 'Selligent',
+    icon: <AtIcon size={20} weight="fill" className="text-[#E4002B]" />,
+  },
   { name: 'Zapier', icon: <LightningIcon size={20} weight="fill" className="text-[#FF4A00]" /> },
   { name: 'SMTP', icon: <AtIcon size={20} weight="fill" className="text-[#999]" /> },
   { name: 'SMS', icon: <PhoneIcon size={20} weight="fill" className="text-[#999]" /> },

--- a/apps/web/src/lib/source.ts
+++ b/apps/web/src/lib/source.ts
@@ -28,6 +28,7 @@ const transportChannels: Record<string, string | string[]> = {
   resend: 'email',
   'cloudflare-email': 'email',
   mailchimp: 'email',
+  selligent: 'email',
   discord: 'discord',
   slack: 'slack',
   telegram: 'telegram',

--- a/examples/welcome-text/apps/cli/.env.example
+++ b/examples/welcome-text/apps/cli/.env.example
@@ -23,6 +23,12 @@ RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxxx
 RESEND_FROM_EMAIL=noreply@example.com
 RESEND_DESTINATION_EMAIL=example@email.com
 
+SELLIGENT_CLIENT_ID=12345
+SELLIGENT_CLIENT_SECRET=secret123
+SELLIGENT_ACCOUNT_ID=ACCT_ABC
+SELLIGENT_FROM_EMAIL=noreply@example.com
+SELLIGENT_DESTINATION_EMAIL=example@email.com
+
 SLACK_BOT_TOKEN=xoxb-your-bot-token
 SLACK_CHANNEL=#general
 

--- a/examples/welcome-text/apps/cli/package.json
+++ b/examples/welcome-text/apps/cli/package.json
@@ -22,6 +22,7 @@
     "@betternotify/push": "workspace:*",
     "@betternotify/react-email": "workspace:*",
     "@betternotify/resend": "workspace:*",
+    "@betternotify/selligent": "workspace:*",
     "@betternotify/slack": "workspace:*",
     "@betternotify/sms": "workspace:*",
     "@betternotify/smtp": "workspace:*",

--- a/examples/welcome-text/apps/cli/src/env.ts
+++ b/examples/welcome-text/apps/cli/src/env.ts
@@ -95,6 +95,35 @@ export const env = createEnv({
       .describe('Resend destination email'),
 
     /**
+     * Selligent cluster
+     */
+    SELLIGENT_CLIENT_ID: z
+      .string()
+      .optional()
+      .default('12345')
+      .describe('Selligent OAuth client ID'),
+    SELLIGENT_CLIENT_SECRET: z
+      .string()
+      .optional()
+      .default('secret123')
+      .describe('Selligent OAuth client secret'),
+    SELLIGENT_ACCOUNT_ID: z
+      .string()
+      .optional()
+      .default('ACCT_ABC')
+      .describe('Selligent account ID'),
+    SELLIGENT_FROM_EMAIL: z
+      .string()
+      .optional()
+      .default('noreply@example.com')
+      .describe('Selligent from email'),
+    SELLIGENT_DESTINATION_EMAIL: z
+      .string()
+      .optional()
+      .default('example@email.com')
+      .describe('Selligent destination email'),
+
+    /**
      * Slack cluster
      */
     SLACK_BOT_TOKEN: z.string().optional().default('xoxb-test').describe('Slack bot token'),

--- a/examples/welcome-text/apps/cli/src/examples/email-selligent.ts
+++ b/examples/welcome-text/apps/cli/src/examples/email-selligent.ts
@@ -1,0 +1,55 @@
+import { createNotify, createClient, consoleLogger } from '@betternotify/core';
+import { emailChannel } from '@betternotify/email';
+import { selligentTransport } from '@betternotify/selligent';
+import { z } from 'zod';
+import { env } from '../env';
+
+const ch = emailChannel({
+  defaults: { from: { name: 'Better-Notify', email: env.SELLIGENT_FROM_EMAIL } },
+});
+
+const rpc = createNotify({ channels: { email: ch } });
+
+const catalog = rpc.catalog({
+  welcome: rpc
+    .email()
+    .input(z.object({ name: z.string(), verifyUrl: z.string().url() }))
+    .subject(({ input }) => `Welcome, ${input.name}!`)
+    .template({
+      render: async ({ input }) => ({
+        text: `Welcome, ${input.name}! Verify here: ${input.verifyUrl}`,
+        html: `<p>Welcome, ${input.name}! <a href="${input.verifyUrl}">Verify</a></p>`,
+      }),
+    }),
+});
+
+export const runEmailSelligent = async (): Promise<void> => {
+  const transport = selligentTransport({
+    clientId: Number(env.SELLIGENT_CLIENT_ID),
+    clientSecret: env.SELLIGENT_CLIENT_SECRET,
+    accountId: env.SELLIGENT_ACCOUNT_ID,
+  });
+
+  if (transport.verify) {
+    const verifyResult = await transport.verify();
+    console.log('Verify:', verifyResult.ok ? 'OK' : `FAILED — ${verifyResult.details}`);
+  }
+
+  const mail = createClient({
+    catalog,
+    channels: { email: ch },
+    transportsByChannel: { email: transport },
+    logger: consoleLogger({ level: 'debug' }),
+  });
+
+  const result = await mail.welcome.send({
+    to: env.SELLIGENT_DESTINATION_EMAIL,
+    input: { name: 'John Doe', verifyUrl: 'https://example.com/verify?token=abc123' },
+  });
+
+  console.log('Message ID:', result.messageId);
+  console.log('From:      ', result.envelope?.from);
+  console.log('To:        ', result.envelope?.to.join(', '));
+  console.log('Render:    ', `${result.timing.renderMs.toFixed(1)}ms`);
+  console.log('Send:      ', `${result.timing.sendMs.toFixed(1)}ms`);
+};

--- a/examples/welcome-text/apps/cli/src/index.ts
+++ b/examples/welcome-text/apps/cli/src/index.ts
@@ -47,6 +47,7 @@ import { runEmailMultiOnesignalSmtp } from './examples/email-multi-onesignal-smt
 import { runPushOnesignal } from './examples/push-onesignal';
 import { runEmailOnesignal } from './examples/email-onesignal';
 import { runSmsOnesignal } from './examples/sms-onesignal';
+import { runEmailSelligent } from './examples/email-selligent';
 
 const examples: Record<string, () => Promise<void>> = {
   single: runSingle,
@@ -98,6 +99,7 @@ const examples: Record<string, () => Promise<void>> = {
   'push-onesignal': runPushOnesignal,
   'email-onesignal': runEmailOnesignal,
   'sms-onesignal': runSmsOnesignal,
+  'email-selligent': runEmailSelligent,
 };
 
 const main = async (): Promise<void> => {

--- a/packages/selligent/README.md
+++ b/packages/selligent/README.md
@@ -1,0 +1,104 @@
+# @betternotify/selligent
+
+[Selligent (Marigold Engage)](https://www.marigold.com/products/marigold-engage) transactional email transport for [Better-Notify](https://github.com/better-notify/better-notify). Delivers rendered emails through the Selligent Delivery Cloud (SDC) `POST /email/v1/messages/send` API.
+
+<p>
+  <a href="https://better-notify.com">Website</a> ·
+  <a href="https://better-notify.com/docs">Docs</a> ·
+  <a href="https://github.com/better-notify/better-notify">GitHub</a> ·
+  <a href="https://x.com/better_notify">X</a>
+</p>
+
+## Install
+
+```sh
+npm install @betternotify/selligent @betternotify/core @betternotify/email
+```
+
+## Usage
+
+```ts
+import { createNotify, createClient } from '@betternotify/core';
+import { emailChannel } from '@betternotify/email';
+import { selligentTransport } from '@betternotify/selligent';
+
+const email = emailChannel({
+  defaults: { from: { name: 'My App', email: 'noreply@example.com' } },
+});
+
+const rpc = createNotify({ channels: { email } });
+const catalog = rpc.catalog({
+  /* routes */
+});
+
+const mail = createClient({
+  catalog,
+  channels: { email },
+  transportsByChannel: {
+    email: selligentTransport({
+      clientId: Number(process.env.SELLIGENT_CLIENT_ID!),
+      clientSecret: process.env.SELLIGENT_CLIENT_SECRET!,
+      accountId: process.env.SELLIGENT_ACCOUNT_ID!,
+    }),
+  },
+});
+```
+
+Alternatively, if you already manage OAuth tokens externally:
+
+```ts
+selligentTransport({
+  getAccessToken: () => myTokenManager.getToken(),
+});
+```
+
+## Options
+
+| Field          | Type       | Description                                                                          |
+| -------------- | ---------- | ------------------------------------------------------------------------------------ |
+| `clientId`     | `number`   | Selligent OAuth client ID. Required (unless using `getAccessToken`).                 |
+| `clientSecret` | `string`   | Selligent OAuth client secret. Required (unless using `getAccessToken`).             |
+| `accountId`    | `string`   | Selligent account ID. Required (unless using `getAccessToken`).                      |
+| `getAccessToken` | `() => Promise<string>` | Provide your own token. Mutually exclusive with OAuth credentials.   |
+| `baseUrl`      | `string`   | Override the SDC API base URL. Defaults to `https://sdc.slgnt.eu`.                   |
+| `authUrl`      | `string`   | Override the OAuth token endpoint. Defaults to `https://auth.slgnt.eu/oauth/token`.  |
+| `audience`     | `string`   | Override the OAuth audience. Defaults to `https://sdc.slgnt.eu`.                     |
+| `logger`       | `object`   | Optional `LoggerLike`. Defaults to `consoleLogger()`.                                |
+| `http`         | `object`   | HTTP behavior options (retry, timeout, hooks).                                       |
+
+## Authentication
+
+Unlike API-key-based transports, Selligent uses **OAuth 2.0 client credentials**. The transport handles token management automatically — it fetches a token before the first send, caches it, and refreshes it when it's about to expire (within 60 seconds of expiry).
+
+The `verify()` method tests credentials by attempting a token fetch without sending any email.
+
+## Per-send overrides
+
+Pass Selligent-specific fields per-send via the `transport` key in `.send()`:
+
+```ts
+await mail.welcome.send({
+  to: 'user@example.com',
+  input: { name: 'Jane' },
+  transport: {
+    selligent: {
+      profile: 'crm-id-123',
+      tags: ['campaign-spring'],
+      metadata: '{"ref": 123}',
+      list_unsubscribe: '<https://example.com/unsub>',
+      custom_send_time: '2025-09-02T12:00:00',
+      time_to_live: 'P2D',
+    },
+  },
+});
+```
+
+## Caveats
+
+SDC sends message content without any modifications — it does not inject tracking pixels or rewrite links. Open/click tracking must be implemented by the sender.
+
+The following `RenderedMessage` fields are not part of SDC's send schema and are silently dropped: `cc`, `bcc`, custom `headers`, `tags`, `priority`, and `inlineAssets`.
+
+## License
+
+MIT

--- a/packages/selligent/package.json
+++ b/packages/selligent/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@betternotify/selligent",
+  "version": "1.0.0-beta.1",
+  "description": "Selligent (Marigold Engage) transactional email transport for Better-Notify.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-notify/better-notify",
+    "directory": "packages/selligent"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "NODE_OPTIONS='--import tsx/esm' rolldown -c",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@betternotify/core": "workspace:*",
+    "@betternotify/email": "workspace:*"
+  },
+  "devDependencies": {
+    "@internal/rolldown-config": "workspace:*",
+    "@internal/tsconfig": "workspace:*",
+    "rolldown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/selligent/rolldown.config.ts
+++ b/packages/selligent/rolldown.config.ts
@@ -1,0 +1,5 @@
+import { baseConfig } from '@internal/rolldown-config';
+
+export default baseConfig({
+  entries: { index: 'src/index.ts' },
+});

--- a/packages/selligent/src/index.test.ts
+++ b/packages/selligent/src/index.test.ts
@@ -1,0 +1,638 @@
+import { describe, expect, it, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import type { RenderedMessage } from '@betternotify/email';
+import type { SendContext } from '@betternotify/core';
+import { NotifyRpcProviderError } from '@betternotify/core';
+
+let fetchMock: Mock;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const baseMessage: RenderedMessage = {
+  from: { name: 'App', email: 'noreply@example.com' },
+  to: [{ email: 'user@example.com' }],
+  subject: 'Hello',
+  html: '<p>hi</p>',
+  text: 'hi',
+};
+
+const baseCtx: SendContext = { route: 'welcome', messageId: 'm1', attempt: 1 };
+
+const tokenResponse = {
+  access_token: 'jwt_token_123',
+  token_type: 'Bearer',
+  refresh_token: 'refresh_456',
+  scope: 'send:email',
+  expires_in: 86400,
+};
+
+const oauthOpts = {
+  clientId: 12345,
+  clientSecret: 'secret123',
+  accountId: 'ACCT_ABC',
+};
+
+const mockTokenThenSend = () => {
+  fetchMock
+    .mockResolvedValueOnce(new Response(JSON.stringify(tokenResponse), { status: 200 }))
+    .mockResolvedValueOnce(new Response('', { status: 202 }));
+};
+
+describe('selligentTransport — OAuth token management', () => {
+  it('fetches an OAuth token before the first send', async () => {
+    const { selligentTransport } = await import('./index.js');
+    mockTokenThenSend();
+    const t = selligentTransport(oauthOpts);
+    await t.send(baseMessage, baseCtx);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [tokenUrl, tokenInit] = fetchMock.mock.calls[0]!;
+    expect(String(tokenUrl)).toBe('https://auth.slgnt.eu/oauth/token');
+    expect(tokenInit.method).toBe('POST');
+    const tokenBody = JSON.parse(tokenInit.body);
+    expect(tokenBody.client_id).toBe(12345);
+    expect(tokenBody.client_secret).toBe('secret123');
+    expect(tokenBody.account_id).toBe('ACCT_ABC');
+    expect(tokenBody.grant_type).toBe('client_credentials');
+    expect(tokenBody.audience).toBe('https://sdc.slgnt.eu');
+  });
+
+  it('caches the token for subsequent sends', async () => {
+    const { selligentTransport } = await import('./index.js');
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify(tokenResponse), { status: 200 }))
+      .mockResolvedValueOnce(new Response('', { status: 202 }))
+      .mockResolvedValueOnce(new Response('', { status: 202 }));
+
+    const t = selligentTransport(oauthOpts);
+    await t.send(baseMessage, baseCtx);
+    await t.send(baseMessage, baseCtx);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const calls = fetchMock.mock.calls.map((c) => String(c[0]));
+    expect(calls[0]).toContain('oauth/token');
+    expect(calls[1]).toContain('/email/v1/messages/send');
+    expect(calls[2]).toContain('/email/v1/messages/send');
+  });
+
+  it('refreshes the token when it is about to expire', async () => {
+    const { selligentTransport } = await import('./index.js');
+    const shortToken = { ...tokenResponse, expires_in: 30 };
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify(shortToken), { status: 200 }))
+      .mockResolvedValueOnce(new Response('', { status: 202 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(tokenResponse), { status: 200 }))
+      .mockResolvedValueOnce(new Response('', { status: 202 }));
+
+    const t = selligentTransport(oauthOpts);
+    await t.send(baseMessage, baseCtx);
+    await t.send(baseMessage, baseCtx);
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    const calls = fetchMock.mock.calls.map((c) => String(c[0]));
+    expect(calls[0]).toContain('oauth/token');
+    expect(calls[2]).toContain('oauth/token');
+  });
+
+  it('returns CONFIG error when token request fails with 4xx', async () => {
+    const { selligentTransport } = await import('./index.js');
+    fetchMock.mockResolvedValueOnce(new Response('Invalid credentials', { status: 401 }));
+
+    const t = selligentTransport(oauthOpts);
+    const result = await t.send(baseMessage, baseCtx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('CONFIG');
+    expect(err.provider).toBe('selligent');
+    expect(err.httpStatus).toBe(401);
+    expect(err.retriable).toBe(false);
+  });
+
+  it('returns retriable CONFIG error when token request fails with 5xx', async () => {
+    const { selligentTransport } = await import('./index.js');
+    fetchMock.mockResolvedValueOnce(new Response('Server error', { status: 500 }));
+
+    const t = selligentTransport(oauthOpts);
+    const result = await t.send(baseMessage, baseCtx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('CONFIG');
+    expect(err.provider).toBe('selligent');
+    expect(err.retriable).toBe(true);
+  });
+
+  it('returns CONFIG error when token fetch throws a network error', async () => {
+    const { selligentTransport } = await import('./index.js');
+    fetchMock.mockRejectedValueOnce(new TypeError('fetch failed'));
+
+    const t = selligentTransport(oauthOpts);
+    const result = await t.send(baseMessage, baseCtx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('CONFIG');
+    expect(err.provider).toBe('selligent');
+    expect(err.retriable).toBe(true);
+    expect(err.message).toContain('fetch failed');
+  });
+
+  it('uses custom authUrl and audience', async () => {
+    const { selligentTransport } = await import('./index.js');
+    mockTokenThenSend();
+    const t = selligentTransport({
+      ...oauthOpts,
+      authUrl: 'https://auth.custom.com/oauth/token',
+      audience: 'https://sdc.custom.com',
+    });
+    await t.send(baseMessage, baseCtx);
+
+    const [tokenUrl] = fetchMock.mock.calls[0]!;
+    expect(String(tokenUrl)).toBe('https://auth.custom.com/oauth/token');
+    const tokenBody = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(tokenBody.audience).toBe('https://sdc.custom.com');
+  });
+
+  it('uses getAccessToken when provided instead of OAuth flow', async () => {
+    const { selligentTransport } = await import('./index.js');
+    fetchMock.mockResolvedValueOnce(new Response('', { status: 202 }));
+
+    const getAccessToken = vi.fn().mockResolvedValue('custom_token');
+    const t = selligentTransport({ getAccessToken });
+    await t.send(baseMessage, baseCtx);
+
+    expect(getAccessToken).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0]!;
+    const headers = new Headers(init.headers as Record<string, string>);
+    expect(headers.get('Authorization')).toBe('Bearer custom_token');
+  });
+});
+
+describe('selligentTransport — send', () => {
+  it('sends a POST to the SDC email send endpoint', async () => {
+    const { selligentTransport } = await import('./index.js');
+    mockTokenThenSend();
+    const t = selligentTransport(oauthOpts);
+    await t.send(baseMessage, baseCtx);
+
+    const [sendUrl, sendInit] = fetchMock.mock.calls[1]!;
+    expect(String(sendUrl)).toBe('https://sdc.slgnt.eu/email/v1/messages/send');
+    expect(sendInit.method).toBe('POST');
+    const headers = new Headers(sendInit.headers as Record<string, string>);
+    expect(headers.get('Authorization')).toBe('Bearer jwt_token_123');
+    expect(headers.get('Content-Type')).toBe('application/json');
+  });
+
+  it('maps RenderedMessage to SDC message items array', async () => {
+    const { selligentTransport } = await import('./index.js');
+    mockTokenThenSend();
+    const t = selligentTransport(oauthOpts);
+    await t.send(baseMessage, baseCtx);
+
+    const body = JSON.parse(fetchMock.mock.calls[1]![1].body);
+    expect(Array.isArray(body)).toBe(true);
+    expect(body).toHaveLength(1);
+    expect(body[0].reference).toBe('m1-0');
+    expect(body[0].content.html).toBe('<p>hi</p>');
+    expect(body[0].content.text).toBe('hi');
+    expect(body[0].headers.subject).toBe('Hello');
+    expect(body[0].headers.to).toEqual({ alias: '', address: 'user@example.com' });
+    expect(body[0].headers.from).toEqual({ alias: 'App', address: 'noreply@example.com' });
+    expect(body[0].context.profile).toBe('user@example.com');
+  });
+
+  it('maps string from address', async () => {
+    const { selligentTransport } = await import('./index.js');
+    mockTokenThenSend();
+    const t = selligentTransport(oauthOpts);
+    await t.send({ ...baseMessage, from: 'plain@example.com' }, baseCtx);
+
+    const body = JSON.parse(fetchMock.mock.calls[1]![1].body);
+    expect(body[0].headers.from).toEqual({ alias: '', address: 'plain@example.com' });
+  });
+
+  it('maps replyTo to the reply header', async () => {
+    const { selligentTransport } = await import('./index.js');
+    mockTokenThenSend();
+    const t = selligentTransport(oauthOpts);
+    await t.send(
+      { ...baseMessage, replyTo: { name: 'Support', email: 'support@example.com' } },
+      baseCtx,
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[1]![1].body);
+    expect(body[0].headers.reply).toEqual({ alias: 'Support', address: 'support@example.com' });
+  });
+
+  it('creates one message item per recipient', async () => {
+    const { selligentTransport } = await import('./index.js');
+    mockTokenThenSend();
+    const t = selligentTransport(oauthOpts);
+    await t.send(
+      {
+        ...baseMessage,
+        to: [{ email: 'a@x.com' }, { name: 'Bee', email: 'b@x.com' }, 'c@x.com'],
+      },
+      baseCtx,
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[1]![1].body);
+    expect(body).toHaveLength(3);
+    expect(body[0].headers.to).toEqual({ alias: '', address: 'a@x.com' });
+    expect(body[0].reference).toBe('m1-0');
+    expect(body[0].context.profile).toBe('a@x.com');
+    expect(body[1].headers.to).toEqual({ alias: 'Bee', address: 'b@x.com' });
+    expect(body[1].reference).toBe('m1-1');
+    expect(body[2].headers.to).toEqual({ alias: '', address: 'c@x.com' });
+    expect(body[2].reference).toBe('m1-2');
+  });
+
+  it('returns accepted addresses on success', async () => {
+    const { selligentTransport } = await import('./index.js');
+    mockTokenThenSend();
+    const t = selligentTransport(oauthOpts);
+    const result = await t.send(baseMessage, baseCtx);
+
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.data.accepted).toEqual(['user@example.com']);
+    expect(result.data.rejected).toEqual([]);
+  });
+
+  it('uses custom baseUrl', async () => {
+    const { selligentTransport } = await import('./index.js');
+    mockTokenThenSend();
+    const t = selligentTransport({ ...oauthOpts, baseUrl: 'https://sdc.custom.com' });
+    await t.send(baseMessage, baseCtx);
+
+    const [sendUrl] = fetchMock.mock.calls[1]!;
+    expect(String(sendUrl)).toBe('https://sdc.custom.com/email/v1/messages/send');
+  });
+
+  it('strips trailing slashes from baseUrl', async () => {
+    const { selligentTransport } = await import('./index.js');
+    mockTokenThenSend();
+    const t = selligentTransport({ ...oauthOpts, baseUrl: 'https://sdc.custom.com///' });
+    await t.send(baseMessage, baseCtx);
+
+    const [sendUrl] = fetchMock.mock.calls[1]!;
+    expect(String(sendUrl)).toBe('https://sdc.custom.com/email/v1/messages/send');
+  });
+
+  it('has name "selligent"', async () => {
+    const { selligentTransport } = await import('./index.js');
+    const t = selligentTransport(oauthOpts);
+    expect(t.name).toBe('selligent');
+  });
+
+  it('omits text when not present', async () => {
+    const { selligentTransport } = await import('./index.js');
+    mockTokenThenSend();
+    const t = selligentTransport(oauthOpts);
+    await t.send({ from: 'a@x.com', to: ['b@x.com'], subject: 's', html: '<p>h</p>' }, baseCtx);
+
+    const body = JSON.parse(fetchMock.mock.calls[1]![1].body);
+    expect(body[0].content.text).toBeUndefined();
+  });
+
+  it('omits reply when replyTo is not present', async () => {
+    const { selligentTransport } = await import('./index.js');
+    mockTokenThenSend();
+    const t = selligentTransport(oauthOpts);
+    await t.send(baseMessage, baseCtx);
+
+    const body = JSON.parse(fetchMock.mock.calls[1]![1].body);
+    expect(body[0].headers.reply).toBeUndefined();
+  });
+
+  it('omits attachments when not present', async () => {
+    const { selligentTransport } = await import('./index.js');
+    mockTokenThenSend();
+    const t = selligentTransport(oauthOpts);
+    await t.send(baseMessage, baseCtx);
+
+    const body = JSON.parse(fetchMock.mock.calls[1]![1].body);
+    expect(body[0].content.attachments).toBeUndefined();
+  });
+
+  it('drops unsupported fields (cc, bcc, headers, tags, priority, inlineAssets)', async () => {
+    const { selligentTransport } = await import('./index.js');
+    mockTokenThenSend();
+    const t = selligentTransport(oauthOpts);
+    const result = await t.send(
+      {
+        ...baseMessage,
+        cc: ['cc@example.com'],
+        bcc: ['bcc@example.com'],
+        headers: { 'X-Campaign': 'launch' },
+        tags: { campaign: 'launch' },
+        priority: 'high',
+        inlineAssets: { logo: { path: '/logo.png' } },
+      },
+      baseCtx,
+    );
+
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('selligentTransport — attachments', () => {
+  it('base64-encodes Buffer attachment content', async () => {
+    const { selligentTransport } = await import('./index.js');
+    mockTokenThenSend();
+    const t = selligentTransport(oauthOpts);
+    await t.send(
+      {
+        ...baseMessage,
+        attachments: [
+          {
+            filename: 'invoice.pdf',
+            content: Buffer.from('pdf-bytes'),
+            contentType: 'application/pdf',
+          },
+        ],
+      },
+      baseCtx,
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[1]![1].body);
+    expect(body[0].content.attachments).toEqual([
+      {
+        file_name: 'invoice.pdf',
+        data: Buffer.from('pdf-bytes').toString('base64'),
+        mime_type: 'application/pdf',
+      },
+    ]);
+  });
+
+  it('base64-encodes string attachment content', async () => {
+    const { selligentTransport } = await import('./index.js');
+    mockTokenThenSend();
+    const t = selligentTransport(oauthOpts);
+    await t.send(
+      {
+        ...baseMessage,
+        attachments: [
+          {
+            filename: 'note.txt',
+            content: 'hello world',
+            contentType: 'text/plain',
+          },
+        ],
+      },
+      baseCtx,
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[1]![1].body);
+    expect(body[0].content.attachments[0].data).toBe(Buffer.from('hello world').toString('base64'));
+  });
+
+  it('defaults mime_type to application/octet-stream when contentType is missing', async () => {
+    const { selligentTransport } = await import('./index.js');
+    mockTokenThenSend();
+    const t = selligentTransport(oauthOpts);
+    await t.send(
+      {
+        ...baseMessage,
+        attachments: [{ filename: 'data.bin', content: Buffer.from('bytes') }],
+      },
+      baseCtx,
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[1]![1].body);
+    expect(body[0].content.attachments[0].mime_type).toBe('application/octet-stream');
+  });
+});
+
+describe('selligentTransport — per-send overrides via TransportDataMap', () => {
+  it('applies profile, tags, metadata, and reference from per-send data', async () => {
+    const { selligentTransport } = await import('./index.js');
+    mockTokenThenSend();
+    const t = selligentTransport(oauthOpts);
+    await t.send(baseMessage, {
+      ...baseCtx,
+      transport: {
+        selligent: {
+          profile: 'crm-123',
+          tags: ['campaign-spring'],
+          metadata: '{"ref":123}',
+          reference: 'custom-ref',
+        },
+      },
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[1]![1].body);
+    expect(body[0].context.profile).toBe('crm-123');
+    expect(body[0].context.tags).toEqual(['campaign-spring']);
+    expect(body[0].context.metadata).toBe('{"ref":123}');
+    expect(body[0].reference).toBe('custom-ref');
+  });
+
+  it('applies list_unsubscribe, custom_send_time, and time_to_live from per-send data', async () => {
+    const { selligentTransport } = await import('./index.js');
+    mockTokenThenSend();
+    const t = selligentTransport(oauthOpts);
+    await t.send(baseMessage, {
+      ...baseCtx,
+      transport: {
+        selligent: {
+          list_unsubscribe: '<https://example.com/unsub>',
+          custom_send_time: '2025-09-02T12:00:00',
+          time_to_live: 'P2D',
+        },
+      },
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[1]![1].body);
+    expect(body[0].headers.list_unsubscribe).toBe('<https://example.com/unsub>');
+    expect(body[0].custom_send_time).toBe('2025-09-02T12:00:00');
+    expect(body[0].time_to_live).toBe('P2D');
+  });
+});
+
+describe('selligentTransport — from validation', () => {
+  it('throws CONFIG error when from is missing', async () => {
+    const { selligentTransport } = await import('./index.js');
+    const t = selligentTransport(oauthOpts);
+    const msg = { ...baseMessage } as Record<string, unknown>;
+    delete msg.from;
+    await expect(t.send(msg as never, baseCtx)).rejects.toThrow(/no "from"/);
+  });
+});
+
+describe('selligentTransport — SDC API errors', () => {
+  it('returns VALIDATION for 422 status', async () => {
+    const { selligentTransport } = await import('./index.js');
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify(tokenResponse), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error_message: 'Invalid property description' }), {
+          status: 422,
+        }),
+      );
+    const t = selligentTransport(oauthOpts);
+    const result = await t.send(baseMessage, baseCtx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('VALIDATION');
+    expect(err.provider).toBe('selligent');
+    expect(err.httpStatus).toBe(422);
+    expect(err.retriable).toBe(false);
+    expect(err.message).toContain('Invalid property description');
+  });
+
+  it('returns CONFIG for 401 status', async () => {
+    const { selligentTransport } = await import('./index.js');
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify(tokenResponse), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error_message: 'Unauthorized' }), { status: 401 }),
+      );
+    const t = selligentTransport(oauthOpts);
+    const result = await t.send(baseMessage, baseCtx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('CONFIG');
+    expect(err.httpStatus).toBe(401);
+    expect(err.retriable).toBe(false);
+  });
+
+  it('returns RATE_LIMITED for 429 status', async () => {
+    const { selligentTransport } = await import('./index.js');
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify(tokenResponse), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error_message: 'Too many requests' }), { status: 429 }),
+      );
+    const t = selligentTransport(oauthOpts);
+    const result = await t.send(baseMessage, baseCtx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('RATE_LIMITED');
+    expect(err.httpStatus).toBe(429);
+    expect(err.retriable).toBe(true);
+  });
+
+  it('returns PROVIDER (retriable) for 500 server error', async () => {
+    const { selligentTransport } = await import('./index.js');
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify(tokenResponse), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 500 }));
+    const t = selligentTransport(oauthOpts);
+    const result = await t.send(baseMessage, baseCtx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('PROVIDER');
+    expect(err.httpStatus).toBe(500);
+    expect(err.retriable).toBe(true);
+  });
+
+  it('falls back to "request failed" when error_message is absent', async () => {
+    const { selligentTransport } = await import('./index.js');
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify(tokenResponse), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 422 }));
+    const t = selligentTransport(oauthOpts);
+    const result = await t.send(baseMessage, baseCtx);
+
+    if (result.ok) throw new Error('expected not ok');
+    expect(result.error.message).toContain('request failed');
+  });
+});
+
+describe('selligentTransport — network errors', () => {
+  it('returns PROVIDER when send fetch throws (network failure)', async () => {
+    const { selligentTransport } = await import('./index.js');
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify(tokenResponse), { status: 200 }))
+      .mockRejectedValueOnce(new TypeError('fetch failed'));
+    const t = selligentTransport(oauthOpts);
+    const result = await t.send(baseMessage, baseCtx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('PROVIDER');
+    expect(err.provider).toBe('selligent');
+    expect(err.retriable).toBe(true);
+    expect(err.message).toContain('network error');
+  });
+
+  it('returns TIMEOUT when send fetch throws AbortError', async () => {
+    const { selligentTransport } = await import('./index.js');
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify(tokenResponse), { status: 200 }))
+      .mockRejectedValueOnce(new DOMException('aborted', 'AbortError'));
+    const t = selligentTransport(oauthOpts);
+    const result = await t.send(baseMessage, baseCtx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected not ok');
+    const err = result.error as NotifyRpcProviderError;
+    expect(err.code).toBe('TIMEOUT');
+    expect(err.provider).toBe('selligent');
+    expect(err.retriable).toBe(true);
+    expect(err.message).toContain('request timed out');
+  });
+});
+
+describe('selligentTransport — verify', () => {
+  it('returns ok:true when token fetch succeeds', async () => {
+    const { selligentTransport } = await import('./index.js');
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(tokenResponse), { status: 200 }));
+    const t = selligentTransport(oauthOpts);
+    const result = await t.verify!();
+
+    expect(result.ok).toBe(true);
+    expect(result.details).toEqual({ tokenLength: tokenResponse.access_token.length });
+  });
+
+  it('returns ok:false when token fetch fails', async () => {
+    const { selligentTransport } = await import('./index.js');
+    fetchMock.mockResolvedValueOnce(new Response('Invalid credentials', { status: 401 }));
+    const t = selligentTransport(oauthOpts);
+    const result = await t.verify!();
+
+    expect(result.ok).toBe(false);
+    expect(result.details).toContain('OAuth token request failed');
+  });
+
+  it('returns ok:false when token fetch throws network error', async () => {
+    const { selligentTransport } = await import('./index.js');
+    fetchMock.mockRejectedValueOnce(new TypeError('fetch failed'));
+    const t = selligentTransport(oauthOpts);
+    const result = await t.verify!();
+
+    expect(result.ok).toBe(false);
+    expect(result.details).toContain('fetch failed');
+  });
+
+  it('delegates to getAccessToken when provided', async () => {
+    const { selligentTransport } = await import('./index.js');
+    const getAccessToken = vi.fn().mockResolvedValue('custom_token');
+    const t = selligentTransport({ getAccessToken });
+    const result = await t.verify!();
+
+    expect(result.ok).toBe(true);
+    expect(getAccessToken).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/selligent/src/index.ts
+++ b/packages/selligent/src/index.ts
@@ -99,9 +99,9 @@ const createTokenManager = (opts: SelligentTransportOptions) => {
     });
 
     if (!res.ok) {
-      const textResult = await handlePromise(res.text());
+      const [, body] = await handlePromise(res.text());
       throw new NotifyRpcProviderError({
-        message: `Selligent transport: OAuth token request failed [${res.status}]${textResult[1] ? `: ${textResult[1]}` : ''}`,
+        message: `Selligent transport: OAuth token request failed [${res.status}]${body ? `: ${body}` : ''}`,
         code: 'CONFIG',
         provider: 'selligent',
         httpStatus: res.status,
@@ -168,11 +168,11 @@ export const selligentTransport = (opts: SelligentTransportOptions) => {
     name: 'selligent',
 
     async verify() {
-      const verifyResult = await handlePromise(tokenManager.getToken());
-      if (verifyResult[0]) {
-        return { ok: false, details: verifyResult[0].message };
+      const [err, token] = await handlePromise(tokenManager.getToken());
+      if (err) {
+        return { ok: false, details: err.message };
       }
-      return { ok: true, details: { tokenLength: verifyResult[1].length } };
+      return { ok: true, details: { tokenLength: token.length } };
     },
 
     async send(message, ctx) {
@@ -186,21 +186,21 @@ export const selligentTransport = (opts: SelligentTransportOptions) => {
         });
       }
 
-      const tokenResult = await handlePromise(tokenManager.getToken());
-      if (tokenResult[0]) {
-        if (tokenResult[0] instanceof NotifyRpcProviderError) {
-          return { ok: false, error: tokenResult[0] };
+      const [tokenErr, token] = await handlePromise(tokenManager.getToken());
+      if (tokenErr) {
+        if (tokenErr instanceof NotifyRpcProviderError) {
+          return { ok: false, error: tokenErr };
         }
         return {
           ok: false,
           error: new NotifyRpcProviderError({
-            message: `Selligent transport: failed to obtain access token: ${tokenResult[0].message}`,
+            message: `Selligent transport: failed to obtain access token: ${tokenErr.message}`,
             code: 'CONFIG',
             provider: 'selligent',
             retriable: true,
             route: ctx.route,
             messageId: ctx.messageId,
-            cause: tokenResult[0],
+            cause: tokenErr,
           }),
         };
       }
@@ -211,7 +211,7 @@ export const selligentTransport = (opts: SelligentTransportOptions) => {
       const result = await http.request<unknown, SelligentErrorResponse>(url, {
         method: 'POST',
         headers: {
-          Authorization: `Bearer ${tokenResult[1]}`,
+          Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(items),

--- a/packages/selligent/src/index.ts
+++ b/packages/selligent/src/index.ts
@@ -1,0 +1,271 @@
+import type { Address, RenderedMessage } from '@betternotify/email';
+import { createTransport, normalizeAddress } from '@betternotify/email/transports';
+import {
+  consoleLogger,
+  handlePromise,
+  NotifyRpcError,
+  NotifyRpcProviderError,
+} from '@betternotify/core';
+import { createHttpClient, mapHttpStatus } from '@betternotify/core/transports';
+import type {
+  SelligentAddress,
+  SelligentAttachment,
+  SelligentErrorResponse,
+  SelligentMessageItem,
+  SelligentPerSendData,
+  SelligentTokenResponse,
+  SelligentTransportOptions,
+} from './types.js';
+
+export type {
+  SelligentAddress,
+  SelligentAttachment,
+  SelligentErrorResponse,
+  SelligentMessageItem,
+  SelligentPerSendData,
+  SelligentTokenResponse,
+  SelligentTransportOptions,
+  SelligentOAuthCredentials,
+  SelligentMessageContext,
+} from './types.js';
+
+export { isSelligentRetriable } from './is-retriable.js';
+
+declare module '@betternotify/core' {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- declaration merging requires interface
+  interface TransportDataMap {
+    selligent: import('./types.js').SelligentPerSendData;
+  }
+}
+
+const DEFAULT_BASE_URL = 'https://sdc.slgnt.eu';
+const DEFAULT_AUTH_URL = 'https://auth.slgnt.eu/oauth/token';
+const DEFAULT_AUDIENCE = 'https://sdc.slgnt.eu';
+const DEFAULT_TIMEOUT_MS = 30_000;
+const TOKEN_REFRESH_BUFFER_MS = 60_000;
+
+const toBase64 = (content: Buffer | string): string => {
+  if (Buffer.isBuffer(content)) return content.toString('base64');
+  return Buffer.from(content).toString('base64');
+};
+
+const toSelligentAddress = (addr: Address): SelligentAddress => {
+  if (typeof addr === 'string') return { alias: '', address: addr };
+  return { alias: addr.name ?? '', address: addr.email };
+};
+
+const toAttachments = (
+  attachments: NonNullable<RenderedMessage['attachments']>,
+): SelligentAttachment[] =>
+  attachments.map((att) => ({
+    file_name: att.filename,
+    data: toBase64(att.content),
+    mime_type: att.contentType ?? 'application/octet-stream',
+  }));
+
+const hasOAuthCredentials = (
+  opts: SelligentTransportOptions,
+): opts is SelligentTransportOptions & {
+  clientId: number;
+  clientSecret: string;
+  accountId: string;
+} => 'clientId' in opts;
+
+const createTokenManager = (opts: SelligentTransportOptions) => {
+  if (!hasOAuthCredentials(opts)) {
+    return { getToken: opts.getAccessToken };
+  }
+
+  const authUrl = opts.authUrl ?? DEFAULT_AUTH_URL;
+  const audience = opts.audience ?? DEFAULT_AUDIENCE;
+  let cachedToken: string | undefined;
+  let expiresAt = 0;
+
+  const getToken = async (): Promise<string> => {
+    if (cachedToken && Date.now() < expiresAt - TOKEN_REFRESH_BUFFER_MS) {
+      return cachedToken;
+    }
+
+    const res = await fetch(authUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: opts.clientId,
+        client_secret: opts.clientSecret,
+        account_id: opts.accountId,
+        grant_type: 'client_credentials',
+        audience,
+      }),
+    });
+
+    if (!res.ok) {
+      const [, body] = await handlePromise(res.text());
+      throw new NotifyRpcProviderError({
+        message: `Selligent transport: OAuth token request failed [${res.status}]${body ? `: ${body}` : ''}`,
+        code: 'CONFIG',
+        provider: 'selligent',
+        httpStatus: res.status,
+        retriable: res.status >= 500,
+      });
+    }
+
+    const data = (await res.json()) as SelligentTokenResponse;
+    cachedToken = data.access_token;
+    expiresAt = Date.now() + data.expires_in * 1000;
+    return cachedToken;
+  };
+
+  return { getToken };
+};
+
+const buildMessageItems = (
+  message: RenderedMessage,
+  from: Address,
+  ctx: { messageId: string },
+  perSend?: SelligentPerSendData,
+): SelligentMessageItem[] =>
+  message.to.map((to, i) => {
+    const item: SelligentMessageItem = {
+      reference: perSend?.reference ?? `${ctx.messageId}-${i}`,
+      content: {
+        html: message.html,
+      },
+      headers: {
+        subject: message.subject,
+        to: toSelligentAddress(to),
+        from: toSelligentAddress(from),
+      },
+      context: {
+        profile: perSend?.profile ?? normalizeAddress(to),
+      },
+    };
+
+    if (message.text) item.content.text = message.text;
+    if (message.attachments?.length) item.content.attachments = toAttachments(message.attachments);
+    if (message.replyTo) item.headers.reply = toSelligentAddress(message.replyTo);
+
+    if (perSend?.list_unsubscribe) item.headers.list_unsubscribe = perSend.list_unsubscribe;
+    if (perSend?.tags) item.context.tags = perSend.tags;
+    if (perSend?.metadata) item.context.metadata = perSend.metadata;
+    if (perSend?.custom_send_time) item.custom_send_time = perSend.custom_send_time;
+    if (perSend?.time_to_live) item.time_to_live = perSend.time_to_live;
+
+    return item;
+  });
+
+/** @experimental Selligent (Marigold Engage) transport using the SDC transactional email API. */
+export const selligentTransport = (opts: SelligentTransportOptions) => {
+  const baseUrl = (opts.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+  const url = `${baseUrl}/email/v1/messages/send`;
+  const log = (opts.logger ?? consoleLogger()).child({ component: 'selligent' });
+  const http = createHttpClient({
+    ...opts.http,
+    timeoutMs: opts.http?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  });
+  const tokenManager = createTokenManager(opts);
+
+  return createTransport({
+    name: 'selligent',
+
+    async verify() {
+      const [err, token] = await handlePromise(tokenManager.getToken());
+
+      if (err) {
+        return { ok: false, details: err.message };
+      }
+
+      return { ok: true, details: { tokenLength: token.length } };
+    },
+
+    async send(message, ctx) {
+      if (!message.from) {
+        throw new NotifyRpcError({
+          message:
+            'Selligent transport: no "from" address. Set it on the channel default, route `.from()` resolver, or per-call args.',
+          code: 'CONFIG',
+          route: ctx.route,
+          messageId: ctx.messageId,
+        });
+      }
+
+      const [tokenErr, token] = await handlePromise(tokenManager.getToken());
+      if (tokenErr) {
+        if (tokenErr instanceof NotifyRpcProviderError) {
+          return { ok: false, error: tokenErr };
+        }
+        return {
+          ok: false,
+          error: new NotifyRpcProviderError({
+            message: `Selligent transport: failed to obtain access token: ${tokenErr.message}`,
+            code: 'CONFIG',
+            provider: 'selligent',
+            retriable: true,
+            route: ctx.route,
+            messageId: ctx.messageId,
+            cause: tokenErr,
+          }),
+        };
+      }
+
+      const perSend = ctx.transport?.selligent as SelligentPerSendData | undefined;
+      const items = buildMessageItems(message, message.from, ctx, perSend);
+
+      const result = await http.request<unknown, SelligentErrorResponse>(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(items),
+      });
+
+      if (!result.ok) {
+        if (result.kind === 'network') {
+          log.error('Selligent fetch failed', { err: result.cause, route: ctx.route });
+          return {
+            ok: false,
+            error: new NotifyRpcProviderError({
+              message: `Selligent transport: ${result.timedOut ? 'request timed out' : `network error: ${result.cause.message}`}`,
+              code: result.timedOut ? 'TIMEOUT' : 'PROVIDER',
+              provider: 'selligent',
+              retriable: true,
+              route: ctx.route,
+              messageId: ctx.messageId,
+              cause: result.cause,
+            }),
+          };
+        }
+
+        const errData = result.body ?? ({} as SelligentErrorResponse);
+        const { code, retriable } = mapHttpStatus(result.status);
+        const errorMessage = `Selligent transport: [${result.status}] ${errData.error_message ?? 'request failed'}`;
+        log.error(errorMessage, {
+          err: { status: result.status, body: errData },
+          route: ctx.route,
+        });
+
+        return {
+          ok: false,
+          error: new NotifyRpcProviderError({
+            message: errorMessage,
+            code,
+            provider: 'selligent',
+            httpStatus: result.status,
+            retriable,
+            route: ctx.route,
+            messageId: ctx.messageId,
+          }),
+        };
+      }
+
+      return {
+        ok: true,
+        data: {
+          accepted: message.to.map(normalizeAddress),
+          rejected: [],
+          raw: items,
+        },
+      };
+    },
+  });
+};

--- a/packages/selligent/src/index.ts
+++ b/packages/selligent/src/index.ts
@@ -99,7 +99,8 @@ const createTokenManager = (opts: SelligentTransportOptions) => {
     });
 
     if (!res.ok) {
-      const [, body] = await handlePromise(res.text());
+      const textResult = await handlePromise(res.text());
+      const body = textResult[1];
       throw new NotifyRpcProviderError({
         message: `Selligent transport: OAuth token request failed [${res.status}]${body ? `: ${body}` : ''}`,
         code: 'CONFIG',
@@ -168,13 +169,11 @@ export const selligentTransport = (opts: SelligentTransportOptions) => {
     name: 'selligent',
 
     async verify() {
-      const [err, token] = await handlePromise(tokenManager.getToken());
-
-      if (err) {
-        return { ok: false, details: err.message };
+      const verifyResult = await handlePromise(tokenManager.getToken());
+      if (verifyResult[0]) {
+        return { ok: false, details: verifyResult[0].message };
       }
-
-      return { ok: true, details: { tokenLength: token.length } };
+      return { ok: true, details: { tokenLength: verifyResult[1].length } };
     },
 
     async send(message, ctx) {
@@ -188,21 +187,21 @@ export const selligentTransport = (opts: SelligentTransportOptions) => {
         });
       }
 
-      const [tokenErr, token] = await handlePromise(tokenManager.getToken());
-      if (tokenErr) {
-        if (tokenErr instanceof NotifyRpcProviderError) {
-          return { ok: false, error: tokenErr };
+      const tokenResult = await handlePromise(tokenManager.getToken());
+      if (tokenResult[0]) {
+        if (tokenResult[0] instanceof NotifyRpcProviderError) {
+          return { ok: false, error: tokenResult[0] };
         }
         return {
           ok: false,
           error: new NotifyRpcProviderError({
-            message: `Selligent transport: failed to obtain access token: ${tokenErr.message}`,
+            message: `Selligent transport: failed to obtain access token: ${tokenResult[0].message}`,
             code: 'CONFIG',
             provider: 'selligent',
             retriable: true,
             route: ctx.route,
             messageId: ctx.messageId,
-            cause: tokenErr,
+            cause: tokenResult[0],
           }),
         };
       }
@@ -213,7 +212,7 @@ export const selligentTransport = (opts: SelligentTransportOptions) => {
       const result = await http.request<unknown, SelligentErrorResponse>(url, {
         method: 'POST',
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: `Bearer ${tokenResult[1]}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(items),

--- a/packages/selligent/src/index.ts
+++ b/packages/selligent/src/index.ts
@@ -100,9 +100,8 @@ const createTokenManager = (opts: SelligentTransportOptions) => {
 
     if (!res.ok) {
       const textResult = await handlePromise(res.text());
-      const body = textResult[1];
       throw new NotifyRpcProviderError({
-        message: `Selligent transport: OAuth token request failed [${res.status}]${body ? `: ${body}` : ''}`,
+        message: `Selligent transport: OAuth token request failed [${res.status}]${textResult[1] ? `: ${textResult[1]}` : ''}`,
         code: 'CONFIG',
         provider: 'selligent',
         httpStatus: res.status,

--- a/packages/selligent/src/is-retriable.test.ts
+++ b/packages/selligent/src/is-retriable.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { NotifyRpcError, NotifyRpcProviderError } from '@betternotify/core';
+import { isSelligentRetriable } from './is-retriable.js';
+
+describe('isSelligentRetriable', () => {
+  it('returns true when NotifyRpcProviderError has retriable: true', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'timeout',
+      provider: 'selligent',
+      retriable: true,
+    });
+    expect(isSelligentRetriable(err)).toBe(true);
+  });
+
+  it('returns false when NotifyRpcProviderError has retriable: false', () => {
+    const err = new NotifyRpcProviderError({
+      message: 'invalid key',
+      provider: 'selligent',
+      code: 'CONFIG',
+      retriable: false,
+    });
+    expect(isSelligentRetriable(err)).toBe(false);
+  });
+
+  it('returns true for non-NotifyRpcProviderError errors', () => {
+    expect(isSelligentRetriable(new NotifyRpcError({ message: 'x' }))).toBe(true);
+    expect(isSelligentRetriable(new Error('random'))).toBe(true);
+  });
+});

--- a/packages/selligent/src/is-retriable.ts
+++ b/packages/selligent/src/is-retriable.ts
@@ -1,0 +1,6 @@
+import { NotifyRpcProviderError } from '@betternotify/core';
+
+export const isSelligentRetriable = (err: unknown): boolean => {
+  if (err instanceof NotifyRpcProviderError) return err.retriable;
+  return true;
+};

--- a/packages/selligent/src/types.ts
+++ b/packages/selligent/src/types.ts
@@ -1,0 +1,74 @@
+import type { LoggerLike } from '@betternotify/core';
+import type { HttpClientBehaviorOptions } from '@betternotify/core/transports';
+
+export type SelligentOAuthCredentials = {
+  clientId: number;
+  clientSecret: string;
+  accountId: string;
+};
+
+export type SelligentTransportOptions = {
+  baseUrl?: string;
+  authUrl?: string;
+  audience?: string;
+  logger?: LoggerLike;
+  http?: HttpClientBehaviorOptions;
+} & (SelligentOAuthCredentials | { getAccessToken: () => Promise<string> });
+
+export type SelligentAddress = {
+  alias: string;
+  address: string;
+};
+
+export type SelligentAttachment = {
+  file_name: string;
+  data: string;
+  mime_type: string;
+};
+
+export type SelligentMessageContext = {
+  profile: string;
+  tags?: string[];
+  metadata?: string;
+};
+
+export type SelligentMessageItem = {
+  reference: string;
+  content: {
+    html: string;
+    text?: string;
+    attachments?: SelligentAttachment[];
+  };
+  headers: {
+    subject: string;
+    to: SelligentAddress;
+    from: SelligentAddress;
+    reply?: SelligentAddress;
+    list_unsubscribe?: string;
+  };
+  context: SelligentMessageContext;
+  custom_send_time?: string;
+  time_to_live?: string;
+};
+
+export type SelligentTokenResponse = {
+  access_token: string;
+  token_type: string;
+  refresh_token: string;
+  scope: string;
+  expires_in: number;
+};
+
+export type SelligentErrorResponse = {
+  error_message?: string;
+};
+
+export type SelligentPerSendData = {
+  profile?: string;
+  tags?: string[];
+  metadata?: string;
+  reference?: string;
+  list_unsubscribe?: string;
+  custom_send_time?: string;
+  time_to_live?: string;
+};

--- a/packages/selligent/tsconfig.json
+++ b/packages/selligent/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@internal/tsconfig/base.json",
+  "compilerOptions": { "rootDir": ".", "outDir": "dist", "noEmit": true },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,6 +320,9 @@ importers:
       '@betternotify/resend':
         specifier: workspace:*
         version: link:../../../../packages/resend
+      '@betternotify/selligent':
+        specifier: workspace:*
+        version: link:../../../../packages/selligent
       '@betternotify/slack':
         specifier: workspace:*
         version: link:../../../../packages/slack
@@ -798,6 +801,31 @@ importers:
         version: 4.3.6
 
   packages/resend:
+    dependencies:
+      '@betternotify/core':
+        specifier: workspace:*
+        version: link:../core
+      '@betternotify/email':
+        specifier: workspace:*
+        version: link:../email
+    devDependencies:
+      '@internal/rolldown-config':
+        specifier: workspace:*
+        version: link:../../internal/rolldown-config
+      '@internal/tsconfig':
+        specifier: workspace:*
+        version: link:../../internal/tsconfig
+      rolldown:
+        specifier: 'catalog:'
+        version: 1.0.0
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@25.6.0)(lightningcss@1.32.0)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))
+
+  packages/selligent:
     dependencies:
       '@betternotify/core':
         specifier: workspace:*

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -105,6 +105,12 @@
       "component": "@betternotify/web",
       "prerelease-type": "beta",
       "bootstrap-sha": "4edb9f254f0a3987a2a3026e1a9e03ed14485ed3"
+    },
+    "packages/selligent": {
+      "release-type": "node",
+      "component": "@betternotify/selligent",
+      "prerelease-type": "beta",
+      "bootstrap-sha": "718f957fc28af4840ad33ebf0f9fe45dccfdd544"
     }
   }
 }


### PR DESCRIPTION
## Overview

Adds the `@betternotify/selligent` transport package for transactional email delivery via the Selligent Delivery Cloud (SDC) API. This is the first OAuth 2.0–based transport in the codebase — all previous transports use static API keys.

## What's changed and why?

### New package: `@betternotify/selligent`
- **`packages/selligent/src/types.ts`** — Type definitions for OAuth credentials, SDC address/message/attachment shapes, per-send overrides, and token/error responses
- **`packages/selligent/src/index.ts`** — Transport factory with built-in OAuth 2.0 client credentials token management (fetch, cache, auto-refresh), SDC message mapping, and error handling. Supports `getAccessToken` escape hatch for users managing tokens externally
- **`packages/selligent/src/is-retriable.ts`** — Standard `isSelligentRetriable` helper
- **`packages/selligent/src/index.test.ts`** — 38 tests covering OAuth flow, token caching/refresh, send mapping, per-send overrides, error handling, and verify
- **`packages/selligent/src/is-retriable.test.ts`** — 3 tests for retriable helper
- **`packages/selligent/README.md`** — Full package documentation

### Release config
- **`release-please-config.json`** — Added `packages/selligent` entry with bootstrap SHA
- **`.release-please-manifest.json`** — Added `packages/selligent` at `1.0.0-beta.1`

### Docs
- **`apps/web/content/docs/transports/selligent.mdx`** — Full docs page covering credentials, install, usage, custom token provider, verify, options, per-send overrides, multiple recipients, authentication flow, error handling, and dropped fields
- **`apps/web/content/docs/transports/meta.json`** — Added `selligent` to nav order
- **`apps/web/content/docs/transports/index.mdx`** — Added Selligent to the transport list
- **`apps/web/src/lib/source.ts`** — Channel badge mapping for `selligent: 'email'`
- **`apps/web/src/components/landing/marquee.tsx`** — Added Selligent to the provider marquee

### Example
- **`examples/welcome-text/apps/cli/src/examples/email-selligent.ts`** — Example showing OAuth transport creation, credential verification, and email send
- **`.env.example`** — Added `SELLIGENT_CLIENT_ID`, `SELLIGENT_CLIENT_SECRET`, `SELLIGENT_ACCOUNT_ID`, `SELLIGENT_FROM_EMAIL`, `SELLIGENT_DESTINATION_EMAIL`
- **`env.ts`** — Added Selligent env vars with Zod validation
- **`index.ts`** — Wired `email-selligent` into the example router

## Key design decisions

- **OAuth 2.0 client credentials** with in-closure token caching and auto-refresh (60s buffer before expiry). Token is fetched lazily on first send, not on transport construction
- **`getAccessToken` escape hatch** for users who already manage tokens externally (e.g. shared token store across services)
- **Batch array format** — maps each `to` recipient into a separate item in the SDC JSON array. One HTTP round-trip per `.send()`
- **`verify()` method** tests credentials by attempting a token fetch without sending email
- **`TransportDataMap` declaration merging** for typed per-send overrides (`profile`, `tags`, `metadata`, `reference`, `list_unsubscribe`, `custom_send_time`, `time_to_live`)
- **Region support** — `baseUrl`, `authUrl`, and `audience` are all configurable for EU/US tenants

## How to test

1. `pnpm install && pnpm build`
2. `pnpm --filter @betternotify/selligent test` — 41 tests pass
3. `pnpm typecheck` — clean
4. `pnpm lint` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Selligent (Marigold Engage) as a new email transport with OAuth2 support, configurable options, and per-message overrides.

* **Documentation**
  * Added full Selligent integration docs and package README; updated site transports listing and marketing marquee.

* **Tests**
  * Added tests covering token handling, send behavior, error mapping, and retry logic.

* **Chores**
  * Registered new package in release manifest and config.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-notify/better-notify/pull/114)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->