### PR TITLE
feat(web): add live GitHub star count to landing header

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ npx create-better-notify@latest
 
 ---
 
+## Star History
+
+<a href="https://www.star-history.com/?repos=better-notify%2Fbetter-notify&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=better-notify/better-notify&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=better-notify/better-notify&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=better-notify/better-notify&type=date&legend=top-left" />
+ </picture>
+</a>
+
+---
+
 <p align="center">
   <a href="https://github.com/better-notify/better-notify">GitHub</a> ·
   <a href="https://x.com/better_notify">X</a>

--- a/apps/web/src/components/landing/header.tsx
+++ b/apps/web/src/components/landing/header.tsx
@@ -15,6 +15,7 @@ import { useTheme } from 'fumadocs-ui/provider/base';
 import type { MouseEvent, ReactNode } from 'react';
 import { useRef, useEffect, useState } from 'react';
 import { useAnalytics } from '@/hooks/use-analytics';
+import { useStarCount, formatStarCount } from '@/hooks/use-star-count';
 
 import { LogoShort } from '@libs/ui';
 import { appConfig } from '@/lib/shared';
@@ -83,6 +84,7 @@ export function LandingHeader() {
   const [brandMenuOpen, setBrandMenuOpen] = useState(false);
   const headerRef = useRef<HTMLElement>(null);
   const analytics = useAnalytics('header');
+  const starCount = useStarCount(appConfig.git.user, appConfig.git.repo);
   const isDark = resolvedTheme === 'dark';
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const isHome = pathname === '/';
@@ -252,9 +254,16 @@ export function LandingHeader() {
           >
             <GithubLogoIcon size={14} />
             GitHub
-            <span className="border-border text-muted-foreground ml-0.5 border-l pl-2">
-              <StarIcon size={12} weight="fill" className="inline" />
-            </span>
+            {(starCount.count != null || starCount.isLoading) && (
+              <span className="border-border text-muted-foreground ml-0.5 flex items-center gap-1 border-l pl-2">
+                <StarIcon size={12} weight="fill" className="inline" />
+                {starCount.count != null ? (
+                  formatStarCount(starCount.count)
+                ) : (
+                  <span className="inline-block h-3.5 w-6 animate-pulse rounded-sm bg-bn-slate-200 dark:bg-bn-slate-700" />
+                )}
+              </span>
+            )}
           </a>
 
           <button

--- a/apps/web/src/hooks/use-local-storage.ts
+++ b/apps/web/src/hooks/use-local-storage.ts
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+const ROOT_KEY = 'bn:store';
+const CHANGE_EVENT = 'bn:store:change';
+
+type StoreShape = Record<string, unknown>;
+
+type StoredEntry<T> = { v: T; e?: number };
+
+export type UseLocalStorageOptions = {
+  ttl?: number;
+};
+
+export type UseLocalStorageResult<T> = {
+  value: T | null;
+  setValue: (next: T | null) => void;
+  isHydrated: boolean;
+};
+
+const isBrowser = () => typeof window !== 'undefined';
+
+const readRoot = (): StoreShape => {
+  if (!isBrowser()) return {};
+  const raw = window.localStorage.getItem(ROOT_KEY);
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === 'object' ? (parsed as StoreShape) : {};
+  } catch {
+    return {};
+  }
+};
+
+const writeRoot = (root: StoreShape) => {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(ROOT_KEY, JSON.stringify(root));
+  } catch {
+    return;
+  }
+};
+
+const getAtPath = (root: StoreShape, path: readonly string[]): unknown => {
+  let cursor: unknown = root;
+  for (const segment of path) {
+    if (cursor == null || typeof cursor !== 'object') return undefined;
+    cursor = (cursor as Record<string, unknown>)[segment];
+  }
+  return cursor;
+};
+
+const setAtPath = (root: StoreShape, path: readonly string[], value: unknown): StoreShape => {
+  if (path.length === 0) return root;
+  const clone: StoreShape = { ...root };
+  let cursor: Record<string, unknown> = clone;
+  for (let i = 0; i < path.length - 1; i++) {
+    const segment = path[i];
+    if (segment === undefined) continue;
+    const existing = cursor[segment];
+    const next =
+      existing && typeof existing === 'object' ? { ...(existing as Record<string, unknown>) } : {};
+    cursor[segment] = next;
+    cursor = next;
+  }
+  const last = path[path.length - 1];
+  if (last === undefined) return clone;
+  if (value === undefined) {
+    delete cursor[last];
+  } else {
+    cursor[last] = value;
+  }
+  return clone;
+};
+
+const unwrap = <T>(raw: unknown): T | null => {
+  if (!raw || typeof raw !== 'object') return null;
+  const entry = raw as StoredEntry<T>;
+  if (entry.e != null && entry.e <= Date.now()) return null;
+  return entry.v ?? null;
+};
+
+const notify = () => {
+  if (!isBrowser()) return;
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+};
+
+export const useLocalStorage = <T>(
+  path: readonly string[],
+  options?: UseLocalStorageOptions,
+): UseLocalStorageResult<T> => {
+  const ttl = options?.ttl;
+  const pathKey = useMemo(() => JSON.stringify(path), [path]);
+  const segments = useMemo(() => JSON.parse(pathKey) as string[], [pathKey]);
+
+  const [value, setStateValue] = useState<T | null>(null);
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    const read = (): T | null => {
+      const root = readRoot();
+      return unwrap<T>(getAtPath(root, segments));
+    };
+
+    setStateValue(read());
+    setIsHydrated(true);
+
+    const handler = (event: Event) => {
+      if (event instanceof StorageEvent && event.key !== null && event.key !== ROOT_KEY) {
+        return;
+      }
+      setStateValue(read());
+    };
+
+    window.addEventListener('storage', handler);
+    window.addEventListener(CHANGE_EVENT, handler);
+
+    return () => {
+      window.removeEventListener('storage', handler);
+      window.removeEventListener(CHANGE_EVENT, handler);
+    };
+  }, [segments]);
+
+  const setValue = useCallback(
+    (next: T | null) => {
+      const root = readRoot();
+      const payload =
+        next === null
+          ? undefined
+          : ttl != null
+            ? ({ v: next, e: Date.now() + ttl } satisfies StoredEntry<T>)
+            : ({ v: next } satisfies StoredEntry<T>);
+      writeRoot(setAtPath(root, segments, payload));
+      setStateValue(next);
+      notify();
+    },
+    [segments, ttl],
+  );
+
+  return { value, setValue, isHydrated };
+};

