### PR TITLE
feat: add logo brand asset menu

### DIFF
--- a/apps/web/src/components/landing/header.tsx
+++ b/apps/web/src/components/landing/header.tsx
@@ -8,13 +8,18 @@ import {
   StarIcon,
   ListIcon,
   XLogoIcon,
+  CopyIcon,
+  DownloadSimpleIcon,
 } from '@phosphor-icons/react';
 import { useTheme } from 'fumadocs-ui/provider/base';
+import type { MouseEvent, ReactNode } from 'react';
 import { useRef, useEffect, useState } from 'react';
 import { useAnalytics } from '@/hooks/use-analytics';
 
 import { LogoShort } from '@libs/ui';
 import { appConfig } from '@/lib/shared';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { logoSvg, wordmarkSvg } from '@/lib/brand-assets';
 
 const navLinks = [
   { label: 'Docs', href: '/docs' },
@@ -22,10 +27,60 @@ const navLinks = [
   { label: 'Changelog', href: '/docs/changelog' },
 ] as const;
 
+const writeClipboardText = async (text: string) => {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.top = '-999px';
+  document.body.append(textarea);
+  textarea.select();
+  document.execCommand('copy');
+  textarea.remove();
+};
+
+const downloadBrandAssets = () => {
+  const link = document.createElement('a');
+  link.href = '/brand-assets.zip';
+  link.download = 'better-notify-brand-assets.zip';
+  document.body.append(link);
+  link.click();
+  link.remove();
+};
+
+function BrandAssetAction({
+  children,
+  icon,
+  onSelect,
+}: {
+  children: ReactNode;
+  icon: ReactNode;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className="group flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2 py-2 text-left text-[13px] font-medium text-foreground transition-colors hover:bg-bn-slate-100 focus-visible:bg-bn-slate-100 focus-visible:outline-none dark:hover:bg-bn-slate-800 dark:focus-visible:bg-bn-slate-800"
+    >
+      <span className="border-border bg-card text-muted-foreground group-hover:text-foreground flex size-7 shrink-0 items-center justify-center rounded-md border transition-colors [&_svg]:size-3.5">
+        {icon}
+      </span>
+      <span className="min-w-0 flex-1 truncate">{children}</span>
+    </button>
+  );
+}
+
 export function LandingHeader() {
   const search = useSearchContext();
   const { setTheme, resolvedTheme } = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [brandMenuOpen, setBrandMenuOpen] = useState(false);
   const headerRef = useRef<HTMLElement>(null);
   const analytics = useAnalytics('header');
   const isDark = resolvedTheme === 'dark';
@@ -44,19 +99,77 @@ export function LandingHeader() {
     return () => ro.disconnect();
   }, []);
 
+  const handleBrandContextMenu = (event: MouseEvent) => {
+    event.preventDefault();
+    setBrandMenuOpen(true);
+  };
+
   return (
     <header
       ref={headerRef}
       className="sticky top-0 z-30 border-b border-bn-slate-200 bg-[color-mix(in_oklch,var(--background)_88%,transparent)] backdrop-blur-md backdrop-saturate-[1.4] dark:border-bn-slate-800"
     >
       <div className="mx-auto flex max-w-[1200px] items-center gap-8 px-5 py-3 md:px-8">
-        <Link
-          to="/"
-          className="flex items-center gap-2.5 text-base font-bold tracking-tight text-foreground no-underline"
+        <Popover
+          open={brandMenuOpen}
+          onOpenChange={(open) => setBrandMenuOpen(open)}
+          triggerId="brand-assets-trigger"
         >
-          <LogoShort className="size-6" />
-          {appConfig.name}
-        </Link>
+          <PopoverTrigger
+            id="brand-assets-trigger"
+            nativeButton={false}
+            onClick={(event) => event.preventBaseUIHandler()}
+            onContextMenu={handleBrandContextMenu}
+            render={
+              <span className="inline-flex">
+                <Link
+                  to="/"
+                  className="flex items-center gap-2.5 rounded-md text-base font-bold tracking-tight text-foreground no-underline outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/30"
+                >
+                  <LogoShort className="size-6" />
+                  {appConfig.name}
+                </Link>
+              </span>
+            }
+          />
+          <PopoverContent
+            align="start"
+            side="bottom"
+            sideOffset={16}
+            className="w-64 gap-1 rounded-md p-1.5 shadow-lg ring-1 ring-foreground/10"
+          >
+            <BrandAssetAction
+              icon={<CopyIcon />}
+              onSelect={() => {
+                void writeClipboardText(logoSvg);
+                setBrandMenuOpen(false);
+                analytics.track('brand_assets').action('export', { asset: 'logo_svg' });
+              }}
+            >
+              Copy logo as SVG
+            </BrandAssetAction>
+            <BrandAssetAction
+              icon={<CopyIcon />}
+              onSelect={() => {
+                void writeClipboardText(wordmarkSvg);
+                setBrandMenuOpen(false);
+                analytics.track('brand_assets').action('export', { asset: 'wordmark_svg' });
+              }}
+            >
+              Copy wordmark as SVG
+            </BrandAssetAction>
+            <BrandAssetAction
+              icon={<DownloadSimpleIcon />}
+              onSelect={() => {
+                downloadBrandAssets();
+                setBrandMenuOpen(false);
+                analytics.track('brand_assets').action('export', { asset: 'brand_assets_zip' });
+              }}
+            >
+              Download brand assets
+            </BrandAssetAction>
+          </PopoverContent>
+        </Popover>
 
         <nav className="hidden items-center gap-5 md:flex">
           {visibleLinks.map((link) => {

--- a/apps/web/src/lib/brand-assets.ts
+++ b/apps/web/src/lib/brand-assets.ts
@@ -1,0 +1,25 @@
+import logoShortSvg from '@libs/ui/assets/logo-short.svg?raw';
+import logoShortWhiteSvg from '@libs/ui/assets/logo-short-white.svg?raw';
+import logoStackedSvg from '@libs/ui/assets/logo-stacked.svg?raw';
+import logoStackedWhiteSvg from '@libs/ui/assets/logo-stacked-white.svg?raw';
+import logoWideSvg from '@libs/ui/assets/logo-wide.svg?raw';
+import logoWideWhiteSvg from '@libs/ui/assets/logo-wide-white.svg?raw';
+
+type BrandAsset = {
+  fileName: string;
+  source: string;
+};
+
+const normalizeSvg = (source: string) => source.trim() + '\n';
+
+export const logoSvg = normalizeSvg(logoShortSvg);
+export const wordmarkSvg = normalizeSvg(logoWideSvg);
+
+export const brandAssets: BrandAsset[] = [
+  { fileName: 'better-notify-logo.svg', source: logoSvg },
+  { fileName: 'better-notify-logo-white.svg', source: normalizeSvg(logoShortWhiteSvg) },
+  { fileName: 'better-notify-wordmark.svg', source: wordmarkSvg },
+  { fileName: 'better-notify-wordmark-white.svg', source: normalizeSvg(logoWideWhiteSvg) },
+  { fileName: 'better-notify-stacked.svg', source: normalizeSvg(logoStackedSvg) },
+  { fileName: 'better-notify-stacked-white.svg', source: normalizeSvg(logoStackedWhiteSvg) },
+];

--- a/apps/web/src/lib/zip.ts
+++ b/apps/web/src/lib/zip.ts
@@ -1,0 +1,99 @@
+type ZipFile = {
+  fileName: string;
+  source: string;
+};
+
+const textEncoder = new TextEncoder();
+const crcTable = new Uint32Array(256);
+
+for (let n = 0; n < 256; n++) {
+  let c = n;
+  for (let k = 0; k < 8; k++) {
+    c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+  }
+  crcTable[n] = c >>> 0;
+}
+
+const crc32 = (data: Uint8Array) => {
+  let crc = 0xffffffff;
+  for (const byte of data) {
+    crc = crcTable[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+};
+
+const writeUint16 = (target: Uint8Array, offset: number, value: number) => {
+  target[offset] = value & 0xff;
+  target[offset + 1] = (value >>> 8) & 0xff;
+};
+
+const writeUint32 = (target: Uint8Array, offset: number, value: number) => {
+  target[offset] = value & 0xff;
+  target[offset + 1] = (value >>> 8) & 0xff;
+  target[offset + 2] = (value >>> 16) & 0xff;
+  target[offset + 3] = (value >>> 24) & 0xff;
+};
+
+const concat = (parts: Uint8Array[]) => {
+  const size = parts.reduce((sum, part) => sum + part.length, 0);
+  const output = new Uint8Array(size);
+  let offset = 0;
+
+  for (const part of parts) {
+    output.set(part, offset);
+    offset += part.length;
+  }
+
+  return output;
+};
+
+export const createStoredZip = (files: ZipFile[]) => {
+  const localParts: Uint8Array[] = [];
+  const centralParts: Uint8Array[] = [];
+  let offset = 0;
+
+  for (const file of files) {
+    const fileName = textEncoder.encode(file.fileName);
+    const data = textEncoder.encode(file.source);
+    const checksum = crc32(data);
+    const localHeader = new Uint8Array(30 + fileName.length);
+    const centralHeader = new Uint8Array(46 + fileName.length);
+
+    writeUint32(localHeader, 0, 0x04034b50);
+    writeUint16(localHeader, 4, 20);
+    writeUint16(localHeader, 6, 0);
+    writeUint16(localHeader, 8, 0);
+    writeUint32(localHeader, 14, checksum);
+    writeUint32(localHeader, 18, data.length);
+    writeUint32(localHeader, 22, data.length);
+    writeUint16(localHeader, 26, fileName.length);
+    localHeader.set(fileName, 30);
+
+    writeUint32(centralHeader, 0, 0x02014b50);
+    writeUint16(centralHeader, 4, 20);
+    writeUint16(centralHeader, 6, 20);
+    writeUint16(centralHeader, 8, 0);
+    writeUint16(centralHeader, 10, 0);
+    writeUint32(centralHeader, 16, checksum);
+    writeUint32(centralHeader, 20, data.length);
+    writeUint32(centralHeader, 24, data.length);
+    writeUint16(centralHeader, 28, fileName.length);
+    writeUint32(centralHeader, 42, offset);
+    centralHeader.set(fileName, 46);
+
+    localParts.push(localHeader, data);
+    centralParts.push(centralHeader);
+    offset += localHeader.length + data.length;
+  }
+
+  const centralDirectory = concat(centralParts);
+  const endRecord = new Uint8Array(22);
+
+  writeUint32(endRecord, 0, 0x06054b50);
+  writeUint16(endRecord, 8, files.length);
+  writeUint16(endRecord, 10, files.length);
+  writeUint32(endRecord, 12, centralDirectory.length);
+  writeUint32(endRecord, 16, offset);
+
+  return concat([...localParts, centralDirectory, endRecord]);
+};

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as SitemapDotxmlRouteImport } from './routes/sitemap[.]xml'
 import { Route as RobotsDottxtRouteImport } from './routes/robots[.]txt'
 import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
 import { Route as LlmsFullDottxtRouteImport } from './routes/llms-full[.]txt'
+import { Route as BrandAssetsDotzipRouteImport } from './routes/brand-assets[.]zip'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as IntegrationsIndexRouteImport } from './routes/integrations/index'
 import { Route as ForIndexRouteImport } from './routes/for/index'
@@ -44,6 +45,11 @@ const LlmsDottxtRoute = LlmsDottxtRouteImport.update({
 const LlmsFullDottxtRoute = LlmsFullDottxtRouteImport.update({
   id: '/llms-full.txt',
   path: '/llms-full.txt',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BrandAssetsDotzipRoute = BrandAssetsDotzipRouteImport.update({
+  id: '/brand-assets.zip',
+  path: '/brand-assets.zip',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -109,6 +115,7 @@ const LlmsDotmdxDocsSplatRoute = LlmsDotmdxDocsSplatRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/brand-assets.zip': typeof BrandAssetsDotzipRoute
   '/llms-full.txt': typeof LlmsFullDottxtRoute
   '/llms.txt': typeof LlmsDottxtRoute
   '/robots.txt': typeof RobotsDottxtRoute
@@ -127,6 +134,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/brand-assets.zip': typeof BrandAssetsDotzipRoute
   '/llms-full.txt': typeof LlmsFullDottxtRoute
   '/llms.txt': typeof LlmsDottxtRoute
   '/robots.txt': typeof RobotsDottxtRoute
@@ -146,6 +154,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/brand-assets.zip': typeof BrandAssetsDotzipRoute
   '/llms-full.txt': typeof LlmsFullDottxtRoute
   '/llms.txt': typeof LlmsDottxtRoute
   '/robots.txt': typeof RobotsDottxtRoute
@@ -166,6 +175,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/brand-assets.zip'
     | '/llms-full.txt'
     | '/llms.txt'
     | '/robots.txt'
@@ -184,6 +194,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/brand-assets.zip'
     | '/llms-full.txt'
     | '/llms.txt'
     | '/robots.txt'
@@ -202,6 +213,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/brand-assets.zip'
     | '/llms-full.txt'
     | '/llms.txt'
     | '/robots.txt'
@@ -221,6 +233,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  BrandAssetsDotzipRoute: typeof BrandAssetsDotzipRoute
   LlmsFullDottxtRoute: typeof LlmsFullDottxtRoute
   LlmsDottxtRoute: typeof LlmsDottxtRoute
   RobotsDottxtRoute: typeof RobotsDottxtRoute
@@ -266,6 +279,13 @@ declare module '@tanstack/react-router' {
       path: '/llms-full.txt'
       fullPath: '/llms-full.txt'
       preLoaderRoute: typeof LlmsFullDottxtRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/brand-assets.zip': {
+      id: '/brand-assets.zip'
+      path: '/brand-assets.zip'
+      fullPath: '/brand-assets.zip'
+      preLoaderRoute: typeof BrandAssetsDotzipRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -357,6 +377,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  BrandAssetsDotzipRoute: BrandAssetsDotzipRoute,
   LlmsFullDottxtRoute: LlmsFullDottxtRoute,
   LlmsDottxtRoute: LlmsDottxtRoute,
   RobotsDottxtRoute: RobotsDottxtRoute,

--- a/apps/web/src/routes/brand-assets[.]zip.ts
+++ b/apps/web/src/routes/brand-assets[.]zip.ts
@@ -1,0 +1,19 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { brandAssets } from '@/lib/brand-assets';
+import { createStoredZip } from '@/lib/zip';
+
+export const Route = createFileRoute('/brand-assets.zip')({
+  server: {
+    handlers: {
+      GET() {
+        return new Response(createStoredZip(brandAssets), {
+          headers: {
+            'Content-Type': 'application/zip',
+            'Content-Disposition': 'attachment; filename="better-notify-brand-assets.zip"',
+          },
+        });
+      },
+    },
+  },
+});

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
# Overview

Adds a right-click brand assets popover to the web header.

# What's changed and why?

- `apps/web/src/components/landing/header.tsx`: Adds a styled popover below the logo with copy and download actions.
- `apps/web/src/lib/brand-assets.ts`: Reuses existing SVG assets for clipboard and download content.
- `apps/web/src/lib/zip.ts`: Builds the brand assets ZIP response.
- `apps/web/src/routes/brand-assets[.]zip.ts`: Adds the download endpoint.
- `apps/web/src/routeTree.gen.ts` and `apps/web/src/vite-env.d.ts`: Updates routing and raw SVG import typing.

# How to test

- Run `pnpm --filter @betternotify/web typecheck`.
- Open the web app, right-click the logo, and use the three brand asset options.

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

