### PR TITLE
feat(web): redesign hero code snippet and CLI preview

### DIFF
--- a/apps/web/src/components/landing/cli-preview.tsx
+++ b/apps/web/src/components/landing/cli-preview.tsx
@@ -19,6 +19,11 @@ export function CliPreview() {
     skill: 'npx skills add better-notify/better-notify',
   } as const;
 
+  const hints = {
+    cli: 'Scaffolds a new project with routing, transports, and templates.',
+    skill: 'Adds the Better-Notify skill to your AI coding assistant.',
+  } as const;
+
   async function handleCopy() {
     const ok = await navigator.clipboard?.writeText(commands[active]).then(
       () => true,
@@ -62,26 +67,31 @@ export function CliPreview() {
         ))}
       </div>
 
-      <div className="flex items-center gap-3 px-4 py-3 text-left">
-        <span className="select-none font-mono text-[13px] text-bn-slate-400 dark:text-bn-slate-600">
-          $
-        </span>
-        <code className="flex-1 font-mono text-[13px] text-bn-slate-700 dark:text-bn-slate-300">
-          <span className="font-medium text-bn-navy-700 dark:text-bn-navy-300">npx</span>{' '}
-          {commands[active].replace(/^npx\s+/, '')}
-        </code>
-        <button
-          type="button"
-          aria-label={copied ? 'Copied' : 'Copy command'}
-          onClick={handleCopy}
-          className={`flex-shrink-0 border-0 bg-transparent transition-colors ${
-            copied
-              ? 'text-bn-success-700 dark:text-bn-success-300'
-              : 'text-bn-slate-400 hover:text-bn-slate-600 dark:text-bn-slate-500 dark:hover:text-bn-slate-300'
-          }`}
-        >
-          {copied ? <Check size={14} /> : <Copy size={14} />}
-        </button>
+      <div className="px-4 py-3 text-left">
+        <div className="flex items-center gap-3">
+          <span className="select-none font-mono text-[13px] text-bn-slate-400 dark:text-bn-slate-600">
+            $
+          </span>
+          <code className="flex-1 font-mono text-[13px] text-bn-slate-700 dark:text-bn-slate-300">
+            <span className="font-medium text-bn-navy-700 dark:text-bn-navy-300">npx</span>{' '}
+            {commands[active].replace(/^npx\s+/, '')}
+          </code>
+          <button
+            type="button"
+            aria-label={copied ? 'Copied' : 'Copy command'}
+            onClick={handleCopy}
+            className={`flex-shrink-0 border-0 bg-transparent transition-colors ${
+              copied
+                ? 'text-bn-success-700 dark:text-bn-success-300'
+                : 'text-bn-slate-400 hover:text-bn-slate-600 dark:text-bn-slate-500 dark:hover:text-bn-slate-300'
+            }`}
+          >
+            {copied ? <Check size={14} /> : <Copy size={14} />}
+          </button>
+        </div>
+        <p className="mt-2 pl-[22px] text-[12px] leading-snug text-bn-slate-400 dark:text-bn-slate-500">
+          {hints[active]}
+        </p>
       </div>
     </div>
   );

