### PR TITLE
feat(core): infer channels from catalog

### DIFF
--- a/packages/core/src/catalog.ts
+++ b/packages/core/src/catalog.ts
@@ -1,11 +1,12 @@
 import type { InferInput, InferOutput } from './schema.js';
-import type { ChannelDefinition } from './channel/types.js';
+import type { ChannelDefinition, ChannelMap } from './channel/types.js';
 
 const CATALOG_BRAND = 'Catalog' as const;
 
-export type Catalog<M, Ctx = unknown> = {
+export type Catalog<M, Ctx = unknown, Channels extends ChannelMap = ChannelMap> = {
   readonly _brand: typeof CATALOG_BRAND;
   readonly _ctx: Ctx;
+  readonly _channels: Channels;
   readonly definitions: { readonly [k: string]: ChannelDefinition<any, any> };
   readonly nested: { readonly [K in keyof M]: NestedValue<M[K]> };
   readonly routes: ReadonlyArray<string>;
@@ -14,6 +15,7 @@ export type Catalog<M, Ctx = unknown> = {
 export type AnyCatalog = {
   readonly _brand: typeof CATALOG_BRAND;
   readonly _ctx: any;
+  readonly _channels: any;
   readonly definitions: Record<string, ChannelDefinition<any, any>>;
   readonly nested: Record<string, unknown>;
   readonly routes: ReadonlyArray<string>;
@@ -86,6 +88,7 @@ export const createCatalog = <const M extends Record<string, unknown>, Ctx = unk
   return {
     _brand: CATALOG_BRAND,
     _ctx: undefined as never,
+    _channels: undefined as never,
     definitions,
     nested: nested as Catalog<M, Ctx>['nested'],
     routes,
@@ -97,6 +100,8 @@ type SchemaOf<B> = B extends { readonly schema: infer S } ? S : never;
 type CatalogOf<R> = R extends Catalog<infer M, any> ? M : never;
 
 export type CtxOf<R> = R extends Catalog<any, infer Ctx> ? Ctx : unknown;
+
+export type ChannelsOf<R> = R extends Catalog<any, any, infer C> ? C : ChannelMap;
 
 export type InputOf<R extends AnyCatalog, K extends keyof CatalogOf<R> & string> =
   InferInput<SchemaOf<CatalogOf<R>[K]>> extends never

--- a/packages/core/src/channel/define-channel.ts
+++ b/packages/core/src/channel/define-channel.ts
@@ -2,7 +2,7 @@ import type { AnyStandardSchema, InferOutput } from '../schema.js';
 import { validate } from '../schema.js';
 import type { AnyMiddleware, Middleware } from '../middlewares/types.js';
 import type { Transport } from '../transport.js';
-import type { Channel, ChannelBuilderCtx, ChannelDefinition } from './types.js';
+import type { AnyChannel, Channel, ChannelBuilderCtx, ChannelDefinition } from './types.js';
 
 export type ResolverSlot<TValue> = TValue | ((args: { input: any; ctx: unknown }) => TValue);
 
@@ -116,6 +116,7 @@ const buildBuilder = <
   channelName: TChannel,
   slots: TSlotConfig,
   state: BuilderState,
+  getChannelRef: () => AnyChannel,
 ): ChannelBuilder<TInput, TSlotValues, TSlotConfig, TArgsBase, TRendered, TChannel> => {
   const next = (
     patch: Partial<BuilderState>,
@@ -128,6 +129,7 @@ const buildBuilder = <
         ...patch,
         runtime: { ...state.runtime, ...patch.runtime },
       },
+      getChannelRef,
     );
 
   const builder: Record<string | symbol, unknown> = {
@@ -157,6 +159,7 @@ const buildBuilder = <
         schema: state.schema,
         middleware: state.middleware,
         runtime: state.runtime,
+        channelRef: getChannelRef(),
         _args: undefined as never,
         _rendered: undefined as never,
       };
@@ -202,68 +205,90 @@ export const defineChannel = <
   ArgsFromValidator<TValidator>,
   TRendered,
   Transport<TRendered, unknown>
-> => ({
-  name: opts.name,
-  createBuilder: (ctx: ChannelBuilderCtx) =>
-    buildBuilder<
+> => {
+  const channel: Channel<
+    TName,
+    ChannelBuilder<
       unknown,
       SlotValuesOf<TSlotConfig>,
       TSlotConfig,
       ArgsBase<ArgsFromValidator<TValidator>>,
       TRendered,
       TName
-    >(opts.name, opts.slots, {
-      schema: undefined,
-      middleware: [...ctx.rootMiddleware],
-      runtime: {},
-    }),
-  finalize: (state, id) =>
-    (
-      state as ChannelBuilder<
+    >,
+    ArgsFromValidator<TValidator>,
+    TRendered,
+    Transport<TRendered, unknown>
+  > = {
+    name: opts.name,
+    createBuilder: (ctx: ChannelBuilderCtx) =>
+      buildBuilder<
         unknown,
         SlotValuesOf<TSlotConfig>,
         TSlotConfig,
         ArgsBase<ArgsFromValidator<TValidator>>,
         TRendered,
         TName
-      >
-    )._finalize(id) as ChannelDefinition<ArgsFromValidator<TValidator>, TRendered>,
-  validateArgs: isStandardSchema(opts.validateArgs)
-    ? async (args: unknown) => {
-        const validated = (await validate(opts.validateArgs as AnyStandardSchema, args, {
-          route: opts.name,
-        })) as Record<string, unknown>;
-        const inputField =
-          args && typeof args === 'object' && 'input' in args
-            ? (args as { input: unknown }).input
-            : undefined;
-        return { input: inputField, ...validated } as ArgsFromValidator<TValidator>;
-      }
-    : (opts.validateArgs as (
-        args: unknown,
-      ) => ArgsFromValidator<TValidator> | Promise<ArgsFromValidator<TValidator>>),
-  render: async (def, args, ctx) => {
-    const runtime = resolveRuntime(
-      def.runtime as Record<string, unknown>,
-      opts.slots,
-      (args as { input: unknown }).input,
-      ctx,
-    ) as { [K in keyof TSlotConfig]: SlotRuntimeType<TSlotConfig[K], ValueOf<TSlotConfig[K]>> };
-    return opts.render({ runtime, args: args as WithInput<ArgsFromValidator<TValidator>>, ctx });
-  },
-  previewRender: opts.previewRender
-    ? ((_fn) => async (def: ChannelDefinition<unknown, unknown>, input: unknown, ctx: unknown) => {
-        const runtime = resolveRuntime(
-          def.runtime as Record<string, unknown>,
-          opts.slots,
-          input,
-          ctx,
-        ) as never;
-        return _fn({ runtime, input, ctx });
-      })(opts.previewRender)
-    : undefined,
-  _transport: undefined as never,
-});
+      >(
+        opts.name,
+        opts.slots,
+        {
+          schema: undefined,
+          middleware: [...ctx.rootMiddleware],
+          runtime: {},
+        },
+        () => channel as unknown as AnyChannel,
+      ),
+    finalize: (state, id) =>
+      (
+        state as ChannelBuilder<
+          unknown,
+          SlotValuesOf<TSlotConfig>,
+          TSlotConfig,
+          ArgsBase<ArgsFromValidator<TValidator>>,
+          TRendered,
+          TName
+        >
+      )._finalize(id) as ChannelDefinition<ArgsFromValidator<TValidator>, TRendered>,
+    validateArgs: isStandardSchema(opts.validateArgs)
+      ? async (args: unknown) => {
+          const validated = (await validate(opts.validateArgs as AnyStandardSchema, args, {
+            route: opts.name,
+          })) as Record<string, unknown>;
+          const inputField =
+            args && typeof args === 'object' && 'input' in args
+              ? (args as { input: unknown }).input
+              : undefined;
+          return { input: inputField, ...validated } as ArgsFromValidator<TValidator>;
+        }
+      : (opts.validateArgs as (
+          args: unknown,
+        ) => ArgsFromValidator<TValidator> | Promise<ArgsFromValidator<TValidator>>),
+    render: async (def, args, ctx) => {
+      const runtime = resolveRuntime(
+        def.runtime as Record<string, unknown>,
+        opts.slots,
+        (args as { input: unknown }).input,
+        ctx,
+      ) as { [K in keyof TSlotConfig]: SlotRuntimeType<TSlotConfig[K], ValueOf<TSlotConfig[K]>> };
+      return opts.render({ runtime, args: args as WithInput<ArgsFromValidator<TValidator>>, ctx });
+    },
+    previewRender: opts.previewRender
+      ? ((_fn) =>
+          async (def: ChannelDefinition<unknown, unknown>, input: unknown, ctx: unknown) => {
+            const runtime = resolveRuntime(
+              def.runtime as Record<string, unknown>,
+              opts.slots,
+              input,
+              ctx,
+            ) as never;
+            return _fn({ runtime, input, ctx });
+          })(opts.previewRender)
+      : undefined,
+    _transport: undefined as never,
+  };
+  return channel;
+};
 
 type ResolverSlotSpec<TValue, R extends boolean> = SlotConfig<'resolver'> & {
   required: R;

--- a/packages/core/src/channel/types.ts
+++ b/packages/core/src/channel/types.ts
@@ -7,6 +7,7 @@ export type ChannelDefinition<TArgs, TRendered> = {
   readonly schema: AnyStandardSchema;
   readonly middleware: ReadonlyArray<AnyMiddleware>;
   readonly runtime: unknown;
+  readonly channelRef?: AnyChannel;
   readonly _args: TArgs;
   readonly _rendered: TRendered;
 };

--- a/packages/core/src/client.multichannel.test.ts
+++ b/packages/core/src/client.multichannel.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { createClient } from './client.js';
+import { defineChannel, slot } from './channel/define-channel.js';
+import { createNotify } from './notify.js';
 import { NotifyRpcError } from './errors.js';
 import type { AnyChannel, AnyCatalog, ChannelDefinition } from './index.js';
 
@@ -88,6 +90,7 @@ const buildTestCatalog = (): AnyCatalog => {
   return {
     _brand: 'Catalog' as const,
     _ctx: undefined as never,
+    _channels: undefined as never,
     definitions: { ping: def },
     nested: { ping: def as unknown as Record<string, unknown> },
     routes: ['ping'],
@@ -854,6 +857,7 @@ describe('createClient multi-channel', () => {
     const outerCatalog = {
       _brand: 'Catalog' as const,
       _ctx: undefined as never,
+      _channels: undefined as never,
       definitions: { 'ns.ping': inner.definitions.ping! },
       nested: { ns: inner },
       routes: ['ns.ping'],
@@ -975,6 +979,7 @@ describe('createClient multi-channel', () => {
     const orphan: AnyCatalog = {
       _brand: 'Catalog' as const,
       _ctx: undefined as never,
+      _channels: undefined as never,
       definitions: {},
       nested: { ghost: def as unknown as Record<string, unknown> },
       routes: ['ghost'],
@@ -1083,5 +1088,130 @@ describe('createClient multi-channel', () => {
     }) as unknown as { ping: { send: (a: TestArgs) => Promise<unknown> } };
     await expect(mail.ping.send({ to: 'a@x.com', input: { name: 'A' } })).rejects.toBeTruthy();
     expect(logs.filter((l) => l.msg === 'hook failed').length).toBeGreaterThanOrEqual(2);
+  });
+
+  describe('channel inference from catalog', () => {
+    const inferChannel = () =>
+      defineChannel({
+        name: 'infer' as const,
+        slots: {
+          body: slot.resolver<string>(),
+        },
+        validateArgs: (args: unknown): { to: string; input: unknown } => {
+          const a = args as Record<string, unknown>;
+          if (typeof a.to !== 'string') throw new Error('to required');
+          return a as { to: string; input: unknown };
+        },
+        render: ({ runtime, args }): { body: string; to: string } => ({
+          body: runtime.body,
+          to: (args as { to: string }).to,
+        }),
+      });
+
+    it('works without explicit channels when catalog has channelRef', async () => {
+      const ch = inferChannel();
+      const rpc = createNotify({ channels: { infer: ch } });
+      const catalog = rpc.catalog({
+        greeting: rpc
+          .infer()
+          .input(z.object({ name: z.string() }))
+          .body(({ input }: { input: { name: string } }) => `Hi ${input.name}`),
+      });
+
+      const sent: Array<{ rendered: unknown; route: string }> = [];
+      const transport = {
+        name: 'mem',
+        send: async (rendered: unknown, ctx: { route: string; messageId: string; attempt: number }) => {
+          sent.push({ rendered, route: ctx.route });
+          return { ok: true as const, data: { id: ctx.messageId } };
+        },
+      };
+
+      const mail = createClient({
+        catalog,
+        transportsByChannel: { infer: transport },
+      }) as unknown as {
+        greeting: {
+          send: (a: { to: string; input: { name: string } }) => Promise<{ messageId: string }>;
+        };
+      };
+
+      const result = await mail.greeting.send({ to: 'bob@x.com', input: { name: 'Bob' } });
+      expect(result.messageId).toBeTruthy();
+      expect(sent).toHaveLength(1);
+      expect(sent[0]?.rendered).toEqual({ body: 'Hi Bob', to: 'bob@x.com' });
+    });
+
+    it('explicit channels takes precedence over channelRef', async () => {
+      const ch = inferChannel();
+      const rpc = createNotify({ channels: { infer: ch } });
+      const catalog = rpc.catalog({
+        greeting: rpc
+          .infer()
+          .input(z.object({ name: z.string() }))
+          .body(({ input }: { input: { name: string } }) => `Hi ${input.name}`),
+      });
+
+      const overrideChannel = {
+        ...ch,
+        validateArgs: (args: unknown) => {
+          const a = args as Record<string, unknown>;
+          (a as Record<string, unknown>).wasOverridden = true;
+          return a as { to: string; input: unknown };
+        },
+      } as unknown as AnyChannel;
+
+      const sent: Array<{ rendered: unknown }> = [];
+      const transport = {
+        name: 'mem',
+        send: async (rendered: unknown, ctx: { route: string; messageId: string; attempt: number }) => {
+          sent.push({ rendered });
+          return { ok: true as const, data: { id: ctx.messageId } };
+        },
+      };
+
+      const mail = createClient({
+        catalog,
+        channels: { infer: overrideChannel } as never,
+        transportsByChannel: { infer: transport },
+      }) as unknown as {
+        greeting: {
+          send: (a: { to: string; input: { name: string } }) => Promise<{ messageId: string }>;
+        };
+      };
+
+      await mail.greeting.send({ to: 'bob@x.com', input: { name: 'Bob' } });
+      expect(sent).toHaveLength(1);
+      const rendered = sent[0]?.rendered as Record<string, unknown>;
+      expect(rendered.body).toBe('Hi Bob');
+    });
+
+    it('channelRef is embedded in definitions created via createCatalog', () => {
+      const ch = inferChannel();
+      const rpc = createNotify({ channels: { infer: ch } });
+      const catalog = rpc.catalog({
+        greeting: rpc
+          .infer()
+          .input(z.object({ name: z.string() }))
+          .body(({ input }: { input: { name: string } }) => `Hi ${input.name}`),
+      });
+
+      const def = catalog.definitions.greeting;
+      expect(def).toBeDefined();
+      expect(def!.channelRef).toBeDefined();
+      expect(def!.channelRef!.name).toBe('infer');
+    });
+
+    it('hand-built definitions without channelRef still require explicit channels', async () => {
+      const catalog = buildTestCatalog();
+      const mail = createClient({
+        catalog,
+        transportsByChannel: { test: createTestTransport() },
+      }) as unknown as { ping: { send: (a: TestArgs) => Promise<unknown> } };
+
+      await expect(
+        mail.ping.send({ to: 'a@x.com', input: { name: 'A' } }),
+      ).rejects.toThrow(/No channel registered/);
+    });
   });
 });

--- a/packages/core/src/client.multichannel.test.ts
+++ b/packages/core/src/client.multichannel.test.ts
@@ -1202,6 +1202,39 @@ describe('createClient multi-channel', () => {
       expect(def!.channelRef!.name).toBe('infer');
     });
 
+    it('.render() falls back to channelRef when channels is omitted', async () => {
+      const ch = defineChannel({
+        name: 'prev' as const,
+        slots: { body: slot.resolver<string>() },
+        validateArgs: (args: unknown) => args as { to: string; input: unknown },
+        render: ({ runtime, args }): { body: string; to: string } => ({
+          body: runtime.body,
+          to: (args as { to: string }).to,
+        }),
+        previewRender: ({ runtime }) => ({ body: runtime.body }),
+      });
+      const rpc = createNotify({ channels: { prev: ch } });
+      const catalog = rpc.catalog({
+        msg: rpc
+          .prev()
+          .input(z.object({ name: z.string() }))
+          .body(({ input }: { input: { name: string } }) => `Hi ${input.name}`),
+      });
+
+      const transport = {
+        name: 'mem',
+        send: async (_r: unknown, ctx: { messageId: string }) =>
+          ({ ok: true as const, data: { id: ctx.messageId } }),
+      };
+      const mail = createClient({
+        catalog,
+        transportsByChannel: { prev: transport },
+      }) as unknown as { msg: { render: (input: unknown) => Promise<unknown> } };
+
+      const result = await mail.msg.render({ name: 'Ada' });
+      expect(result).toEqual({ body: 'Hi Ada' });
+    });
+
     it('hand-built definitions without channelRef still require explicit channels', async () => {
       const catalog = buildTestCatalog();
       const mail = createClient({

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1,6 +1,6 @@
 import { validate } from './schema.js';
 import { NotifyRpcError } from './errors.js';
-import type { AnyCatalog, CtxOf, Catalog, InputOf } from './catalog.js';
+import type { AnyCatalog, CtxOf, ChannelsOf, Catalog, InputOf } from './catalog.js';
 import { isCatalog } from './catalog.js';
 import type { Plugin } from './plugins/types.js';
 import type { AnyMiddleware } from './middlewares/types.js';
@@ -112,10 +112,11 @@ export type ClientHooks<R extends AnyCatalog = AnyCatalog> = {
   onError?: HookFn<ErrorCtx<R>> | HookFn<ErrorCtx<R>>[];
 };
 
-export type CreateClientOptions<R extends AnyCatalog, Channels extends ChannelMap = ChannelMap> = {
+export type CreateClientOptions<R extends AnyCatalog> = {
   catalog: R;
-  channels: Channels;
-  transportsByChannel: Partial<TransportsFor<Channels>>;
+  /** @deprecated Channels are now inferred from the catalog. Only needed to override a channel at runtime. */
+  channels?: Partial<ChannelsOf<R>>;
+  transportsByChannel: Partial<TransportsFor<ChannelsOf<R>>>;
   ctx?: CtxOf<R>;
   hooks?: ClientHooks<R>;
   logger?: LoggerLike;
@@ -262,11 +263,11 @@ const composeMiddleware = (
   return (ctx) => chain(ctx);
 };
 
-export const createClient = <R extends AnyCatalog, Channels extends ChannelMap = ChannelMap>(
-  options: CreateClientOptions<R, Channels>,
+export const createClient = <R extends AnyCatalog>(
+  options: CreateClientOptions<R>,
 ): Client<R> & { close: () => Promise<void> } => {
   const { catalog } = options;
-  const channels = options.channels as Record<string, AnyChannel>;
+  const channels = (options.channels ?? {}) as Record<string, AnyChannel>;
   const transportsByChannel = options.transportsByChannel as Record<
     string,
     Transport<unknown, unknown>
@@ -311,7 +312,7 @@ export const createClient = <R extends AnyCatalog, Channels extends ChannelMap =
     rawArgs: unknown,
     flatKey: string,
   ): Promise<ChannelSendResult> => {
-    const channel = channels[channelDef.channel];
+    const channel = channels[channelDef.channel] ?? channelDef.channelRef;
     if (!channel) {
       throw new NotifyRpcError({
         message: `No channel registered for "${channelDef.channel}".`,
@@ -560,7 +561,7 @@ export const createClient = <R extends AnyCatalog, Channels extends ChannelMap =
           }),
         ),
       render: async (input: unknown, renderOpts?: { ctx?: unknown }) => {
-        const channel = channels[channelDef.channel];
+        const channel = channels[channelDef.channel] ?? channelDef.channelRef;
         if (!channel?.previewRender) {
           throw new NotifyRpcError({
             message: `Channel "${channelDef.channel}" does not support .render().`,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export type {
   InputOf,
   OutputOf,
   CtxOf,
+  ChannelsOf,
 } from './catalog.js';
 
 export { createClient } from './client.js';

--- a/packages/core/src/notify.ts
+++ b/packages/core/src/notify.ts
@@ -12,7 +12,7 @@ export type RootBuilder<M extends ChannelMap, Ctx> = {
   ): RootBuilder<M, TCtxOut>;
   catalog<const Map extends Record<string, unknown>>(
     map: Map & ValidateCatalog<Map>,
-  ): Catalog<Map, Ctx>;
+  ): Catalog<Map, Ctx, M>;
 } & {
   [K in keyof M & string]: () => BuilderFor<M[K]>;
 };
@@ -26,7 +26,7 @@ const buildRoot = <M extends ChannelMap, Ctx>(
       return buildRoot<M, TCtxOut>(channels, [...rootMiddleware, middleware as AnyMiddleware]);
     },
     catalog<const Map extends Record<string, unknown>>(map: Map & ValidateCatalog<Map>) {
-      return createCatalog(map as never) as Catalog<Map, Ctx>;
+      return createCatalog(map as never) as unknown as Catalog<Map, Ctx, M>;
     },
   };
   for (const name of Object.keys(channels)) {

--- a/packages/core/src/worker.test.ts
+++ b/packages/core/src/worker.test.ts
@@ -9,6 +9,7 @@ describe('worker stubs', () => {
     const catalog: AnyCatalog = {
       _brand: 'Catalog',
       _ctx: undefined as never,
+      _channels: undefined as never,
       definitions: {},
       nested: {},
       routes: [],


### PR DESCRIPTION
## Summary

- Catalog now carries the channel map type via a third type parameter (`Catalog<M, Ctx, Channels>`), threaded from `createNotify` through `rpc.catalog()`
- `channels` is now optional (and deprecated) in `createClient` — `transportsByChannel` keys and transport types are inferred from the catalog
- `ChannelDefinition` stores an optional `channelRef` to the channel object, embedded at `_finalize` time via a self-referential closure in `defineChannel`
- New `ChannelsOf<R>` utility type extracts the channel map from a catalog

### Before
```ts
const mail = createClient({
  catalog,
  channels: { email: ch },
  transportsByChannel: { email: resendTransport({ apiKey }) },
});
```

### After
```ts
const mail = createClient({
  catalog,
  transportsByChannel: { email: resendTransport({ apiKey }) },
});
```

## Test plan

- [x] All 558 existing tests pass
- [x] 4 new tests: channel inference works, explicit channels override, channelRef embedded in definitions, hand-built definitions without channelRef error correctly
- [x] Full monorepo typecheck passes
- [x] Full monorepo build passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channel definitions can now be automatically inferred from catalog definitions, eliminating the need to explicitly register channels in many cases.

* **Improvements**
  * Simplified client creation API with optional channel configuration and improved type inference.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-notify/better-notify/pull/124)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->