### PR TITLE
fix(webpush): set initial version to 1.0.0-beta.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -21,5 +21,5 @@
   "packages/selligent": "1.0.0-beta.1",
   "apps/web": "1.1.0-beta.7",
   "packages/github": "1.0.0-beta.1",
-  "packages/webpush": "0.0.0-beta.0"
+  "packages/webpush": "1.0.0-beta.1"
 }

--- a/packages/webpush/package.json
+++ b/packages/webpush/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betternotify/webpush",
-  "version": "0.0.0",
+  "version": "1.0.0-beta.1",
   "description": "Web Push notification channel and VAPID transport for betternotify.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
# Overview

Aligns `@betternotify/webpush` initial version with all other packages.

# What's changed and why?

The webpush package was bootstrapped with `0.0.0` instead of `1.0.0-beta.1`. This fixes the version to match the convention used by every other package.

- `.release-please-manifest.json` — bumped webpush entry from `0.0.0-beta.0` to `1.0.0-beta.1`
- `packages/webpush/package.json` — set version to `1.0.0-beta.1`

# How to test

- Verify `packages/webpush/package.json` has version `1.0.0-beta.1`
- Verify `.release-please-manifest.json` entry for webpush matches

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated webpush package version to 1.0.0-beta.1, reflecting progress toward a stable release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-notify/better-notify/pull/133)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->