--- a/apps/web/src/hooks/use-star-count.ts
+++ b/apps/web/src/hooks/use-star-count.ts
@@ -1,0 +1,62 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useLocalStorage } from './use-local-storage';
+
+const TTL_MS = 10 * 60 * 1000;
+
+export type StarCountState = { count: number | null; isLoading: boolean };
+
+export const useStarCount = (owner: string, repo: string): StarCountState => {
+  const path = useMemo(() => ['starCount', `${owner}/${repo}`], [owner, repo]);
+  const {
+    value: cached,
+    setValue: setCached,
+    isHydrated,
+  } = useLocalStorage<number>(path, {
+    ttl: TTL_MS,
+  });
+  const [fetchResolved, setFetchResolved] = useState(false);
+
+  useEffect(() => {
+    if (!isHydrated) return;
+    if (cached != null) {
+      setFetchResolved(true);
+      return;
+    }
+
+    setFetchResolved(false);
+    const controller = new AbortController();
+
+    fetch(`https://api.github.com/repos/${owner}/${repo}`, {
+      signal: controller.signal,
+      headers: { Accept: 'application/vnd.github.v3+json' },
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        const value = data?.stargazers_count;
+        if (typeof value === 'number') {
+          setCached(value);
+        }
+        setFetchResolved(true);
+      })
+      .catch((err) => {
+        if (err?.name !== 'AbortError') {
+          setFetchResolved(true);
+        }
+      });
+
+    return () => controller.abort();
+  }, [owner, repo, isHydrated, cached, setCached]);
+
+  return {
+    count: cached,
+    isLoading: !isHydrated || (cached == null && !fetchResolved),
+  };
+};
+
+export const formatStarCount = (count: number): string => {
+  if (count >= 1000) {
+    const k = count / 1000;
+    return `${k % 1 === 0 ? k.toFixed(0) : k.toFixed(1)}k`;
+  }
+  return String(count);
+};


### PR DESCRIPTION
# Overview

Shows the live GitHub star count next to the GitHub button in the landing header, backed by a small reusable localStorage store.

# What's changed and why?

- `apps/web/src/hooks/use-local-storage.ts` — new generic store hook. Persists a deep object under a single `bn:store` key, with optional TTL, SSR-safe hydration, and same-tab/cross-tab sync.
- `apps/web/src/hooks/use-star-count.ts` — fetches the star count from the GitHub API and caches it through the store hook (10 min TTL). Falls back cleanly when the API fails or is rate-limited.
- `apps/web/src/components/landing/header.tsx` — renders the formatted count next to the star icon; hides the badge entirely if the count is unavailable.
- `README.md` — adds a Star History chart section.

# How to test

- Run the web app and open the landing page; the GitHub button shows a star count.
- Refresh the page within 10 minutes — no new GitHub API request is made (check the network tab).
- Block `api.github.com` in DevTools and reload — the star badge is hidden instead of stuck loading.

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Star History chart visualization to README documentation
  * Header now displays real-time GitHub star count alongside the GitHub link with loading state indicator

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-notify/better-notify/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->