### PR TITLE
fix(web): align blog page titles with home page format

### DIFF
--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -22,7 +22,7 @@ export const Route = createFileRoute('/blog/$slug')({
   head: ({ loaderData }) => {
     if (!loaderData) return { meta: [], links: [] };
 
-    const title = `${loaderData.pageTitle} — ${appConfig.name} Blog`;
+    const title = `${appConfig.name}: ${loaderData.pageTitle}`;
     const description = loaderData.pageDescription ?? 'Better-Notify blog.';
     const url = `${appConfig.baseUrl}/blog/${loaderData.slug}`;
     const image = loaderData.pageImage ?? `${appConfig.baseUrl}/og/image.png`;

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -23,7 +23,7 @@ export const Route = createFileRoute('/blog/')({
     return await serverLoader();
   },
   head: () => {
-    const title = `Blog — ${appConfig.name}`;
+    const title = `${appConfig.name}: Blog`;
     const description = 'Articles, guides, and updates from the Better-Notify team.';
     const url = `${appConfig.baseUrl}/blog`;
 


### PR DESCRIPTION
# Overview

Blog page titles now follow the same format as the home page.

# What's changed and why?

- **`apps/web/src/routes/blog/index.tsx`** — Changed title from `Blog — Better-Notify` to `Better-Notify: Blog`
- **`apps/web/src/routes/blog/$slug.tsx`** — Changed title from `[Post Title] — Better-Notify Blog` to `Better-Notify: [Post Title]`

# How to test

1. Visit `/blog` and check the browser tab title
2. Open any blog post and verify the tab title follows `Better-Notify: [Post Title]`