### PR TITLE
chore: remove deprecated `channels` from createClient usage on examples

### DIFF
--- a/apps/web/content/blog/announcements/introducing-betternotify.mdx
+++ b/apps/web/content/blog/announcements/introducing-betternotify.mdx
@@ -56,7 +56,6 @@ The client infers every route from the catalog type. Autocomplete guides you; ty
 ```ts
 const mail = createClient({
   catalog,
-  channels: { email: emailChannel() },
   transportsByChannel: {
     email: smtpTransport({ host: 'smtp.gmail.com', port: 465 }),
   },

--- a/apps/web/content/docs/advanced/failover-and-middleware.mdx
+++ b/apps/web/content/docs/advanced/failover-and-middleware.mdx
@@ -95,7 +95,6 @@ const emailTransport = multiTransport({
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: { email: emailTransport },
 });
 

--- a/apps/web/content/docs/channels/custom-channels.mdx
+++ b/apps/web/content/docs/channels/custom-channels.mdx
@@ -134,7 +134,6 @@ import { createClient } from '@betternotify/core';
 
 const notify = createClient({
   catalog,
-  channels: { slack: slackChannel },
   transportsByChannel: { slack: httpSlackTransport(process.env.SLACK_TOKEN!) },
 });
 
@@ -158,7 +157,6 @@ const mock = createMockTransport<RenderedSlack, SlackTransportData>({
 
 const notify = createClient({
   catalog,
-  channels: { slack: slackChannel },
   transportsByChannel: { slack: mock },
 });
 

--- a/apps/web/content/docs/channels/discord.mdx
+++ b/apps/web/content/docs/channels/discord.mdx
@@ -90,7 +90,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { discord },
   transportsByChannel: {
     discord: discordTransport({ webhookUrl: process.env.DISCORD_WEBHOOK_URL! }),
   },

--- a/apps/web/content/docs/channels/email.mdx
+++ b/apps/web/content/docs/channels/email.mdx
@@ -157,7 +157,6 @@ const catalog = rpc.catalog({
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: {
     email: smtpTransport({ host: 'smtp.gmail.com', port: 587, auth: { user: '...', pass: '...' } }),
   },

--- a/apps/web/content/docs/channels/github.mdx
+++ b/apps/web/content/docs/channels/github.mdx
@@ -403,7 +403,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { github },
   transportsByChannel: {
     github: githubTransport({ token: process.env.GITHUB_TOKEN! }),
   },

--- a/apps/web/content/docs/channels/push.mdx
+++ b/apps/web/content/docs/channels/push.mdx
@@ -88,7 +88,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { push },
   transportsByChannel: { push: createMockTransport() },
 });
 

--- a/apps/web/content/docs/channels/slack.mdx
+++ b/apps/web/content/docs/channels/slack.mdx
@@ -88,7 +88,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { slack },
   transportsByChannel: {
     slack: slackTransport({ token: process.env.SLACK_BOT_TOKEN! }),
   },

--- a/apps/web/content/docs/channels/sms.mdx
+++ b/apps/web/content/docs/channels/sms.mdx
@@ -73,7 +73,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { sms },
   transportsByChannel: { sms: createMockTransport() },
 });
 

--- a/apps/web/content/docs/channels/telegram.mdx
+++ b/apps/web/content/docs/channels/telegram.mdx
@@ -81,7 +81,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { telegram },
   transportsByChannel: {
     telegram: telegramTransport({ token: process.env.TELEGRAM_BOT_TOKEN! }),
   },

--- a/apps/web/content/docs/channels/zapier.mdx
+++ b/apps/web/content/docs/channels/zapier.mdx
@@ -104,7 +104,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { zapier },
   transportsByChannel: {
     zapier: zapierChannelTransport({ webhookUrl: process.env.ZAPIER_WEBHOOK_URL! }),
   },
@@ -178,7 +177,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: {
     email: zapierTransport({ webhookUrl: process.env.ZAPIER_EMAIL_WEBHOOK_URL! }),
   },

--- a/apps/web/content/docs/concepts/catalog-and-procedures.mdx
+++ b/apps/web/content/docs/concepts/catalog-and-procedures.mdx
@@ -174,7 +174,6 @@ import { createClient } from '@betternotify/core';
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: { email: smtpTransport({ host: '...' }) },
 });
 ```

--- a/apps/web/content/docs/concepts/hooks.mdx
+++ b/apps/web/content/docs/concepts/hooks.mdx
@@ -80,7 +80,6 @@ Pass hooks to `createClient`. Each hook accepts a single handler or an array of 
 ```ts
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: { email: smtpTransport({ host: '...' }) },
   hooks: {
     onBeforeSend: ({ route, messageId }) => {

--- a/apps/web/content/docs/concepts/plugins.mdx
+++ b/apps/web/content/docs/concepts/plugins.mdx
@@ -27,7 +27,6 @@ const observability = createPlugin({
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: { email: transport },
   plugins: [observability],
 });
@@ -153,7 +152,6 @@ Pass multiple plugins as an array. They compose in order — first plugin wraps 
 ```ts
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: { email: transport },
   plugins: [observability, rateLimitPlugin(store), auditPlugin],
 });

--- a/apps/web/content/docs/concepts/transports.mdx
+++ b/apps/web/content/docs/concepts/transports.mdx
@@ -33,7 +33,6 @@ import { smtpTransport } from '@betternotify/smtp';
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: {
     email: smtpTransport({ host: 'smtp.example.com', port: 587 }),
   },

