### PR TITLE
chore: add general question issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/general_question.yml
+++ b/.github/ISSUE_TEMPLATE/general_question.yml
@@ -1,0 +1,34 @@
+name: General Question
+description: Ask a general question about Better-Notify
+labels: ['question']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your question! Please share enough context so we can help.
+
+  - type: input
+    id: package
+    attributes:
+      label: Package
+      description: Which package does this relate to? Leave blank if it's general.
+      placeholder: '@betternotify/core'
+    validations:
+      required: false
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What would you like to know?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Share relevant code, configuration, or details about what you're trying to do.
+      render: typescript
+    validations:
+      required: false

--- a/apps/web/src/components/landing/trusted-by.tsx
+++ b/apps/web/src/components/landing/trusted-by.tsx
@@ -16,7 +16,9 @@ export function TrustedBy() {
   return (
     <div>
       <div className="flex flex-wrap items-center gap-x-6 gap-y-3 max-lg:justify-center">
-        <span className="text-muted-foreground/40 font-mono text-[11px] uppercase tracking-bn-widest">In production at</span>
+        <span className="text-muted-foreground/40 font-mono text-[11px] uppercase tracking-bn-widest">
+          In production at
+        </span>
         {companies.map((c) => (
           <a
             key={c.name}


### PR DESCRIPTION
# Overview

Adds a new General Question issue template.

# What's changed and why?

- `.github/ISSUE_TEMPLATE/general_question.yml`: Adds a form for general questions with package, question, and context fields.
- `apps/web/src/components/landing/trusted-by.tsx`: Formats the "In production at" label across multiple lines.

# How to test

- Open GitHub's new issue page and confirm "General Question" appears.
- YAML was parsed locally.

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->
