### PR TITLE
fix(web): rename blog article slug and metadata for SEO

### DIFF
--- a/apps/web/content/blog/announcements/5-new-transports-2-channels-bun-support.mdx
+++ b/apps/web/content/blog/announcements/5-new-transports-2-channels-bun-support.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'New Updates!'
-description: '5 new transport packages, 2 new channels, Bun support, catalog inference, and more.'
+title: '5 New Transports, 2 Channels, Bun Support, and More'
+description: 'Announcing Web Push, GitHub notifications, Autosend, Selligent, and OneSignal transports — plus Bun runtime support and catalog channel inference.'
 date: '2026-05-14'
 tags:
   - release


### PR DESCRIPTION
# Overview

Rename the `every-channel` blog article to a more SEO-friendly slug and improve its metadata.

# What's changed and why?

- **`apps/web/content/blog/announcements/every-channel.mdx` → `5-new-transports-2-channels-bun-support.mdx`** — Renamed file to a keyword-rich slug that describes the actual content
- Updated `title` from generic "New Updates!" to "5 New Transports, 2 Channels, Bun Support, and More"
- Updated `description` to mention specific transports and features for better search visibility

# How to test

1. Run `pnpm dev` and navigate to `/blog`
2. Confirm the article loads at `/blog/5-new-transports-2-channels-bun-support`
3. Verify the old `/blog/every-channel` route no longer resolves

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the announcement blog post to reflect the current platform offering, including five new transports, two additional channels, Bun runtime support, and related feature enhancements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-notify/better-notify/pull/145)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->