### PR TITLE
fix(web): use correct Manrope Variable font-family name

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -49,10 +49,10 @@
   --color-bn-warning-500: oklch(75% 0.16 85);
   --color-bn-warning-700: oklch(58% 0.14 85);
 
-  --font-sans: 'Manrope', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', 'Roboto', sans-serif;
+  --font-sans: 'Manrope Variable', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', 'Roboto', sans-serif;
   --font-mono:
     'JetBrains Mono', ui-monospace, 'SF Mono', 'Cascadia Code', 'Menlo', 'Consolas', monospace;
-  --font-display: 'Manrope', ui-sans-serif, system-ui, sans-serif;
+  --font-display: 'Manrope Variable', ui-sans-serif, system-ui, sans-serif;
 
   --shadow-bn-xs: 0 1px 1px 0 oklch(20% 0.02 258 / 0.04);
   --shadow-bn-sm: 0 1px 2px 0 oklch(20% 0.02 258 / 0.06), 0 1px 1px 0 oklch(20% 0.02 258 / 0.04);


### PR DESCRIPTION
# Overview

Fix the Manrope font not loading on the docs site.

# What's changed and why?

- **`apps/web/src/styles/app.css`** — Changed `'Manrope'` to `'Manrope Variable'` in `--font-sans` and `--font-display` CSS theme variables.

The `@fontsource-variable/manrope` package registers the font as `"Manrope Variable"`, not `"Manrope"`. This mismatch meant the font was never loaded, and all text silently fell back to system fonts.

# How to test

1. Run `pnpm dev` and open the docs site
2. Open DevTools → Elements → pick any text element
3. Computed styles should show `Manrope Variable` as the rendered font (not system-ui or SF Pro)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated typography fonts across the application to enhanced variable font variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-notify/better-notify/pull/134)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->