### PR TITLE
docs: add npm badges and fix inaccuracies across package READMEs

### DIFF
--- a/apps/web/src/styles/app.css
+++ b/apps/web/src/styles/app.css
@@ -49,7 +49,8 @@
   --color-bn-warning-500: oklch(75% 0.16 85);
   --color-bn-warning-700: oklch(58% 0.14 85);
 
-  --font-sans: 'Manrope Variable', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', 'Roboto', sans-serif;
+  --font-sans:
+    'Manrope Variable', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', 'Roboto', sans-serif;
   --font-mono:
     'JetBrains Mono', ui-monospace, 'SF Mono', 'Cascadia Code', 'Menlo', 'Consolas', monospace;
   --font-display: 'Manrope Variable', ui-sans-serif, system-ui, sans-serif;

--- a/packages/autosend/README.md
+++ b/packages/autosend/README.md
@@ -1,5 +1,9 @@
 # @betternotify/autosend
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/autosend)](https://www.npmjs.com/package/@betternotify/autosend)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/autosend)](https://www.npmjs.com/package/@betternotify/autosend)
+[![license](https://img.shields.io/npm/l/@betternotify/autosend)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 [Autosend](https://autosend.com) email transport for [Better-Notify](https://github.com/better-notify/better-notify). Sends rendered emails through the Autosend `POST /v1/mails/send` API.
 
 <p>

--- a/packages/bullmq/README.md
+++ b/packages/bullmq/README.md
@@ -1,5 +1,9 @@
 # @betternotify/bullmq
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/bullmq)](https://www.npmjs.com/package/@betternotify/bullmq)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/bullmq)](https://www.npmjs.com/package/@betternotify/bullmq)
+[![license](https://img.shields.io/npm/l/@betternotify/bullmq)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 BullMQ queue adapter for Better-Notify. **v0.1 stub** — full implementation lands in v0.3.
 
 <p>
@@ -8,3 +12,13 @@ BullMQ queue adapter for Better-Notify. **v0.1 stub** — full implementation la
   <a href="https://github.com/better-notify/better-notify">GitHub</a> ·
   <a href="https://x.com/better_notify">X</a>
 </p>
+
+## Install
+
+```sh
+npm install @betternotify/bullmq @betternotify/core bullmq
+```
+
+## License
+
+MIT

--- a/packages/cloudflare-email/README.md
+++ b/packages/cloudflare-email/README.md
@@ -1,6 +1,10 @@
 # @betternotify/cloudflare-email
 
-Cloudflare Email Service transport for [Better-Notify](https://github.com/better-notify/better-notify).
+[![npm version](https://img.shields.io/npm/v/@betternotify/cloudflare-email)](https://www.npmjs.com/package/@betternotify/cloudflare-email)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/cloudflare-email)](https://www.npmjs.com/package/@betternotify/cloudflare-email)
+[![license](https://img.shields.io/npm/l/@betternotify/cloudflare-email)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
+[Cloudflare Email Routing](https://developers.cloudflare.com/email-routing/) transport for [Better-Notify](https://github.com/better-notify/better-notify). Sends rendered emails through the Cloudflare Email Sending API.
 
 <p>
   <a href="https://better-notify.com">Website</a> ·
@@ -8,3 +12,53 @@ Cloudflare Email Service transport for [Better-Notify](https://github.com/better
   <a href="https://github.com/better-notify/better-notify">GitHub</a> ·
   <a href="https://x.com/better_notify">X</a>
 </p>
+
+## Install
+
+```sh
+npm install @betternotify/cloudflare-email @betternotify/core @betternotify/email
+```
+
+## Usage
+
+```ts
+import { createNotify, createClient } from '@betternotify/core';
+import { emailChannel } from '@betternotify/email';
+import { cloudflareEmailTransport } from '@betternotify/cloudflare-email';
+
+const email = emailChannel({
+  defaults: { from: { name: 'My App', email: 'noreply@example.com' } },
+});
+const rpc = createNotify({ channels: { email } });
+const catalog = rpc.catalog({
+  /* routes */
+});
+
+const mail = createClient({
+  catalog,
+  transportsByChannel: {
+    email: cloudflareEmailTransport({
+      accountId: process.env.CLOUDFLARE_ACCOUNT_ID!,
+      apiToken: process.env.CLOUDFLARE_API_TOKEN!,
+    }),
+  },
+});
+```
+
+## Options
+
+| Field       | Type     | Description                                                          |
+| ----------- | -------- | -------------------------------------------------------------------- |
+| `accountId` | `string` | Cloudflare account ID. Required.                                     |
+| `apiToken`  | `string` | Cloudflare API token with email sending permissions. Required.       |
+| `baseUrl`   | `string` | Override the API base URL. Defaults to `https://api.cloudflare.com`. |
+| `logger`    | `object` | Optional `LoggerLike`. Defaults to `consoleLogger()`.                |
+| `http`      | `object` | HTTP behavior options (retry, timeout, hooks).                       |
+
+## Caveats
+
+The Cloudflare Email Sending API does not support `tags`, `priority`, or `inlineAssets` from `RenderedMessage` — these fields are silently dropped. `cc`, `bcc`, `replyTo`, custom `headers`, and `attachments` are fully supported.
+
+## License
+
+MIT

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,5 +1,9 @@
 # @betternotify/core
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/core)](https://www.npmjs.com/package/@betternotify/core)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/core)](https://www.npmjs.com/package/@betternotify/core)
+[![license](https://img.shields.io/npm/l/@betternotify/core)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 Channel-agnostic notification infrastructure: contracts, client pipeline, transport factories, middleware, hooks, plugins, and observability primitives.
 
 <p>

--- a/packages/create-better-notify/README.md
+++ b/packages/create-better-notify/README.md
@@ -1,5 +1,9 @@
 # create-better-notify
 
+[![npm version](https://img.shields.io/npm/v/create-better-notify)](https://www.npmjs.com/package/create-better-notify)
+[![npm downloads](https://img.shields.io/npm/dm/create-better-notify)](https://www.npmjs.com/package/create-better-notify)
+[![license](https://img.shields.io/npm/l/create-better-notify)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 Scaffold a [Better Notify](https://github.com/better-notify/better-notify) project with your preferred framework and RPC layer. One command gives you a working server with typed notifications, OpenAPI playground, and email templates ready to go.
 
 <p>

--- a/packages/discord/README.md
+++ b/packages/discord/README.md
@@ -1,5 +1,9 @@
 # @betternotify/discord
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/discord)](https://www.npmjs.com/package/@betternotify/discord)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/discord)](https://www.npmjs.com/package/@betternotify/discord)
+[![license](https://img.shields.io/npm/l/@betternotify/discord)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 Discord channel for [Better-Notify](https://github.com/better-notify/better-notify). Provides `discordChannel()`, a `mockDiscordTransport` for tests, and a `discordTransport` that posts to Discord webhooks.
 
 <p>

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -1,5 +1,9 @@
 # @betternotify/email
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/email)](https://www.npmjs.com/package/@betternotify/email)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/email)](https://www.npmjs.com/package/@betternotify/email)
+[![license](https://img.shields.io/npm/l/@betternotify/email)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 Email channel for [Better-Notify](https://github.com/better-notify/better-notify). Provides `emailChannel()`, a `mockTransport` for tests, address helpers, and `multiTransport` / `createTransport` factories pre-parameterized for `RenderedMessage`.
 
 <p>

--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -1,5 +1,9 @@
 # @betternotify/github
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/github)](https://www.npmjs.com/package/@betternotify/github)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/github)](https://www.npmjs.com/package/@betternotify/github)
+[![license](https://img.shields.io/npm/l/@betternotify/github)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 [GitHub](https://github.com) channel for [Better-Notify](https://github.com/better-notify/better-notify). Creates issues, posts comments, and submits PR reviews through the GitHub REST API using a single channel with discriminated builder actions.
 
 <p>

--- a/packages/handlebars/README.md
+++ b/packages/handlebars/README.md
@@ -1,5 +1,9 @@
 # @betternotify/handlebars
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/handlebars)](https://www.npmjs.com/package/@betternotify/handlebars)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/handlebars)](https://www.npmjs.com/package/@betternotify/handlebars)
+[![license](https://img.shields.io/npm/l/@betternotify/handlebars)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 Handlebars template adapter for [Better-Notify](https://github.com/better-notify/better-notify).
 
 <p>
@@ -67,3 +71,7 @@ Returns a `TemplateAdapter<TInput>`. Each `render({ input })` call executes the 
 - Pre-compiled at creation time for fast renders
 - Isolated instance per adapter (helpers/partials don't leak between templates)
 - Subject and text templates share the same helpers and partials
+
+## License
+
+MIT

--- a/packages/mailchimp/README.md
+++ b/packages/mailchimp/README.md
@@ -1,5 +1,9 @@
 # @betternotify/mailchimp
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/mailchimp)](https://www.npmjs.com/package/@betternotify/mailchimp)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/mailchimp)](https://www.npmjs.com/package/@betternotify/mailchimp)
+[![license](https://img.shields.io/npm/l/@betternotify/mailchimp)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 Mailchimp Transactional (Mandrill) email transport for [Better-Notify](https://github.com/better-notify/better-notify). Sends rendered emails through the Mandrill `/messages/send` API.
 
 <p>

--- a/packages/mjml/README.md
+++ b/packages/mjml/README.md
@@ -1,5 +1,9 @@
 # @betternotify/mjml
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/mjml)](https://www.npmjs.com/package/@betternotify/mjml)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/mjml)](https://www.npmjs.com/package/@betternotify/mjml)
+[![license](https://img.shields.io/npm/l/@betternotify/mjml)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 MJML + Handlebars template adapter for [Better-Notify](https://github.com/better-notify/better-notify).
 
 <p>
@@ -84,3 +88,7 @@ Returns a `TemplateAdapter<TInput>`. Two-phase rendering:
 ## Node.js only
 
 MJML requires a Node.js runtime (it depends on `htmlnano`, `cheerio`, etc.). For Cloudflare Workers or edge runtimes, use `@betternotify/react-email` or `@betternotify/handlebars` instead.
+
+## License
+
+MIT

--- a/packages/onesignal/README.md
+++ b/packages/onesignal/README.md
@@ -1,5 +1,9 @@
 # @betternotify/onesignal
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/onesignal)](https://www.npmjs.com/package/@betternotify/onesignal)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/onesignal)](https://www.npmjs.com/package/@betternotify/onesignal)
+[![license](https://img.shields.io/npm/l/@betternotify/onesignal)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 [OneSignal](https://onesignal.com) push, email, and SMS transports for [Better-Notify](https://github.com/better-notify/better-notify). Delivers rendered messages through the OneSignal `POST /notifications` API across all three channels.
 
 <p>

--- a/packages/push/README.md
+++ b/packages/push/README.md
@@ -1,5 +1,9 @@
 # @betternotify/push
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/push)](https://www.npmjs.com/package/@betternotify/push)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/push)](https://www.npmjs.com/package/@betternotify/push)
+[![license](https://img.shields.io/npm/l/@betternotify/push)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 Push notification channel for [Better-Notify](https://github.com/better-notify/better-notify). Provides `pushChannel()`, a `mockPushTransport` for tests, and `multiTransport` / `createTransport` factories pre-parameterized for `RenderedPush`.
 
 <p>

--- a/packages/react-email/README.md
+++ b/packages/react-email/README.md
@@ -1,5 +1,9 @@
 # @betternotify/react-email
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/react-email)](https://www.npmjs.com/package/@betternotify/react-email)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/react-email)](https://www.npmjs.com/package/@betternotify/react-email)
+[![license](https://img.shields.io/npm/l/@betternotify/react-email)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 React Email render helper for [Better-Notify](https://github.com/better-notify/better-notify).
 
 <p>
@@ -95,3 +99,7 @@ These scenarios go beyond unit tests and need visual inspection:
 - **Dark mode**: verify the template renders correctly in dark-mode email clients (Outlook dark, Gmail dark).
 - **Mobile responsiveness**: check the rendered email on a mobile viewport — React Email components should be responsive by default, but custom styles may break.
 - **Plain-text quality**: enable `plainText: true` and review the generated text for readability — check that links are visible, headings are clear, and no HTML artifacts leak through.
+
+## License
+
+MIT

--- a/packages/resend/README.md
+++ b/packages/resend/README.md
@@ -1,6 +1,10 @@
 # @betternotify/resend
 
-Resend provider for Better-Notify. **v0.1 stub** — full implementation lands in v0.3.
+[![npm version](https://img.shields.io/npm/v/@betternotify/resend)](https://www.npmjs.com/package/@betternotify/resend)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/resend)](https://www.npmjs.com/package/@betternotify/resend)
+[![license](https://img.shields.io/npm/l/@betternotify/resend)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
+[Resend](https://resend.com) email transport for [Better-Notify](https://github.com/better-notify/better-notify). Sends rendered emails through the Resend `POST /emails` API.
 
 <p>
   <a href="https://better-notify.com">Website</a> ·
@@ -8,3 +12,51 @@ Resend provider for Better-Notify. **v0.1 stub** — full implementation lands i
   <a href="https://github.com/better-notify/better-notify">GitHub</a> ·
   <a href="https://x.com/better_notify">X</a>
 </p>
+
+## Install
+
+```sh
+npm install @betternotify/resend @betternotify/core @betternotify/email
+```
+
+## Usage
+
+```ts
+import { createNotify, createClient } from '@betternotify/core';
+import { emailChannel } from '@betternotify/email';
+import { resendTransport } from '@betternotify/resend';
+
+const email = emailChannel({
+  defaults: { from: { name: 'My App', email: 'noreply@example.com' } },
+});
+const rpc = createNotify({ channels: { email } });
+const catalog = rpc.catalog({
+  /* routes */
+});
+
+const mail = createClient({
+  catalog,
+  transportsByChannel: {
+    email: resendTransport({
+      apiKey: process.env.RESEND_API_KEY!,
+    }),
+  },
+});
+```
+
+## Options
+
+| Field     | Type     | Description                                                      |
+| --------- | -------- | ---------------------------------------------------------------- |
+| `apiKey`  | `string` | Resend API key. Required.                                        |
+| `baseUrl` | `string` | Override the API base URL. Defaults to `https://api.resend.com`. |
+| `logger`  | `object` | Optional `LoggerLike`. Defaults to `consoleLogger()`.            |
+| `http`    | `object` | HTTP behavior options (retry, timeout, hooks).                   |
+
+## Supported fields
+
+Resend supports the full `RenderedMessage` surface: `to`, `cc`, `bcc`, `replyTo`, custom `headers`, `attachments`, and `tags`.
+
+## License
+
+MIT

--- a/packages/selligent/README.md
+++ b/packages/selligent/README.md
@@ -1,5 +1,9 @@
 # @betternotify/selligent
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/selligent)](https://www.npmjs.com/package/@betternotify/selligent)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/selligent)](https://www.npmjs.com/package/@betternotify/selligent)
+[![license](https://img.shields.io/npm/l/@betternotify/selligent)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 [Selligent (Marigold Engage)](https://www.marigold.com/products/marigold-engage) transactional email transport for [Better-Notify](https://github.com/better-notify/better-notify). Delivers rendered emails through the Selligent Delivery Cloud (SDC) `POST /email/v1/messages/send` API.
 
 <p>

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -1,5 +1,9 @@
 # @betternotify/slack
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/slack)](https://www.npmjs.com/package/@betternotify/slack)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/slack)](https://www.npmjs.com/package/@betternotify/slack)
+[![license](https://img.shields.io/npm/l/@betternotify/slack)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 Slack channel for [Better-Notify](https://github.com/better-notify/better-notify). Provides `slackChannel()`, a `mockSlackTransport` for tests, and a `slackTransport` that posts to Slack via incoming webhooks or the Web API.
 
 <p>
@@ -78,12 +82,12 @@ notify.deployAlert.send({
 import { slackTransport, mockSlackTransport } from '@betternotify/slack';
 
 const transport = slackTransport({
-  botToken: process.env.SLACK_BOT_TOKEN!,
+  token: process.env.SLACK_BOT_TOKEN!,
 });
 ```
 
 - `mockSlackTransport()` — records sent messages for tests.
-- `slackTransport({ botToken })` — sends via Slack Web API / incoming webhooks.
+- `slackTransport({ token })` — sends via Slack Web API / incoming webhooks.
 
 Custom transport contract: `Transport<RenderedSlack, SlackTransportData>`.
 

--- a/packages/sms/README.md
+++ b/packages/sms/README.md
@@ -1,5 +1,9 @@
 # @betternotify/sms
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/sms)](https://www.npmjs.com/package/@betternotify/sms)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/sms)](https://www.npmjs.com/package/@betternotify/sms)
+[![license](https://img.shields.io/npm/l/@betternotify/sms)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 SMS channel for [Better-Notify](https://github.com/better-notify/better-notify). Provides `smsChannel()`, a `mockSmsTransport` for tests, and `multiTransport` / `createTransport` factories pre-parameterized for `RenderedSms`.
 
 <p>

--- a/packages/smtp/README.md
+++ b/packages/smtp/README.md
@@ -1,5 +1,9 @@
 # @betternotify/smtp
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/smtp)](https://www.npmjs.com/package/@betternotify/smtp)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/smtp)](https://www.npmjs.com/package/@betternotify/smtp)
+[![license](https://img.shields.io/npm/l/@betternotify/smtp)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 Nodemailer-backed SMTP transport for [Better-Notify](https://github.com/better-notify/better-notify).
 
 <p>
@@ -153,3 +157,7 @@ These scenarios need live credentials and cannot be fully automated:
 - **Large attachments**: send a message with a 10 MB+ attachment; confirm the provider doesn't silently truncate or reject.
 - **Connection pool reconnect**: enable `pool: true`, send a message, wait 10+ minutes (beyond server idle timeout), then send another. Verify the pool recovers without error.
 - **TLS modes**: test both `secure: false` (STARTTLS on 587) and `secure: true` (implicit TLS on 465) against your provider.
+
+## License
+
+MIT

--- a/packages/telegram/README.md
+++ b/packages/telegram/README.md
@@ -1,5 +1,9 @@
 # @betternotify/telegram
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/telegram)](https://www.npmjs.com/package/@betternotify/telegram)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/telegram)](https://www.npmjs.com/package/@betternotify/telegram)
+[![license](https://img.shields.io/npm/l/@betternotify/telegram)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 Telegram channel for [Better-Notify](https://github.com/better-notify/better-notify). Provides `telegramChannel()`, a `mockTelegramTransport` for tests, a `telegramTransport` that sends via the Telegram Bot API, and markdown escape utilities.
 
 <p>
@@ -78,12 +82,12 @@ const bold = md.bold('important');
 import { telegramTransport, mockTelegramTransport } from '@betternotify/telegram';
 
 const transport = telegramTransport({
-  botToken: process.env.TELEGRAM_BOT_TOKEN!,
+  token: process.env.TELEGRAM_BOT_TOKEN!,
 });
 ```
 
 - `mockTelegramTransport()` — records sent messages for tests.
-- `telegramTransport({ botToken })` — sends via the Telegram Bot API.
+- `telegramTransport({ token })` — sends via the Telegram Bot API.
 
 Custom transport contract: `Transport<RenderedTelegram, TelegramTransportData>`.
 

--- a/packages/twilio/README.md
+++ b/packages/twilio/README.md
@@ -1,5 +1,9 @@
 # @betternotify/twilio
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/twilio)](https://www.npmjs.com/package/@betternotify/twilio)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/twilio)](https://www.npmjs.com/package/@betternotify/twilio)
+[![license](https://img.shields.io/npm/l/@betternotify/twilio)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 Twilio SMS transport for [Better-Notify](https://github.com/better-notify/better-notify). Sends rendered SMS messages through the Twilio Messages API.
 
 <p>
@@ -39,7 +43,7 @@ const notify = createClient({
     sms: twilioSmsTransport({
       accountSid: process.env.TWILIO_ACCOUNT_SID!,
       authToken: process.env.TWILIO_AUTH_TOKEN!,
-      from: process.env.TWILIO_FROM_NUMBER!,
+      fromNumber: process.env.TWILIO_FROM_NUMBER!,
     }),
   },
 });
@@ -49,12 +53,15 @@ await notify.loginCode.send({ to: '+15555555555', input: { code: '424242' } });
 
 ## Options
 
-| Field        | Type     | Description                                             |
-| ------------ | -------- | ------------------------------------------------------- |
-| `accountSid` | `string` | Twilio Account SID. Required.                           |
-| `authToken`  | `string` | Twilio Auth Token. Required.                            |
-| `from`       | `string` | Sender phone number or messaging service SID. Required. |
-| `http`       | `object` | HTTP behavior options (retry, timeout, hooks).          |
+| Field                 | Type     | Description                                                                                       |
+| --------------------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `accountSid`          | `string` | Twilio Account SID. Required.                                                                     |
+| `authToken`           | `string` | Twilio Auth Token. Required.                                                                      |
+| `fromNumber`          | `string` | Sender phone number (e.g. `+15555550000`). One of `fromNumber` or `messagingServiceSid` required. |
+| `messagingServiceSid` | `string` | Twilio Messaging Service SID. Alternative to `fromNumber`.                                        |
+| `baseUrl`             | `string` | Override the API base URL. Defaults to `https://api.twilio.com`.                                  |
+| `logger`              | `object` | Optional `LoggerLike`. Defaults to `consoleLogger()`.                                             |
+| `http`                | `object` | HTTP behavior options (retry, timeout, hooks).                                                    |
 
 ## License
 

--- a/packages/webpush/README.md
+++ b/packages/webpush/README.md
@@ -1,5 +1,9 @@
 # @betternotify/webpush
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/webpush)](https://www.npmjs.com/package/@betternotify/webpush)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/webpush)](https://www.npmjs.com/package/@betternotify/webpush)
+[![license](https://img.shields.io/npm/l/@betternotify/webpush)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 Web Push channel and VAPID transport for [Better-Notify](https://github.com/better-notify/better-notify). Send push notifications to any browser via the [VAPID protocol](https://developer.mozilla.org/en-US/docs/Web/API/Push_API) (RFC 8291 + RFC 8292).
 
 <p>

--- a/packages/zapier/README.md
+++ b/packages/zapier/README.md
@@ -1,5 +1,9 @@
 # @betternotify/zapier
 
+[![npm version](https://img.shields.io/npm/v/@betternotify/zapier)](https://www.npmjs.com/package/@betternotify/zapier)
+[![npm downloads](https://img.shields.io/npm/dm/@betternotify/zapier)](https://www.npmjs.com/package/@betternotify/zapier)
+[![license](https://img.shields.io/npm/l/@betternotify/zapier)](https://github.com/better-notify/better-notify/blob/main/LICENSE)
+
 Zapier channel and email transport for [Better-Notify](https://github.com/better-notify/better-notify). Provides `zapierChannel()` for sending structured events to Zapier webhooks, plus `zapierTransport()` as an email transport that forwards rendered emails to Zapier for downstream processing.
 
 <p>


### PR DESCRIPTION
# Overview

Standardize all 23 package READMEs with npm badges and fix wrong/missing content.

# What's changed and why?

- **All 23 `packages/*/README.md`** — Added npm version, downloads, and license badges
- **`packages/resend/README.md`** — Rewrote from stub disclaimer to full docs (transport is implemented, README was outdated)
- **`packages/cloudflare-email/README.md`** — Added usage example, options table, and caveats (was missing all content)
- **`packages/bullmq/README.md`** — Added Install and License sections (still a genuine stub)
- **`packages/slack/README.md`** — Fixed `botToken` → `token` to match actual API
- **`packages/telegram/README.md`** — Fixed `botToken` → `token` to match actual API
- **`packages/twilio/README.md`** — Fixed `from` → `fromNumber`, added `messagingServiceSid`, `baseUrl`, `logger` options
- **`packages/handlebars/README.md`**, **`packages/mjml/README.md`**, **`packages/react-email/README.md`**, **`packages/smtp/README.md`** — Added missing License section

# How to test

- Open any package README on GitHub and verify badges render correctly
- Compare code examples against `src/` exports for accuracy

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->