### PR TITLE
chore: remove deprecated `channels` from createClient in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ const catalog = rpc.catalog({
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: { email: mockTransport() },
 });
 

--- a/packages/autosend/README.md
+++ b/packages/autosend/README.md
@@ -32,7 +32,6 @@ const catalog = rpc.catalog({
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: {
     email: autosendTransport({
       apiKey: process.env.AUTOSEND_API_KEY!,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -18,7 +18,7 @@ npm install @betternotify/core
 ## What's in here
 
 - **`createNotify({ channels })`** — root builder factory. Returns a typed `rpc` with `.use(mw)`, `.catalog(...)`, and one method per registered channel.
-- **`createClient({ catalog, channels, transportsByChannel, ... })`** — typed client. `mail.<route>.send()`, `.batch()`, `.queue()`, `.render()`.
+- **`createClient({ catalog, transportsByChannel, ... })`** — typed client. `mail.<route>.send()`, `.batch()`, `.queue()`, `.render()`.
 - **`createCatalog(map)`** — aggregates channel routes (and sub-catalogs) into one typed `Catalog<M, Ctx>`.
 - **`Channel<TName, TBuilder, TArgs, TRendered, TTransport>`** — channel contract. Exposes `createBuilder`, `validateArgs`, `render`, optional `previewRender`, `finalize`.
 - **`defineChannel({ name, slots, validateArgs, render })`** — factory that generates the entire `Channel<>` plus a chained slot-setter builder. See custom-channel example.

--- a/packages/discord/README.md
+++ b/packages/discord/README.md
@@ -43,7 +43,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { discord },
   transportsByChannel: { discord: mockDiscordTransport() },
 });
 

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -42,7 +42,6 @@ const catalog = rpc.catalog({
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: { email: mockTransport() },
 });
 

--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -63,7 +63,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { github },
   transportsByChannel: {
     github: githubTransport({ token: process.env.GITHUB_TOKEN! }),
   },

--- a/packages/mailchimp/README.md
+++ b/packages/mailchimp/README.md
@@ -32,7 +32,6 @@ const catalog = rpc.catalog({
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: {
     email: mailchimpTransport({
       apiKey: process.env.MANDRILL_API_KEY!,

--- a/packages/onesignal/README.md
+++ b/packages/onesignal/README.md
@@ -48,7 +48,6 @@ const shared = {
 
 const notify = createClient({
   catalog,
-  channels: { email, push, sms },
   transportsByChannel: {
     email: onesignalEmailTransport(shared),
     push: onesignalPushTransport(shared),

--- a/packages/push/README.md
+++ b/packages/push/README.md
@@ -36,7 +36,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { push },
   transportsByChannel: { push: mockPushTransport() },
 });
 

--- a/packages/selligent/README.md
+++ b/packages/selligent/README.md
@@ -33,7 +33,6 @@ const catalog = rpc.catalog({
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: {
     email: selligentTransport({
       clientId: Number(process.env.SELLIGENT_CLIENT_ID!),

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -44,7 +44,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { slack },
   transportsByChannel: { slack: mockSlackTransport() },
 });
 

--- a/packages/sms/README.md
+++ b/packages/sms/README.md
@@ -34,7 +34,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { sms },
   transportsByChannel: { sms: mockSmsTransport() },
 });
 

--- a/packages/smtp/README.md
+++ b/packages/smtp/README.md
@@ -32,7 +32,6 @@ const catalog = rpc.catalog({
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: {
     email: smtpTransport({
       host: 'smtp.example.com',

--- a/packages/telegram/README.md
+++ b/packages/telegram/README.md
@@ -34,7 +34,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { telegram },
   transportsByChannel: { telegram: mockTelegramTransport() },
 });
 

--- a/packages/twilio/README.md
+++ b/packages/twilio/README.md
@@ -35,7 +35,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { sms },
   transportsByChannel: {
     sms: twilioSmsTransport({
       accountSid: process.env.TWILIO_ACCOUNT_SID!,

--- a/packages/zapier/README.md
+++ b/packages/zapier/README.md
@@ -35,7 +35,6 @@ const catalog = rpc.catalog({
 
 const notify = createClient({
   catalog,
-  channels: { zapier },
   transportsByChannel: { zapier: mockZapierTransport() },
 });
 
@@ -74,7 +73,6 @@ import { zapierTransport } from '@betternotify/zapier';
 
 const mail = createClient({
   catalog,
-  channels: { email },
   transportsByChannel: {
     email: zapierTransport({ webhookUrl: 'https://hooks.zapier.com/hooks/catch/...' }),
   },

--- a/skills/better-notify/best-practices/SKILL.md
+++ b/skills/better-notify/best-practices/SKILL.md
@@ -20,15 +20,15 @@ description: Quick reference for Better Notify configuration, patterns, and comm
 
 ## Core API
 
-| Function                                                   | Import               | Purpose                                         |
-| ---------------------------------------------------------- | -------------------- | ----------------------------------------------- |
-| `createNotify({ channels })`                               | `@betternotify/core` | Root builder with channel map                   |
-| `createClient({ catalog, channels, transportsByChannel })` | `@betternotify/core` | Type-safe send client                           |
-| `createCatalog(map)`                                       | `@betternotify/core` | Standalone catalog (without builder)            |
-| `defineChannel({ name, slots, validateArgs, render })`     | `@betternotify/core` | Custom channel definition                       |
-| `slot.resolver<T>()` / `slot.value<T>()`                   | `@betternotify/core` | Template slot declarations                      |
-| `consoleLogger({ level })`                                 | `@betternotify/core` | Built-in console logger                         |
-| `handlePromise(promise)`                                   | `@betternotify/core` | Tuple-returning async wrapper `[error, result]` |
+| Function                                               | Import               | Purpose                                         |
+| ------------------------------------------------------ | -------------------- | ----------------------------------------------- |
+| `createNotify({ channels })`                           | `@betternotify/core` | Root builder with channel map                   |
+| `createClient({ catalog, transportsByChannel })`       | `@betternotify/core` | Type-safe send client                           |
+| `createCatalog(map)`                                   | `@betternotify/core` | Standalone catalog (without builder)            |
+| `defineChannel({ name, slots, validateArgs, render })` | `@betternotify/core` | Custom channel definition                       |
+| `slot.resolver<T>()` / `slot.value<T>()`               | `@betternotify/core` | Template slot declarations                      |
+| `consoleLogger({ level })`                             | `@betternotify/core` | Built-in console logger                         |
+| `handlePromise(promise)`                               | `@betternotify/core` | Tuple-returning async wrapper `[error, result]` |
 
 ---
 
@@ -163,7 +163,6 @@ Hooks observe but don't mutate. Set on `createClient`:
 ```typescript
 const mail = createClient({
   catalog,
-  channels: { email: ch },
   transportsByChannel: { email: transport },
   hooks: {
     onBeforeSend: ({ route, messageId, args }) => { ... },

--- a/skills/better-notify/setup/SKILL.md
+++ b/skills/better-notify/setup/SKILL.md
@@ -199,7 +199,6 @@ import { catalog, ch } from './notify';
 
 export const mail = createClient({
   catalog,
-  channels: { email: ch },
   transportsByChannel: {
     email: smtpTransport({
       host: process.env.SMTP_HOST!,
@@ -291,7 +290,6 @@ import { catalog, ch } from './notify';
 const mock = mockTransport();
 const mail = createClient({
   catalog,
-  channels: { email: ch },
   transportsByChannel: { email: mock },
 });
 


### PR DESCRIPTION
# Overview

Follows up on #125 — removes the deprecated `channels` prop from `createClient()` usage across all README and skill files.

# What's changed and why?

`channels` is now inferred from the catalog (#124), so passing it to `createClient` is unnecessary.

- **`README.md`** — removed `channels` from quick-start `createClient` snippet
- **`packages/core/README.md`** — updated `createClient` signature docs
- **`packages/{email,discord,slack,telegram,push,sms,twilio,smtp,mailchimp,selligent,autosend,onesignal,github,zapier}/README.md`** — removed `channels` from `createClient` examples
- **`skills/better-notify/best-practices/SKILL.md`** — updated API table and hooks example
- **`skills/better-notify/setup/SKILL.md`** — removed `channels` from client and test snippets

# How to test

- Verify code snippets in changed READMEs no longer include `channels` in `createClient` calls
- `channels` on `createNotify` should remain untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all package documentation, README files, and skill guides with current and consistent code examples. Covered integrations include email, SMS, push notifications, Discord, Slack, Telegram, GitHub, Mailchimp, OneSignal, Zapier, Autosend, SMTP, Selligent, Twilio, and more. Examples now demonstrate the latest recommended patterns for initializing and configuring clients.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-notify/better-notify/pull/126)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->