### PR TITLE
fix(ci): use client-id for app token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         id: app-token
         with:
-          app-id: ${{ secrets.BETTER_NOTIFY_APP_ID }}
+          client-id: ${{ secrets.BETTER_NOTIFY_APP_ID }}
           private-key: ${{ secrets.BETTER_NOTIFY_APP_PRIVATE_KEY }}
 
       - name: Release Please


### PR DESCRIPTION
# Overview

Fixes the deprecated GitHub App token input in the release workflow.

# What's changed and why?

- `.github/workflows/release.yml`: replaced `app-id` with `client-id` for `actions/create-github-app-token`.

This removes the deprecation warning while keeping the same secret value.

# How to test

- Confirm `.github` no longer contains `app-id:`.
- Review the workflow diff against `main`.

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->
