### PR TITLE
fix(web): correct Autosend link in blog article

### DIFF
--- a/apps/web/content/blog/announcements/5-new-transports-2-channels-bun-support.mdx
+++ b/apps/web/content/blog/announcements/5-new-transports-2-channels-bun-support.mdx
@@ -44,7 +44,7 @@ const rpc = createNotify({
 
 ### Autosend
 
-`@betternotify/autosend` adds [Autosend](https://autosend.io) as an email transport. Use it standalone or pair it with `multiTransport` for failover alongside SMTP or Resend. See the [Autosend transport](/docs/transports/autosend) docs.
+`@betternotify/autosend` adds [Autosend](https://autosend.com) as an email transport. Use it standalone or pair it with `multiTransport` for failover alongside SMTP or Resend. See the [Autosend transport](/docs/transports/autosend) docs.
 
 ```package-install
 @betternotify/autosend


### PR DESCRIPTION
# Overview

Fix broken Autosend link in blog article.

# What's changed and why?

- `apps/web/content/blog/announcements/5-new-transports-2-channels-bun-support.mdx` — changed Autosend link from `autosend.io` to `autosend.com`

# How to test

1. Open the blog article "5 new transports, 2 channels, Bun support"
2. Click the Autosend link and confirm it goes to `autosend.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the Autosend email transport service URL in the release announcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-notify/better-notify/pull/149)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->