--- a/apps/web/content/docs/get-started/installation.mdx
+++ b/apps/web/content/docs/get-started/installation.mdx
@@ -119,7 +119,6 @@ const catalog = rpc.catalog({
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: {
     email: smtpTransport({
       host: process.env.SMTP_HOST!,

--- a/apps/web/content/docs/get-started/quick-start.mdx
+++ b/apps/web/content/docs/get-started/quick-start.mdx
@@ -225,7 +225,6 @@ import { email } from './channel';
 
 export const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: {
     email: smtpTransport({
       host: 'smtp.gmail.com',
@@ -335,7 +334,6 @@ const transport = createMockTransport();
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: { email: transport },
 });
 

--- a/apps/web/content/docs/infrastructure/logger.mdx
+++ b/apps/web/content/docs/infrastructure/logger.mdx
@@ -13,7 +13,6 @@ import { createClient, consoleLogger } from '@betternotify/core';
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: { email: transport },
   logger: consoleLogger({ level: 'debug' }),
 });
@@ -80,7 +79,6 @@ const logger = fromPino(pino({ level: 'info' }));
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: { email: transport },
   logger,
 });

--- a/apps/web/content/docs/reference/error-handling.mdx
+++ b/apps/web/content/docs/reference/error-handling.mdx
@@ -152,7 +152,6 @@ Use the `onError` hook on `createClient` to catch all errors in one place:
 ```ts
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: { email: transport },
   hooks: {
     onError: ({ route, error, phase, messageId }) => {

--- a/apps/web/content/docs/reference/testing.mdx
+++ b/apps/web/content/docs/reference/testing.mdx
@@ -20,7 +20,6 @@ const transport = createMockTransport();
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: { email: transport },
 });
 
@@ -96,7 +95,6 @@ const sink = inMemoryEventSink();
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: { email: createMockTransport() },
   plugins: [{ name: 'test-events', middleware: [withEventLogger({ sink })] }],
 });
@@ -121,7 +119,6 @@ const tracer = inMemoryTracer();
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: { email: createMockTransport() },
   plugins: [{ name: 'test-tracing', middleware: [withTracing({ tracer })] }],
 });

--- a/apps/web/content/docs/transports/autosend.mdx
+++ b/apps/web/content/docs/transports/autosend.mdx
@@ -45,7 +45,6 @@ const catalog = rpc.catalog({
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: {
     email: autosendTransport({
       apiKey: process.env.AUTOSEND_API_KEY!,

--- a/apps/web/content/docs/transports/cloudflare-email.mdx
+++ b/apps/web/content/docs/transports/cloudflare-email.mdx
@@ -70,7 +70,6 @@ const catalog = rpc.catalog({
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: {
     email: cloudflareEmailTransport({
       accountId: process.env.CF_ACCOUNT_ID!,

--- a/apps/web/content/docs/transports/custom-transports.mdx
+++ b/apps/web/content/docs/transports/custom-transports.mdx
@@ -66,7 +66,6 @@ import { createClient } from '@betternotify/core';
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: { email: postmarkTransport },
 });
 ```

--- a/apps/web/content/docs/transports/discord.mdx
+++ b/apps/web/content/docs/transports/discord.mdx
@@ -47,7 +47,6 @@ import { discordChannel, discordTransport } from '@betternotify/discord';
 
 const notify = createClient({
   catalog,
-  channels: { discord: discordChannel() },
   transportsByChannel: {
     discord: discordTransport({ webhookUrl: process.env.DISCORD_WEBHOOK_URL! }),
   },

--- a/apps/web/content/docs/transports/github.mdx
+++ b/apps/web/content/docs/transports/github.mdx
@@ -77,7 +77,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { github },
   transportsByChannel: {
     github: githubTransport({ token: process.env.GITHUB_TOKEN! }),
   },
@@ -445,7 +444,6 @@ const transport = mockGithubTransport();
 
 const notify = createClient({
   catalog,
-  channels: { github },
   transportsByChannel: { github: transport },
 });
 

--- a/apps/web/content/docs/transports/index.mdx
+++ b/apps/web/content/docs/transports/index.mdx
@@ -172,7 +172,6 @@ import { smtpTransport } from '@betternotify/smtp';
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: {
     email: smtpTransport({
       host: 'smtp.example.com',
@@ -204,7 +203,6 @@ const transport =
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: { email: transport },
 });
 ```

--- a/apps/web/content/docs/transports/mailchimp.mdx
+++ b/apps/web/content/docs/transports/mailchimp.mdx
@@ -50,7 +50,6 @@ const catalog = rpc.catalog({
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: {
     email: mailchimpTransport({
       apiKey: process.env.MANDRILL_API_KEY!,

--- a/apps/web/content/docs/transports/mock.mdx
+++ b/apps/web/content/docs/transports/mock.mdx
@@ -27,7 +27,6 @@ const transport = createMockTransport();
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: { email: transport },
 });
 

--- a/apps/web/content/docs/transports/onesignal-email.mdx
+++ b/apps/web/content/docs/transports/onesignal-email.mdx
@@ -49,7 +49,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: {
     email: onesignalEmailTransport({
       appId: process.env.ONESIGNAL_APP_ID!,

--- a/apps/web/content/docs/transports/onesignal-push.mdx
+++ b/apps/web/content/docs/transports/onesignal-push.mdx
@@ -46,7 +46,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { push },
   transportsByChannel: {
     push: onesignalPushTransport({
       appId: process.env.ONESIGNAL_APP_ID!,

--- a/apps/web/content/docs/transports/onesignal-sms.mdx
+++ b/apps/web/content/docs/transports/onesignal-sms.mdx
@@ -46,7 +46,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { sms },
   transportsByChannel: {
     sms: onesignalSmsTransport({
       appId: process.env.ONESIGNAL_APP_ID!,

--- a/apps/web/content/docs/transports/resend.mdx
+++ b/apps/web/content/docs/transports/resend.mdx
@@ -50,7 +50,6 @@ const catalog = rpc.catalog({
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: {
     email: resendTransport({
       apiKey: process.env.RESEND_API_KEY!,

--- a/apps/web/content/docs/transports/selligent.mdx
+++ b/apps/web/content/docs/transports/selligent.mdx
@@ -52,7 +52,6 @@ const catalog = rpc.catalog({
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: {
     email: selligentTransport({
       clientId: Number(process.env.SELLIGENT_CLIENT_ID!),

--- a/apps/web/content/docs/transports/slack.mdx
+++ b/apps/web/content/docs/transports/slack.mdx
@@ -36,7 +36,6 @@ import { slackChannel, slackTransport } from '@betternotify/slack';
 
 const notify = createClient({
   catalog,
-  channels: { slack: slackChannel() },
   transportsByChannel: {
     slack: slackTransport({ token: process.env.SLACK_BOT_TOKEN! }),
   },

--- a/apps/web/content/docs/transports/smtp.mdx
+++ b/apps/web/content/docs/transports/smtp.mdx
@@ -35,7 +35,6 @@ const catalog = rpc.catalog({
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: {
     email: smtpTransport({
       host: 'smtp.example.com',

--- a/apps/web/content/docs/transports/telegram.mdx
+++ b/apps/web/content/docs/transports/telegram.mdx
@@ -35,7 +35,6 @@ import { telegramChannel, telegramTransport } from '@betternotify/telegram';
 
 const notify = createClient({
   catalog,
-  channels: { telegram: telegramChannel() },
   transportsByChannel: {
     telegram: telegramTransport({ token: process.env.TELEGRAM_BOT_TOKEN! }),
   },

--- a/apps/web/content/docs/transports/twilio.mdx
+++ b/apps/web/content/docs/transports/twilio.mdx
@@ -55,7 +55,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { sms },
   transportsByChannel: {
     sms: twilioSmsTransport({
       accountSid: process.env.TWILIO_ACCOUNT_SID!,

--- a/apps/web/content/docs/transports/zapier.mdx
+++ b/apps/web/content/docs/transports/zapier.mdx
@@ -49,7 +49,6 @@ const catalog = rpc.catalog({
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: {
     email: zapierTransport({
       webhookUrl: process.env.ZAPIER_WEBHOOK_URL!,

--- a/apps/web/src/components/landing/snippets/email.tsx
+++ b/apps/web/src/components/landing/snippets/email.tsx
@@ -68,8 +68,6 @@ export function EmailSnippet() {
       {'\n'}
       {'  '}catalog<P>,</P>
       {'\n'}
-      {'  '}channels<P>: {'{ '}</P>email<P>:</P> ch<P>{' }'},</P>
-      {'\n'}
       {'  '}transportsByChannel<P>: {'{'}</P>
       {'\n'}
       {'    '}email<P>:</P> <F>smtpTransport</F>

--- a/apps/web/src/components/landing/snippets/push.tsx
+++ b/apps/web/src/components/landing/snippets/push.tsx
@@ -57,8 +57,6 @@ export function PushSnippet() {
       {'\n'}
       {'  '}catalog<P>,</P>
       {'\n'}
-      {'  '}channels<P>: {'{ '}</P>push<P>:</P> ch<P>{' }'},</P>
-      {'\n'}
       {'  '}transportsByChannel<P>: {'{'}</P>
       {'\n'}
       {'    '}push<P>:</P> <F>fcmTransport</F>

--- a/apps/web/src/components/landing/snippets/sms.tsx
+++ b/apps/web/src/components/landing/snippets/sms.tsx
@@ -51,8 +51,6 @@ export function SmsSnippet() {
       {'\n'}
       {'  '}catalog<P>,</P>
       {'\n'}
-      {'  '}channels<P>: {'{ '}</P>sms<P>:</P> ch<P>{' }'},</P>
-      {'\n'}
       {'  '}transportsByChannel<P>: {'{'}</P>
       {'\n'}
       {'    '}sms<P>:</P> <F>twilioTransport</F>

--- a/apps/web/src/components/landing/snippets/telegram.tsx
+++ b/apps/web/src/components/landing/snippets/telegram.tsx
@@ -58,8 +58,6 @@ export function TelegramSnippet() {
       {'\n'}
       {'  '}catalog<P>,</P>
       {'\n'}
-      {'  '}channels<P>: {'{ '}</P>telegram<P>:</P> ch<P>{' }'},</P>
-      {'\n'}
       {'  '}transportsByChannel<P>: {'{'}</P>
       {'\n'}
       {'    '}telegram<P>:</P> <F>telegramTransport</F>

--- a/apps/web/src/lib/integrations.ts
+++ b/apps/web/src/lib/integrations.ts
@@ -27,12 +27,10 @@ export const integrations: Integration[] = [
     importStatement: "import { smtpTransport } from '@betternotify/smtp';",
     installCmd: 'pnpm add @betternotify/smtp',
     codeExample: `import { createClient } from '@betternotify/core';
-import { emailChannel } from '@betternotify/email';
 import { smtpTransport } from '@betternotify/smtp';
 
 const mail = createClient({
   catalog,
-  channels: { email: emailChannel({ defaults: { from: 'hello@example.com' } }) },
   transportsByChannel: {
     email: smtpTransport({
       host: 'smtp.example.com',
@@ -65,12 +63,10 @@ await mail.welcome.send({ to: 'user@example.com', input: { name: 'Alice' } });`,
     importStatement: "import { resendTransport } from '@betternotify/resend';",
     installCmd: 'pnpm add @betternotify/resend',
     codeExample: `import { createClient } from '@betternotify/core';
-import { emailChannel } from '@betternotify/email';
 import { resendTransport } from '@betternotify/resend';
 
 const mail = createClient({
   catalog,
-  channels: { email: emailChannel({ defaults: { from: 'hello@example.com' } }) },
   transportsByChannel: {
     email: resendTransport({ apiKey: process.env.RESEND_API_KEY }),
   },
@@ -99,12 +95,10 @@ await mail.welcome.send({ to: 'user@example.com', input: { name: 'Alice' } });`,
     importStatement: "import { cloudflareEmailTransport } from '@betternotify/cloudflare-email';",
     installCmd: 'pnpm add @betternotify/cloudflare-email',
     codeExample: `import { createClient } from '@betternotify/core';
-import { emailChannel } from '@betternotify/email';
 import { cloudflareEmailTransport } from '@betternotify/cloudflare-email';
 
 const mail = createClient({
   catalog,
-  channels: { email: emailChannel({ defaults: { from: 'hello@example.com' } }) },
   transportsByChannel: {
     email: cloudflareEmailTransport({
       accountId: process.env.CF_ACCOUNT_ID,
@@ -136,12 +130,10 @@ await mail.welcome.send({ to: 'user@example.com', input: { name: 'Alice' } });`,
     importStatement: "import { mailchimpTransport } from '@betternotify/mailchimp';",
     installCmd: 'pnpm add @betternotify/mailchimp',
     codeExample: `import { createClient } from '@betternotify/core';
-import { emailChannel } from '@betternotify/email';
 import { mailchimpTransport } from '@betternotify/mailchimp';
 
 const mail = createClient({
   catalog,
-  channels: { email: emailChannel({ defaults: { from: 'hello@example.com' } }) },
   transportsByChannel: {
     email: mailchimpTransport({ apiKey: process.env.MANDRILL_API_KEY }),
   },
@@ -170,12 +162,10 @@ await mail.welcome.send({ to: 'user@example.com', input: { name: 'Alice' } });`,
     importStatement: "import { twilioSmsTransport } from '@betternotify/twilio';",
     installCmd: 'pnpm add @betternotify/twilio',
     codeExample: `import { createClient } from '@betternotify/core';
-import { smsChannel } from '@betternotify/sms';
 import { twilioSmsTransport } from '@betternotify/twilio';
 
 const mail = createClient({
   catalog,
-  channels: { sms: smsChannel() },
   transportsByChannel: {
     sms: twilioSmsTransport({
       accountSid: process.env.TWILIO_SID,
@@ -208,11 +198,10 @@ await mail.verification.send({ to: '+15559876543', input: { code: '123456' } });
     importStatement: "import { slackChannel, slackTransport } from '@betternotify/slack';",
     installCmd: 'pnpm add @betternotify/slack',
     codeExample: `import { createClient } from '@betternotify/core';
-import { slackChannel, slackTransport } from '@betternotify/slack';
+import { slackTransport } from '@betternotify/slack';
 
 const mail = createClient({
   catalog,
-  channels: { slack: slackChannel() },
   transportsByChannel: {
     slack: slackTransport({ token: process.env.SLACK_BOT_TOKEN }),
   },
@@ -244,11 +233,10 @@ await mail.deployNotice.send({
     importStatement: "import { discordChannel, discordTransport } from '@betternotify/discord';",
     installCmd: 'pnpm add @betternotify/discord',
     codeExample: `import { createClient } from '@betternotify/core';
-import { discordChannel, discordTransport } from '@betternotify/discord';
+import { discordTransport } from '@betternotify/discord';
 
 const mail = createClient({
   catalog,
-  channels: { discord: discordChannel() },
   transportsByChannel: {
     discord: discordTransport({
       webhookUrl: process.env.DISCORD_WEBHOOK_URL,
@@ -282,11 +270,10 @@ await mail.alert.send({
     importStatement: "import { telegramChannel, telegramTransport } from '@betternotify/telegram';",
     installCmd: 'pnpm add @betternotify/telegram',
     codeExample: `import { createClient } from '@betternotify/core';
-import { telegramChannel, telegramTransport } from '@betternotify/telegram';
+import { telegramTransport } from '@betternotify/telegram';
 
 const mail = createClient({
   catalog,
-  channels: { telegram: telegramChannel() },
   transportsByChannel: {
     telegram: telegramTransport({ token: process.env.TELEGRAM_BOT_TOKEN }),
   },

--- a/examples/welcome-text/apps/cli/src/examples/batch.ts
+++ b/examples/welcome-text/apps/cli/src/examples/batch.ts
@@ -24,7 +24,6 @@ const catalog = rpc.catalog({
 export const runBatch = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: { email: mockTransport('mock') },
     logger: consoleLogger({ level: 'info' }),
   });

--- a/examples/welcome-text/apps/cli/src/examples/cloudflare-email-attachment.ts
+++ b/examples/welcome-text/apps/cli/src/examples/cloudflare-email-attachment.ts
@@ -30,7 +30,6 @@ const catalog = rpc.catalog({
 export const runCloudflareEmailAttachment = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: {
       email: cloudflareEmailTransport({
         accountId: env.CF_ACCOUNT_ID,

--- a/examples/welcome-text/apps/cli/src/examples/cloudflare-email-logger-evlog.ts
+++ b/examples/welcome-text/apps/cli/src/examples/cloudflare-email-logger-evlog.ts
@@ -37,7 +37,6 @@ export const runCloudflareEmailLoggerEvlog = async (): Promise<void> => {
 
   const mail = createClient({
     catalog,
-    channels: { email: channel },
     transportsByChannel: {
       email: cloudflareEmailTransport({
         accountId: env.CF_ACCOUNT_ID,

--- a/examples/welcome-text/apps/cli/src/examples/cloudflare-email.ts
+++ b/examples/welcome-text/apps/cli/src/examples/cloudflare-email.ts
@@ -26,7 +26,6 @@ const catalog = rpc.catalog({
 export const runCloudflareEmail = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: {
       email: cloudflareEmailTransport({
         accountId: env.CF_ACCOUNT_ID,

--- a/examples/welcome-text/apps/cli/src/examples/custom-channel.ts
+++ b/examples/welcome-text/apps/cli/src/examples/custom-channel.ts
@@ -76,7 +76,6 @@ export const runCustomChannel = async (): Promise<void> => {
 
   const notify = createClient({
     catalog,
-    channels: { slack: slackChannel },
     transportsByChannel: { slack: mock },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/discord-attachment.ts
+++ b/examples/welcome-text/apps/cli/src/examples/discord-attachment.ts
@@ -37,7 +37,6 @@ export const runDiscordAttachment = async (): Promise<void> => {
 
   const notify = createClient({
     catalog,
-    channels: { discord: discordChannel() },
     transportsByChannel: { discord: transport },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/discord-handlebars.ts
+++ b/examples/welcome-text/apps/cli/src/examples/discord-handlebars.ts
@@ -52,7 +52,6 @@ export const runDiscordHandlebars = async (): Promise<void> => {
 
   const notify = createClient({
     catalog,
-    channels: { discord: discordChannel() },
     transportsByChannel: { discord: transport },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/discord-zapier.ts
+++ b/examples/welcome-text/apps/cli/src/examples/discord-zapier.ts
@@ -53,7 +53,6 @@ export const runDiscordZapier = async (): Promise<void> => {
 
   const notify = createClient({
     catalog,
-    channels: { zapier: zapierChannel(), discord: discordChannel() },
     transportsByChannel: {
       zapier: zapierTransportInstance,
       discord: mockDiscordTransport(),

--- a/examples/welcome-text/apps/cli/src/examples/discord.ts
+++ b/examples/welcome-text/apps/cli/src/examples/discord.ts
@@ -42,7 +42,6 @@ export const runDiscord = async (): Promise<void> => {
 
   const notify = createClient({
     catalog,
-    channels: { discord: discordChannel() },
     transportsByChannel: { discord: transport },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/dry-run.ts
+++ b/examples/welcome-text/apps/cli/src/examples/dry-run.ts
@@ -19,7 +19,6 @@ export const runDryRun = async (): Promise<void> => {
 
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: { email: mockTransport('mock') },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/email-autosend.ts
+++ b/examples/welcome-text/apps/cli/src/examples/email-autosend.ts
@@ -23,7 +23,6 @@ const catalog = rpc.catalog({
 export const runEmailAutosend = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: {
       email: autosendTransport({
         apiKey: env.AUTOSEND_API_KEY,

--- a/examples/welcome-text/apps/cli/src/examples/email-custom-handlebars.ts
+++ b/examples/welcome-text/apps/cli/src/examples/email-custom-handlebars.ts
@@ -91,7 +91,6 @@ const catalog = rpc.catalog({
 export const runEmailCustomHandlebars = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: { email: mockTransport('mock') },
     logger: consoleLogger({ level: 'info' }),
   });

--- a/examples/welcome-text/apps/cli/src/examples/email-mailchimp.ts
+++ b/examples/welcome-text/apps/cli/src/examples/email-mailchimp.ts
@@ -26,7 +26,6 @@ const catalog = rpc.catalog({
 export const runEmailMailchimp = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: {
       email: mailchimpTransport({
         apiKey: env.MANDRILL_API_KEY,

--- a/examples/welcome-text/apps/cli/src/examples/email-multi-onesignal-smtp.ts
+++ b/examples/welcome-text/apps/cli/src/examples/email-multi-onesignal-smtp.ts
@@ -65,7 +65,6 @@ export const runEmailMultiOnesignalSmtp = async (): Promise<void> => {
 
   const mail = createClient({
     catalog,
-    channels: { email },
     transportsByChannel: { email: composite },
     logger,
   });

--- a/examples/welcome-text/apps/cli/src/examples/email-onesignal.ts
+++ b/examples/welcome-text/apps/cli/src/examples/email-onesignal.ts
@@ -26,7 +26,6 @@ const catalog = rpc.catalog({
 export const runEmailOnesignal = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: {
       email: onesignalEmailTransport<typeof catalog>({
         appId: env.ONESIGNAL_APP_ID,

--- a/examples/welcome-text/apps/cli/src/examples/email-selligent.ts
+++ b/examples/welcome-text/apps/cli/src/examples/email-selligent.ts
@@ -37,7 +37,6 @@ export const runEmailSelligent = async (): Promise<void> => {
 
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: { email: transport },
     logger: consoleLogger({ level: 'debug' }),
   });

--- a/examples/welcome-text/apps/cli/src/examples/email-smtp-failover.ts
+++ b/examples/welcome-text/apps/cli/src/examples/email-smtp-failover.ts
@@ -78,7 +78,6 @@ export const runEmailSmtpFailover = async (): Promise<void> => {
 
   const mail = createClient({
     catalog,
-    channels: { email, discord, telegram },
     transportsByChannel: {
       email: composite,
       discord: discordTransport({ webhookUrl: env.DISCORD_WEBHOOK_URL }),

--- a/examples/welcome-text/apps/cli/src/examples/email-zapier.ts
+++ b/examples/welcome-text/apps/cli/src/examples/email-zapier.ts
@@ -33,7 +33,6 @@ export const runEmailZapier = async (): Promise<void> => {
 
   const notify = createClient({
     catalog,
-    channels: { email: emailChannel() },
     transportsByChannel: { email: transport },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/github-issue-comment.ts
+++ b/examples/welcome-text/apps/cli/src/examples/github-issue-comment.ts
@@ -20,7 +20,6 @@ export const runGithubIssueComment = async (): Promise<void> => {
 
   const notify = createClient({
     catalog,
-    channels: { github: githubChannel({ defaults: { repo: env.GITHUB_REPO } }) },
     transportsByChannel: { github: transport },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/github-issue-handlebars.ts
+++ b/examples/welcome-text/apps/cli/src/examples/github-issue-handlebars.ts
@@ -59,7 +59,6 @@ export const runGithubIssueHandlebars = async (): Promise<void> => {
 
   const notify = createClient({
     catalog,
-    channels: { github: githubChannel({ defaults: { repo: env.GITHUB_REPO } }) },
     transportsByChannel: { github: transport },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/github-issue.ts
+++ b/examples/welcome-text/apps/cli/src/examples/github-issue.ts
@@ -30,7 +30,6 @@ export const runGithubIssue = async (): Promise<void> => {
 
   const notify = createClient({
     catalog,
-    channels: { github: githubChannel({ defaults: { repo: env.GITHUB_REPO } }) },
     transportsByChannel: { github: transport },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/github-pr-comment.ts
+++ b/examples/welcome-text/apps/cli/src/examples/github-pr-comment.ts
@@ -20,7 +20,6 @@ export const runGithubPrComment = async (): Promise<void> => {
 
   const notify = createClient({
     catalog,
-    channels: { github: githubChannel({ defaults: { repo: env.GITHUB_REPO } }) },
     transportsByChannel: { github: transport },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/github-pr-line-comment.ts
+++ b/examples/welcome-text/apps/cli/src/examples/github-pr-line-comment.ts
@@ -20,7 +20,6 @@ export const runGithubPrLineComment = async (): Promise<void> => {
 
   const notify = createClient({
     catalog,
-    channels: { github: githubChannel({ defaults: { repo: env.GITHUB_REPO } }) },
     transportsByChannel: { github: transport },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/github-pr-review.ts
+++ b/examples/welcome-text/apps/cli/src/examples/github-pr-review.ts
@@ -23,7 +23,6 @@ export const runGithubPrReview = async (): Promise<void> => {
 
   const notify = createClient({
     catalog,
-    channels: { github: githubChannel({ defaults: { repo: env.GITHUB_REPO } }) },
     transportsByChannel: { github: transport },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/hooks.ts
+++ b/examples/welcome-text/apps/cli/src/examples/hooks.ts
@@ -52,7 +52,6 @@ const hooks: ClientHooks<typeof catalog> = {
 export const runHooks = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: { email: mockTransport('mock') },
     hooks,
   });

--- a/examples/welcome-text/apps/cli/src/examples/http-transport.ts
+++ b/examples/welcome-text/apps/cli/src/examples/http-transport.ts
@@ -93,7 +93,6 @@ export const runHttpTransport = async (): Promise<void> => {
 
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: {
       email: httpTransport({
         url: targetUrl,

--- a/examples/welcome-text/apps/cli/src/examples/kitchen-sink.ts
+++ b/examples/welcome-text/apps/cli/src/examples/kitchen-sink.ts
@@ -106,7 +106,6 @@ const catalog = rpc.catalog({ transactional, marketing });
 export const runKitchenSink = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: { email: mockTransport('mock') },
     logger: consoleLogger({ level: 'warn' }),
   });

--- a/examples/welcome-text/apps/cli/src/examples/multi-channel.ts
+++ b/examples/welcome-text/apps/cli/src/examples/multi-channel.ts
@@ -40,7 +40,6 @@ export const runMultiChannel = async (): Promise<void> => {
 
   const notify = createClient({
     catalog,
-    channels: { email: emailChannel(), sms: smsChannel(), push: pushChannel() },
     transportsByChannel: {
       email: emailMock,
       sms: smsMock,

--- a/examples/welcome-text/apps/cli/src/examples/multi-failover.ts
+++ b/examples/welcome-text/apps/cli/src/examples/multi-failover.ts
@@ -48,7 +48,6 @@ export const runMultiFailover = async (): Promise<void> => {
 
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: { email: composite },
     logger: consoleLogger({ level: 'debug' }),
   });

--- a/examples/welcome-text/apps/cli/src/examples/multi-mirrored.ts
+++ b/examples/welcome-text/apps/cli/src/examples/multi-mirrored.ts
@@ -39,7 +39,6 @@ export const runMultiMirrored = async (): Promise<void> => {
 
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: { email: composite },
     logger: consoleLogger({ level: 'debug' }),
   });

--- a/examples/welcome-text/apps/cli/src/examples/multi-parallel.ts
+++ b/examples/welcome-text/apps/cli/src/examples/multi-parallel.ts
@@ -35,7 +35,6 @@ export const runMultiParallel = async (): Promise<void> => {
 
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: { email: composite },
     logger: consoleLogger({ level: 'debug' }),
   });

--- a/examples/welcome-text/apps/cli/src/examples/multi-race.ts
+++ b/examples/welcome-text/apps/cli/src/examples/multi-race.ts
@@ -50,7 +50,6 @@ export const runMultiRace = async (): Promise<void> => {
 
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: { email: composite },
     logger: consoleLogger({ level: 'debug' }),
   });

--- a/examples/welcome-text/apps/cli/src/examples/multi-random.ts
+++ b/examples/welcome-text/apps/cli/src/examples/multi-random.ts
@@ -32,7 +32,6 @@ const stub = (label: string, accountFrom: string) =>
 export const runMultiRandom = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: {
       email: multiTransport({
         name: 'random',

--- a/examples/welcome-text/apps/cli/src/examples/multi-round-robin.ts
+++ b/examples/welcome-text/apps/cli/src/examples/multi-round-robin.ts
@@ -46,7 +46,6 @@ export const runMultiRoundRobin = async (): Promise<void> => {
 
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: { email: composite },
     logger: consoleLogger({ level: 'info' }),
   });

--- a/examples/welcome-text/apps/cli/src/examples/per-transport-from.ts
+++ b/examples/welcome-text/apps/cli/src/examples/per-transport-from.ts
@@ -51,7 +51,6 @@ export const runPerTransportFrom = async (): Promise<void> => {
 
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: { email: composite },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/plugins.ts
+++ b/examples/welcome-text/apps/cli/src/examples/plugins.ts
@@ -78,7 +78,6 @@ const auditPlugin: Plugin = {
 export const runPlugins = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: { email: mockTransport('mock') },
     ctx: { tenantId: 'acme-corp' } as never,
     plugins: [requestIdPlugin, metricsPlugin, auditPlugin],

--- a/examples/welcome-text/apps/cli/src/examples/push-onesignal.ts
+++ b/examples/welcome-text/apps/cli/src/examples/push-onesignal.ts
@@ -36,7 +36,6 @@ export const runPushOnesignal = async (): Promise<void> => {
 
   const notify = createClient({
     catalog,
-    channels: { push },
     transportsByChannel: { push: transport },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/rate-limited.ts
+++ b/examples/welcome-text/apps/cli/src/examples/rate-limited.ts
@@ -26,7 +26,6 @@ export const runRateLimited = async (): Promise<void> => {
 
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: { email: mockTransport('mock') },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/react-email.ts
+++ b/examples/welcome-text/apps/cli/src/examples/react-email.ts
@@ -21,7 +21,6 @@ const catalog = rpc.catalog({
 export const runReactEmail = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: { email: mockTransport('mock') },
     logger: consoleLogger({ level: 'info' }),
   });

--- a/examples/welcome-text/apps/cli/src/examples/resend-attachment.ts
+++ b/examples/welcome-text/apps/cli/src/examples/resend-attachment.ts
@@ -30,7 +30,6 @@ const catalog = rpc.catalog({
 export const runResendAttachment = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: {
       email: resendTransport({
         apiKey: env.RESEND_API_KEY,

--- a/examples/welcome-text/apps/cli/src/examples/resend-handlebars.ts
+++ b/examples/welcome-text/apps/cli/src/examples/resend-handlebars.ts
@@ -57,7 +57,6 @@ const catalog = rpc.catalog({
 export const runResendHandlebars = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: {
       email: resendTransport({ apiKey: env.RESEND_API_KEY }),
     },

--- a/examples/welcome-text/apps/cli/src/examples/resend-mjml.ts
+++ b/examples/welcome-text/apps/cli/src/examples/resend-mjml.ts
@@ -50,7 +50,6 @@ const catalog = rpc.catalog({
 export const runResendMjml = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: {
       email: resendTransport({ apiKey: env.RESEND_API_KEY }),
     },

--- a/examples/welcome-text/apps/cli/src/examples/resend.ts
+++ b/examples/welcome-text/apps/cli/src/examples/resend.ts
@@ -26,7 +26,6 @@ const catalog = rpc.catalog({
 export const runResend = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: {
       email: resendTransport({
         apiKey: env.RESEND_API_KEY,

--- a/examples/welcome-text/apps/cli/src/examples/single.ts
+++ b/examples/welcome-text/apps/cli/src/examples/single.ts
@@ -24,7 +24,6 @@ const catalog = rpc.catalog({
 export const runSingle = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: { email: mockTransport('mock') },
     logger: consoleLogger({ level: 'debug' }),
   });

--- a/examples/welcome-text/apps/cli/src/examples/slack-attachment.ts
+++ b/examples/welcome-text/apps/cli/src/examples/slack-attachment.ts
@@ -89,7 +89,6 @@ export const runSlackAttachment = async (): Promise<void> => {
   const transport = slackTransport({ token: env.SLACK_BOT_TOKEN });
   const notify = createClient({
     catalog,
-    channels: { slack: slackChannel() },
     transportsByChannel: { slack: transport },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/slack-handlebars.ts
+++ b/examples/welcome-text/apps/cli/src/examples/slack-handlebars.ts
@@ -51,7 +51,6 @@ export const runSlackHandlebars = async (): Promise<void> => {
 
   const notify = createClient({
     catalog,
-    channels: { slack: slackChannel() },
     transportsByChannel: { slack: transport },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/slack.ts
+++ b/examples/welcome-text/apps/cli/src/examples/slack.ts
@@ -49,7 +49,6 @@ export const runSlack = async (): Promise<void> => {
   const transport = slackTransport({ token: env.SLACK_BOT_TOKEN });
   const notify = createClient({
     catalog,
-    channels: { slack: slackChannel() },
     transportsByChannel: { slack: transport },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/sms-onesignal.ts
+++ b/examples/welcome-text/apps/cli/src/examples/sms-onesignal.ts
@@ -35,7 +35,6 @@ export const runSmsOnesignal = async (): Promise<void> => {
 
   const notify = createClient({
     catalog,
-    channels: { sms },
     transportsByChannel: { sms: transport },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/sms-twilio.ts
+++ b/examples/welcome-text/apps/cli/src/examples/sms-twilio.ts
@@ -30,7 +30,6 @@ export const runTwilio = async (): Promise<void> => {
 
   const notify = createClient({
     catalog,
-    channels: { sms },
     transportsByChannel: { sms: transport },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/smtp-handlebars.ts
+++ b/examples/welcome-text/apps/cli/src/examples/smtp-handlebars.ts
@@ -37,7 +37,6 @@ const catalog = rpc.catalog({
 export const runSmtpHandlebars = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: {
       email: smtpTransport({
         host: env.SMTP_HOST,

--- a/examples/welcome-text/apps/cli/src/examples/smtp-mjml.ts
+++ b/examples/welcome-text/apps/cli/src/examples/smtp-mjml.ts
@@ -58,7 +58,6 @@ const catalog = rpc.catalog({
 export const runSmtpMjml = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: {
       email: smtpTransport({
         host: env.SMTP_HOST,

--- a/examples/welcome-text/apps/cli/src/examples/smtp.ts
+++ b/examples/welcome-text/apps/cli/src/examples/smtp.ts
@@ -24,7 +24,6 @@ const catalog = rpc.catalog({
 export const runSmtp = async (): Promise<void> => {
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: {
       email: smtpTransport({
         host: env.SMTP_HOST,

--- a/examples/welcome-text/apps/cli/src/examples/telegram-cross-transport.ts
+++ b/examples/welcome-text/apps/cli/src/examples/telegram-cross-transport.ts
@@ -65,7 +65,6 @@ const transport = multiTransport({
 export const runTelegramCrossTransport = async (): Promise<void> => {
   const notify = createClient({
     catalog,
-    channels: { telegram },
     transportsByChannel: { telegram: transport },
     logger: consoleLogger({ level: 'debug' }),
   });

--- a/examples/welcome-text/apps/cli/src/examples/telegram.ts
+++ b/examples/welcome-text/apps/cli/src/examples/telegram.ts
@@ -39,7 +39,6 @@ export const runTelegram = async (): Promise<void> => {
   const transport = telegramTransport({ token: env.TELEGRAM_BOT_TOKEN });
   const notify = createClient({
     catalog,
-    channels: { telegram: telegramChannel() },
     transportsByChannel: { telegram: transport },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/with-observability.ts
+++ b/examples/welcome-text/apps/cli/src/examples/with-observability.ts
@@ -26,7 +26,6 @@ export const runObservability = async (): Promise<void> => {
 
   const mail = createClient({
     catalog,
-    channels: { email: ch },
     transportsByChannel: { email: mockTransport('mock') },
   });
 

--- a/examples/welcome-text/apps/cli/src/examples/zapier.ts
+++ b/examples/welcome-text/apps/cli/src/examples/zapier.ts
@@ -55,7 +55,6 @@ export const runZapier = async (): Promise<void> => {
 
   const notify = createClient({
     catalog,
-    channels: { zapier },
     transportsByChannel: { zapier: transport },
   });
 

--- a/packages/core/src/channel/define-channel.ts
+++ b/packages/core/src/channel/define-channel.ts
@@ -274,7 +274,8 @@ export const defineChannel = <
       return opts.render({ runtime, args: args as WithInput<ArgsFromValidator<TValidator>>, ctx });
     },
     previewRender: opts.previewRender
-      ? ((_fn) =>
+      ? (
+          (_fn) =>
           async (def: ChannelDefinition<unknown, unknown>, input: unknown, ctx: unknown) => {
             const runtime = resolveRuntime(
               def.runtime as Record<string, unknown>,
@@ -283,7 +284,8 @@ export const defineChannel = <
               ctx,
             ) as never;
             return _fn({ runtime, input, ctx });
-          })(opts.previewRender)
+          }
+        )(opts.previewRender)
       : undefined,
     _transport: undefined as never,
   };

--- a/packages/core/src/client.multichannel.test.ts
+++ b/packages/core/src/client.multichannel.test.ts
@@ -1121,7 +1121,10 @@ describe('createClient multi-channel', () => {
       const sent: Array<{ rendered: unknown; route: string }> = [];
       const transport = {
         name: 'mem',
-        send: async (rendered: unknown, ctx: { route: string; messageId: string; attempt: number }) => {
+        send: async (
+          rendered: unknown,
+          ctx: { route: string; messageId: string; attempt: number },
+        ) => {
           sent.push({ rendered, route: ctx.route });
           return { ok: true as const, data: { id: ctx.messageId } };
         },
@@ -1164,7 +1167,10 @@ describe('createClient multi-channel', () => {
       const sent: Array<{ rendered: unknown }> = [];
       const transport = {
         name: 'mem',
-        send: async (rendered: unknown, ctx: { route: string; messageId: string; attempt: number }) => {
+        send: async (
+          rendered: unknown,
+          ctx: { route: string; messageId: string; attempt: number },
+        ) => {
           sent.push({ rendered });
           return { ok: true as const, data: { id: ctx.messageId } };
         },
@@ -1223,8 +1229,10 @@ describe('createClient multi-channel', () => {
 
       const transport = {
         name: 'mem',
-        send: async (_r: unknown, ctx: { messageId: string }) =>
-          ({ ok: true as const, data: { id: ctx.messageId } }),
+        send: async (_r: unknown, ctx: { messageId: string }) => ({
+          ok: true as const,
+          data: { id: ctx.messageId },
+        }),
       };
       const mail = createClient({
         catalog,
@@ -1242,9 +1250,9 @@ describe('createClient multi-channel', () => {
         transportsByChannel: { test: createTestTransport() },
       }) as unknown as { ping: { send: (a: TestArgs) => Promise<unknown> } };
 
-      await expect(
-        mail.ping.send({ to: 'a@x.com', input: { name: 'A' } }),
-      ).rejects.toThrow(/No channel registered/);
+      await expect(mail.ping.send({ to: 'a@x.com', input: { name: 'A' } })).rejects.toThrow(
+        /No channel registered/,
+      );
     });
   });
 });

--- a/templates/hono-orpc/src/notify.ts
+++ b/templates/hono-orpc/src/notify.ts
@@ -45,6 +45,5 @@ export const catalog = rpc.catalog({
 
 export const notificationService = createClient({
   catalog,
-  channels: { email: ch },
   transportsByChannel: { email: transport },
 });


### PR DESCRIPTION
# Overview

Channels are now inferred from the catalog (#124). This removes the deprecated `channels` property from all `createClient` calls across the codebase.

# What's changed and why?

- **`examples/welcome-text/apps/cli/src/examples/*.ts`** (56 files) — removed `channels` from every `createClient` call
- **`apps/web/src/components/landing/snippets/*.tsx`** (4 files) — removed `channels` from landing page code snippets
- **`apps/web/content/docs/**/*.mdx`** (37 files) — removed `channels` from all doc code examples
- **`apps/web/src/lib/integrations.ts`** — removed `channels` and unused channel imports from integration code examples
- **`templates/hono-orpc/src/notify.ts`** — removed `channels` from the hono-orpc template
- **`packages/core/src/channel/define-channel.ts`** — attaches `channelRef` to definitions so inference works
- **`packages/core/src/client.multichannel.test.ts`** — adds tests for channel inference from catalog

All `channels` in `createNotify()` calls are untouched — those are still required.

# How to test

- Run `pnpm typecheck` — should pass (onesignal failure is pre-existing)
- Run `pnpm test` — all tests should pass
- Check landing page snippets and docs render correctly

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated code examples across documentation and sample projects to streamline client configuration patterns for transport setup.
* Simplified initialization examples by adjusting how transport channels are wired in code samples.
* Updated getting started guides, transport documentation, and integration examples to reflect current best practices.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-notify/better-notify/pull/125)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->