### PR TITLE
fix(web): remove trailing slashes from canonical URLs and sitemap

### DIFF
--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -24,7 +24,7 @@ export const Route = createFileRoute('/blog/$slug')({
 
     const title = `${loaderData.pageTitle} — ${appConfig.name} Blog`;
     const description = loaderData.pageDescription ?? 'Better-Notify blog.';
-    const url = `${appConfig.baseUrl}/blog/${loaderData.slug}/`;
+    const url = `${appConfig.baseUrl}/blog/${loaderData.slug}`;
     const image = loaderData.pageImage ?? `${appConfig.baseUrl}/og/image.png`;
 
     const { meta, links } = seo({

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -24,7 +24,7 @@ export const Route = createFileRoute('/blog/')({
   head: () => {
     const title = `Blog — ${appConfig.name}`;
     const description = 'Articles, guides, and updates from the Better-Notify team.';
-    const url = `${appConfig.baseUrl}/blog/`;
+    const url = `${appConfig.baseUrl}/blog`;
 
     const { meta, links } = seo({
       title,

--- a/apps/web/src/routes/docs/$.tsx
+++ b/apps/web/src/routes/docs/$.tsx
@@ -27,7 +27,7 @@ export const Route = createFileRoute('/docs/$')({
 
     const title = `${loaderData.pageTitle} — ${appConfig.name} Docs`;
     const description = loaderData.pageDescription ?? 'Better-Notify documentation and guides.';
-    const url = `${appConfig.baseUrl}/docs/${loaderData.slugs.join('/')}/`;
+    const url = `${appConfig.baseUrl}/docs/${loaderData.slugs.join('/')}`;
     const image = `${appConfig.baseUrl}/og/docs/${loaderData.slugs.join('/')}/image.png`;
 
     const { meta, links } = seo({

--- a/apps/web/src/routes/for/$slug.tsx
+++ b/apps/web/src/routes/for/$slug.tsx
@@ -18,7 +18,7 @@ export const Route = createFileRoute('/for/$slug')({
   },
   head: ({ loaderData }) => {
     if (!loaderData) return { meta: [], links: [] };
-    const url = `${appConfig.baseUrl}/for/${loaderData.slug}/`;
+    const url = `${appConfig.baseUrl}/for/${loaderData.slug}`;
     const { meta, links } = seo({
       title: `${appConfig.name} for ${loaderData.name} — Type-safe Notifications`,
       description: loaderData.tagline,

--- a/apps/web/src/routes/for/index.tsx
+++ b/apps/web/src/routes/for/index.tsx
@@ -8,7 +8,7 @@ import { personas } from '@/lib/personas';
 export const Route = createFileRoute('/for/')({
   component: PersonasPage,
   head: () => {
-    const url = `${appConfig.baseUrl}/for/`;
+    const url = `${appConfig.baseUrl}/for`;
     const { meta, links } = seo({
       title: `Better-Notify for your stack — ${appConfig.name}`,
       description:

--- a/apps/web/src/routes/integrations/$slug.tsx
+++ b/apps/web/src/routes/integrations/$slug.tsx
@@ -19,7 +19,7 @@ export const Route = createFileRoute('/integrations/$slug')({
   },
   head: ({ loaderData }) => {
     if (!loaderData) return { meta: [], links: [] };
-    const url = `${appConfig.baseUrl}/integrations/${loaderData.slug}/`;
+    const url = `${appConfig.baseUrl}/integrations/${loaderData.slug}`;
     const { meta, links } = seo({
       title: `${loaderData.name} Integration — ${appConfig.name}`,
       description: loaderData.tagline,

--- a/apps/web/src/routes/integrations/index.tsx
+++ b/apps/web/src/routes/integrations/index.tsx
@@ -8,7 +8,7 @@ import { integrations } from '@/lib/integrations';
 export const Route = createFileRoute('/integrations/')({
   component: IntegrationsPage,
   head: () => {
-    const url = `${appConfig.baseUrl}/integrations/`;
+    const url = `${appConfig.baseUrl}/integrations`;
     const { meta, links } = seo({
       title: `Integrations — ${appConfig.name}`,
       description:

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -15,19 +15,19 @@ export const Route = createFileRoute('/sitemap.xml')({
         const urls = [
           { loc: `${appConfig.baseUrl}/`, changefreq: 'daily', priority: '1.0' },
           ...pages.map((page) => ({
-            loc: `${appConfig.baseUrl}${page.url}/`,
+            loc: `${appConfig.baseUrl}${page.url}`,
             changefreq: 'weekly',
             priority: '0.7',
           })),
-          { loc: `${appConfig.baseUrl}/integrations/`, changefreq: 'weekly', priority: '0.8' },
+          { loc: `${appConfig.baseUrl}/integrations`, changefreq: 'weekly', priority: '0.8' },
           ...integrations.map((i) => ({
-            loc: `${appConfig.baseUrl}/integrations/${i.slug}/`,
+            loc: `${appConfig.baseUrl}/integrations/${i.slug}`,
             changefreq: 'monthly',
             priority: '0.6',
           })),
-          { loc: `${appConfig.baseUrl}/for/`, changefreq: 'weekly', priority: '0.8' },
+          { loc: `${appConfig.baseUrl}/for`, changefreq: 'weekly', priority: '0.8' },
           ...personas.map((p) => ({
-            loc: `${appConfig.baseUrl}/for/${p.slug}/`,
+            loc: `${appConfig.baseUrl}/for/${p.slug}`,
             changefreq: 'monthly',
             priority: '0.6',
           })),


### PR DESCRIPTION
# Overview

Fix URL inconsistency that was preventing Google from indexing pages.

# What's changed and why?

Sitemap and canonical tags used trailing slashes (`/docs/quick-start/`) while internal links and fumadocs URLs did not (`/docs/quick-start`). Google treated these as separate URLs and indexed neither — 94 pages stuck as "Discovered - currently not indexed".

- `routes/sitemap[.]xml.ts` — removed trailing `/` from all generated `<loc>` entries
- `routes/docs/$.tsx` — removed trailing `/` from canonical URL
- `routes/integrations/$slug.tsx` — removed trailing `/` from canonical URL
- `routes/integrations/index.tsx` — removed trailing `/` from canonical URL
- `routes/for/$slug.tsx` — removed trailing `/` from canonical URL
- `routes/for/index.tsx` — removed trailing `/` from canonical URL
- `routes/blog/$slug.tsx` — removed trailing `/` from canonical URL
- `routes/blog/index.tsx` — removed trailing `/` from canonical URL

# How to test

1. Deploy to canary/preview
2. Check `/sitemap.xml` — URLs should have no trailing slashes
3. Inspect any page — `<link rel="canonical">` and `og:url` should match internal link format (no trailing slash)