--- a/apps/web/src/components/landing/hero.tsx
+++ b/apps/web/src/components/landing/hero.tsx
@@ -42,7 +42,7 @@ export function Hero() {
     <section className="relative">
       <BgGrid />
       <div className="relative mx-auto max-w-[1200px] px-5 pb-20 pt-14 md:px-8 md:pb-28 md:pt-20 lg:pb-32 lg:pt-24">
-        <div className="grid items-center gap-12 lg:grid-cols-2 lg:gap-16">
+        <div className="grid items-start gap-12 lg:grid-cols-2 lg:gap-16">
           <div className="text-center lg:text-left">
             <h1
               className="hero-anim text-foreground mb-6 font-bold tracking-bn-snug text-balance"
@@ -107,32 +107,19 @@ export function Hero() {
             </div>
 
             <div
-              className="hero-anim flex flex-wrap items-end justify-center gap-x-8 gap-y-3 lg:justify-start"
+              className="hero-anim flex flex-col items-center gap-5 lg:items-start"
               style={{ animationDelay: '280ms' }}
             >
               <RuntimeBadges />
-              <div className="text-muted-foreground/40 flex items-center gap-3 font-mono text-[12px]">
-                <span>ESM-only</span>
-                <span className="text-muted-foreground/20 text-[10px]">·</span>
-                <span>Open source</span>
-              </div>
-            </div>
-
-            <div className="hero-anim mt-8" style={{ animationDelay: '320ms' }}>
               <TrustedBy />
             </div>
           </div>
 
           <div
-            className="hero-anim min-w-0 overflow-hidden rounded-xl border border-bn-slate-200 bg-white shadow-bn-lg dark:border-bn-slate-800 dark:bg-bn-slate-950"
+            className="hero-anim min-w-0 overflow-hidden rounded-xl border border-bn-slate-200 bg-white shadow-bn-lg dark:border-white/[0.08] dark:bg-[oklch(8%_0.02_260)]"
             style={{ animationDelay: '120ms' }}
           >
-            <div className="flex items-center border-b border-bn-slate-200 px-4 py-2.5 dark:border-bn-slate-800">
-              <div className="mr-3 hidden items-center gap-[6px] sm:flex">
-                <span className="block size-[10px] rounded-full bg-[#ff5f57]" />
-                <span className="block size-[10px] rounded-full bg-[#febc2e]" />
-                <span className="block size-[10px] rounded-full bg-[#28c840]" />
-              </div>
+            <div className="flex items-center border-b border-bn-slate-200 px-3 py-2 dark:border-white/[0.06]">
               <div className="flex overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
                 {tabs.map((tab) => (
                   <button
@@ -141,13 +128,16 @@ export function Hero() {
                       setActive(tab);
                       analytics.track('snippet').action('change', { tab });
                     }}
-                    className={`cursor-pointer whitespace-nowrap rounded-md border-0 px-3 py-1 font-mono text-[12px] font-medium transition-colors ${
+                    className={`relative cursor-pointer whitespace-nowrap rounded-md border-0 px-3 py-1.5 font-mono text-[12px] font-medium transition-colors ${
                       active === tab
-                        ? 'bg-bn-slate-100 text-bn-slate-800 dark:bg-bn-slate-800 dark:text-bn-slate-200'
-                        : 'bg-transparent text-bn-slate-400 hover:text-bn-slate-600 dark:text-bn-slate-500 dark:hover:text-bn-slate-300'
+                        ? 'bg-bn-slate-100 text-bn-slate-800 dark:bg-white/[0.07] dark:text-white/80'
+                        : 'bg-transparent text-bn-slate-400 hover:text-bn-slate-600 dark:text-white/30 dark:hover:text-white/50'
                     }`}
                   >
                     {tab}
+                    {active === tab && (
+                      <span className="absolute bottom-0 left-1/2 h-[2px] w-4/5 -translate-x-1/2 rounded-full bg-bn-navy-600 dark:bg-bn-navy-400" />
+                    )}
                   </button>
                 ))}
               </div>

--- a/apps/web/src/components/landing/runtime-badges.tsx
+++ b/apps/web/src/components/landing/runtime-badges.tsx
@@ -6,7 +6,7 @@ export function RuntimeBadges() {
       <span className="text-muted-foreground/40 font-mono text-[11px] uppercase tracking-bn-widest">
         Runs on
       </span>
-      <div className="flex items-center gap-5">
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
         <div className="flex items-center gap-2">
           <Nodejs className="h-[15px] w-auto shrink-0" aria-hidden="true" />
           <span className="text-muted-foreground/40 font-mono text-[12px]">Node.js</span>
@@ -14,6 +14,11 @@ export function RuntimeBadges() {
         <div className="flex items-center gap-1.5">
           <Bun className="h-[18px] w-auto shrink-0" aria-hidden="true" />
           <span className="text-muted-foreground/40 font-mono text-[12px]">Bun</span>
+        </div>
+        <div className="text-muted-foreground/30 flex items-center gap-3 font-mono text-[12px]">
+          <span>ESM-only</span>
+          <span className="text-[10px]">·</span>
+          <span>Open source</span>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/landing/snippets/cross-transport.tsx
+++ b/apps/web/src/components/landing/snippets/cross-transport.tsx
@@ -9,22 +9,25 @@ export function CrossTransportSnippet() {
       <F>createTransport</F>
       <P>{' } '}</P>
       <K>from</K> <S>'@betternotify/core/transports'</S>
+      <P>;</P>
       {'\n'}
       <K>import</K> <P>{'{ '}</P>
       <F>telegramTransport</F>
       <P>{' } '}</P>
       <K>from</K> <S>'@betternotify/telegram'</S>
+      <P>;</P>
       {'\n'}
       <K>import</K> <P>{'{ '}</P>
       <F>smtpTransport</F>
       <P>{' } '}</P>
       <K>from</K> <S>'@betternotify/smtp'</S>
+      <P>;</P>
       {'\n'}
       {'\n'}
       <K>const</K> smtp = <F>smtpTransport</F>
       <P>({'{ '}</P>host<P>:</P> <S>'...'</S>
       <P>{' }'}</P>
-      <P>)</P>
+      <P>);</P>
       {'\n'}
       {'\n'}
       <K>const</K> smtpMirror = <F>createTransport</F>
@@ -43,7 +46,8 @@ export function CrossTransportSnippet() {
       <P>,</P>
       {'\n'}
       {'      '}to<P>: [{'{ '}</P>email<P>:</P> <S>'team@example.com'</S>
-      <P>{' }'}],</P>
+      <P>{' }'}]</P>
+      <P>,</P>
       {'\n'}
       {'      '}subject<P>:</P> <S>{'`[${'}</S>ctx.route<S>{'}] Mirror`'}</S>
       <P>,</P>
@@ -51,17 +55,18 @@ export function CrossTransportSnippet() {
       {'      '}html<P>:</P> <S>{'`<p>${'}</S>rendered.body<S>{'}</p>`'}</S>
       {'\n'}
       {'    '}
-      <P>{'}'}, </P>ctx<P>)</P>
+      <P>{'}'}</P>
+      <P>,</P> ctx<P>);</P>
       {'\n'}
       {'    '}
       <K>return</K> <P>{'{ '}</P>messageId<P>:</P> 0<P>,</P> chatId<P>:</P> rendered.to ?? 0
-      <P>{' }'}</P>
+      <P>{' }'};</P>
       {'\n'}
       {'  '}
       <P>{'}'}</P>
       {'\n'}
       <P>{'}'}</P>
-      <P>)</P>
+      <P>);</P>
       {'\n'}
       {'\n'}
       <K>const</K> transport = <F>multiTransport</F>
@@ -75,9 +80,9 @@ export function CrossTransportSnippet() {
       {'    '}
       <P>{'{ '}</P>transport<P>:</P> <F>telegramTransport</F>
       <P>({'{ '}</P>token<P>:</P> <S>'...'</S>
-      <P>
-        {' }'}){' }'},
-      </P>
+      <P>{' }'}</P>
+      <P>){' }'}</P>
+      <P>,</P>
       {'\n'}
       {'    '}
       <P>{'{ '}</P>transport<P>:</P> smtpMirror<P>{' }'}</P>
@@ -86,7 +91,7 @@ export function CrossTransportSnippet() {
       <P>]</P>
       {'\n'}
       <P>{'}'}</P>
-      <P>)</P>
+      <P>);</P>
     </>
   );
 }

--- a/apps/web/src/components/landing/snippets/email.tsx
+++ b/apps/web/src/components/landing/snippets/email.tsx
@@ -1,4 +1,4 @@
-import { K, F, S, P } from '@/components/landing/syntax';
+import { K, F, S, P, C } from '@/components/landing/syntax';
 
 export function EmailSnippet() {
   return (
@@ -9,61 +9,55 @@ export function EmailSnippet() {
       <F>createClient</F>
       <P>{' } '}</P>
       <K>from</K> <S>'@betternotify/core'</S>
+      <P>;</P>
       {'\n'}
       <K>import</K> <P>{'{ '}</P>
       <F>emailChannel</F>
       <P>{' } '}</P>
       <K>from</K> <S>'@betternotify/email'</S>
+      <P>;</P>
       {'\n'}
       <K>import</K> <P>{'{ '}</P>
       <F>smtpTransport</F>
       <P>{' } '}</P>
       <K>from</K> <S>'@betternotify/smtp'</S>
+      <P>;</P>
       {'\n'}
       {'\n'}
-      <K>const</K> ch = <F>emailChannel</F>
-      <P>()</P>
-      {'\n'}
-      <K>const</K> rpc = <F>createNotify</F>
-      <P>({'{ '}</P>channels<P>: {'{ '}</P>email<P>:</P> ch<P>{' } }'}</P>
-      <P>)</P>
-      {'\n'}
-      {'\n'}
-      <K>const</K> catalog = rpc.<F>catalog</F>
+      <K>const</K> notify = <F>createNotify</F>
       <P>({'{'}</P>
       {'\n'}
-      {'  '}welcome<P>:</P> rpc.<F>email</F>
+      {'  '}channels<P>: {'{ '}</P>email<P>:</P> <F>emailChannel</F>
+      <P>(){' }'}</P>
+      {'\n'}
+      <P>{'}'}</P>
+      <P>);</P>
+      {'\n'}
+      {'\n'}
+      <K>const</K> catalog = notify.<F>catalog</F>
+      <P>({'{'}</P>
+      {'\n'}
+      {'  '}welcome<P>:</P> notify.<F>email</F>
       <P>()</P>
       {'\n'}
       {'    '}.<F>input</F>
       <P>(</P>z.<F>object</F>
       <P>({'{ '}</P>name<P>:</P> z.<F>string</F>
       <P>(){' }'})</P>
+      <P>)</P>
       {'\n'}
       {'    '}.<F>subject</F>
-      <P>(({'{ '}</P>input<P>{' }'}) =&gt;</P>
-      {'\n'}
-      {'      '}
-      <S>{'`Welcome, ${'}</S>input.name<S>{'}`'}</S>
+      <P>(({'{ '}</P>input<P>{' }'}) =&gt;</P> <S>{'`Welcome, ${'}</S>input.name<S>{'}`'}</S>
       <P>)</P>
       {'\n'}
       {'    '}.<F>template</F>
-      <P>(({'{ '}</P>input
-      <P>
-        {' }'}) =&gt; ({'{'}
-      </P>
-      {'\n'}
-      {'      '}html<P>:</P> <S>{'`<p>Hi ${'}</S>input.name<S>{'}</p>`'}</S>
-      {'\n'}
-      {'    '}
-      <P>{'}'})</P>
-      <P>)</P>
+      <P>(</P>WelcomeEmail<P>)</P>
       {'\n'}
       <P>{'}'}</P>
-      <P>)</P>
+      <P>);</P>
       {'\n'}
       {'\n'}
-      <K>const</K> mail = <F>createClient</F>
+      <K>const</K> client = <F>createClient</F>
       <P>({'{'}</P>
       {'\n'}
       {'  '}catalog<P>,</P>
@@ -79,10 +73,12 @@ export function EmailSnippet() {
       <P>{'}'}</P>
       {'\n'}
       <P>{'}'}</P>
-      <P>)</P>
+      <P>);</P>
       {'\n'}
       {'\n'}
-      <K>await</K> mail.welcome.<F>send</F>
+      <C>{'// fully typed: TS knows welcome expects { name: string }'}</C>
+      {'\n'}
+      <K>await</K> client.welcome.<F>send</F>
       <P>({'{'}</P>
       {'\n'}
       {'  '}to<P>:</P> <S>'ada@example.com'</S>
@@ -92,7 +88,7 @@ export function EmailSnippet() {
       <P>{' }'}</P>
       {'\n'}
       <P>{'}'}</P>
-      <P>)</P>
+      <P>);</P>
     </>
   );
 }

--- a/apps/web/src/components/landing/snippets/telegram.tsx
+++ b/apps/web/src/components/landing/snippets/telegram.tsx
@@ -9,39 +9,45 @@ export function TelegramSnippet() {
       <F>createClient</F>
       <P>{' } '}</P>
       <K>from</K> <S>'@betternotify/core'</S>
+      <P>;</P>
       {'\n'}
       <K>import</K> <P>{'{ '}</P>
       <F>telegramChannel</F>
-      <P>, </P>
+      <P>{' } '}</P>
+      <K>from</K> <S>'@betternotify/telegram'</S>
+      <P>;</P>
+      {'\n'}
+      <K>import</K> <P>{'{ '}</P>
       <F>telegramTransport</F>
       <P>{' } '}</P>
       <K>from</K> <S>'@betternotify/telegram'</S>
+      <P>;</P>
       {'\n'}
       {'\n'}
-      <K>const</K> ch = <F>telegramChannel</F>
-      <P>()</P>
-      {'\n'}
-      <K>const</K> rpc = <F>createNotify</F>
-      <P>({'{ '}</P>channels<P>: {'{ '}</P>telegram<P>:</P> ch<P>{' } }'}</P>
-      <P>)</P>
-      {'\n'}
-      {'\n'}
-      <K>const</K> catalog = rpc.<F>catalog</F>
+      <K>const</K> notify = <F>createNotify</F>
       <P>({'{'}</P>
       {'\n'}
-      {'  '}alert<P>:</P> rpc.<F>telegram</F>
+      {'  '}channels<P>: {'{ '}</P>telegram<P>:</P> <F>telegramChannel</F>
+      <P>(){' }'}</P>
+      {'\n'}
+      <P>{'}'}</P>
+      <P>);</P>
+      {'\n'}
+      {'\n'}
+      <K>const</K> catalog = notify.<F>catalog</F>
+      <P>({'{'}</P>
+      {'\n'}
+      {'  '}alert<P>:</P> notify.<F>telegram</F>
       <P>()</P>
       {'\n'}
       {'    '}.<F>input</F>
       <P>(</P>z.<F>object</F>
       <P>({'{ '}</P>msg<P>:</P> z.<F>string</F>
       <P>(){' }'})</P>
+      <P>)</P>
       {'\n'}
       {'    '}.<F>body</F>
-      <P>(({'{ '}</P>input<P>{' }'}) =&gt;</P>
-      {'\n'}
-      {'      '}
-      <S>{'`<b>Alert</b> ${'}</S>input.msg<S>{'}`'}</S>
+      <P>(({'{ '}</P>input<P>{' }'}) =&gt;</P> <S>{'`Alert: ${'}</S>input.msg<S>{'}`'}</S>
       <P>)</P>
       {'\n'}
       {'    '}.<F>parseMode</F>
@@ -50,10 +56,10 @@ export function TelegramSnippet() {
       <P>)</P>
       {'\n'}
       <P>{'}'}</P>
-      <P>)</P>
+      <P>);</P>
       {'\n'}
       {'\n'}
-      <K>const</K> notify = <F>createClient</F>
+      <K>const</K> client = <F>createClient</F>
       <P>({'{'}</P>
       {'\n'}
       {'  '}catalog<P>,</P>
@@ -69,20 +75,20 @@ export function TelegramSnippet() {
       <P>{'}'}</P>
       {'\n'}
       <P>{'}'}</P>
-      <P>)</P>
+      <P>);</P>
       {'\n'}
       {'\n'}
-      <K>await</K> notify.alert.<F>send</F>
+      <K>await</K> client.alert.<F>send</F>
       <P>({'{'}</P>
       {'\n'}
       {'  '}to<P>:</P> <S>'-1001234567890'</S>
       <P>,</P>
       {'\n'}
-      {'  '}input<P>:</P> <P>{'{ '}</P>msg<P>:</P> <S>'Disk 92%'</S>
+      {'  '}input<P>:</P> <P>{'{ '}</P>msg<P>:</P> <S>'Disk at 92%'</S>
       <P>{' }'}</P>
       {'\n'}
       <P>{'}'}</P>
-      <P>)</P>
+      <P>);</P>
     </>
   );
 }

--- a/apps/web/src/components/landing/syntax.tsx
+++ b/apps/web/src/components/landing/syntax.tsx
@@ -10,10 +10,14 @@ export const F = ({ children }: { children: React.ReactNode }) => {
 
 export const S = ({ children }: { children: React.ReactNode }) => {
   return (
-    <span className="text-[oklch(40%_0.14_155)] dark:text-[oklch(75%_0.14_155)]">{children}</span>
+    <span className="text-[oklch(40%_0.14_155)] dark:text-[oklch(72%_0.14_155)]">{children}</span>
   );
 };
 
 export const P = ({ children }: { children: React.ReactNode }) => {
   return <span className="text-bn-slate-400 dark:text-bn-slate-500">{children}</span>;
+};
+
+export const C = ({ children }: { children: React.ReactNode }) => {
+  return <span className="italic text-bn-slate-400 dark:text-bn-slate-500">{children}</span>;
 };

--- a/apps/web/src/components/landing/trusted-by.tsx
+++ b/apps/web/src/components/landing/trusted-by.tsx
@@ -14,11 +14,11 @@ const companies: Company[] = [
 
 export function TrustedBy() {
   return (
-    <div>
-      <div className="flex flex-wrap items-center gap-x-6 gap-y-3 max-lg:justify-center">
-        <span className="text-muted-foreground/40 font-mono text-[11px] uppercase tracking-bn-widest">
-          In production at
-        </span>
+    <div className="flex flex-col gap-2">
+      <span className="text-muted-foreground/40 font-mono text-[11px] uppercase tracking-bn-widest">
+        In production at
+      </span>
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
         {companies.map((c) => (
           <a
             key={c.name}
@@ -31,15 +31,15 @@ export function TrustedBy() {
             {c.name}
           </a>
         ))}
+        <a
+          href="https://github.com/better-notify/better-notify/issues/new?template=add_your_company.yml"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-muted-foreground/40 text-[13px] no-underline transition-colors hover:text-muted-foreground"
+        >
+          Add yours
+        </a>
       </div>
-      <a
-        href="https://github.com/better-notify/better-notify/issues/new?template=add_your_company.yml"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-muted-foreground/40 mt-2.5 text-[13px] no-underline transition-colors hover:text-muted-foreground max-lg:mx-auto max-lg:block max-lg:w-fit"
-      >
-        Add yours
-      </a>
     </div>
   );
 }


### PR DESCRIPTION
# Overview

Redesign the hero section code snippet and CLI preview for better clarity and usability.

# What's changed and why?

- **hero.tsx** — Removed macOS traffic light dots, added tab accent indicator, improved dark mode colors, restructured RUNS ON / IN PRODUCTION AT into a consistent stacked layout
- **syntax.tsx** — Added `C` (comment) token for italic comment highlighting in snippets
- **email.tsx** — Rewrote snippet with better variable names (`notify`, `client` instead of `rpc`, `mail`), added semicolons, added type-safety comment
- **telegram.tsx** — Same variable name improvements, split imports for readability, added semicolons
- **cross-transport.tsx** — Added semicolons throughout
- **cli-preview.tsx** — Added inline hint below each command describing what it does
- **runtime-badges.tsx** — Merged ESM-only / Open source badges into the same row as Node.js / Bun
- **trusted-by.tsx** — Restructured to match RUNS ON label-above-content pattern with consistent gap

# How to test

1. Run `pnpm dev` and open the landing page
2. Verify code snippet tabs switch correctly (email.ts, telegram.ts, cross-transport.ts)
3. Toggle light/dark mode and confirm syntax colors adapt
4. Check mobile (375px) and desktop layouts
5. Verify CLI hint text changes when switching CLI/Skill tabs