### PR TITLE
fix(web): resolve blog 404 errors on nested category paths

### DIFF
--- a/apps/web/src/components/landing/author.tsx
+++ b/apps/web/src/components/landing/author.tsx
@@ -74,8 +74,8 @@ export function BlogAndAuthor({ posts }: { posts: BlogPreviewPost[] }) {
               {posts.map((post) => (
                 <Link
                   key={post.slug}
-                  to="/blog/$slug"
-                  params={{ slug: post.slug }}
+                  to="/blog/$"
+                  params={{ _splat: post.slug }}
                   className="border-border group rounded-lg border bg-white/60 p-4 no-underline transition-colors hover:bg-white/90 dark:bg-bn-slate-900/40 dark:hover:bg-bn-slate-900/70"
                 >
                   <div className="mb-2 flex items-center justify-between">

--- a/apps/web/src/lib/blog-source.ts
+++ b/apps/web/src/lib/blog-source.ts
@@ -36,7 +36,7 @@ const assertUniqueSlugs = (posts: BlogPost[]): void => {
 export const mapPageToPost = (page: (typeof blogSource)['$inferPage']): BlogPost => {
   const data = page.data as unknown as Record<string, unknown>;
   return {
-    slug: page.slugs.at(-1) ?? '',
+    slug: page.slugs.join('/'),
     title: page.data.title,
     description: (page.data.description as string) ?? '',
     date:

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -24,7 +24,7 @@ import { Route as OgSplatRouteImport } from './routes/og.$'
 import { Route as IntegrationsSlugRouteImport } from './routes/integrations/$slug'
 import { Route as ForSlugRouteImport } from './routes/for/$slug'
 import { Route as DocsSplatRouteImport } from './routes/docs/$'
-import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
+import { Route as BlogSplatRouteImport } from './routes/blog/$'
 import { Route as ApiSearchRouteImport } from './routes/api/search'
 import { Route as LlmsDotmdxDocsSplatRouteImport } from './routes/llms[.]mdx.docs.$'
 
@@ -103,9 +103,9 @@ const DocsSplatRoute = DocsSplatRouteImport.update({
   path: '/docs/$',
   getParentRoute: () => rootRouteImport,
 } as any)
-const BlogSlugRoute = BlogSlugRouteImport.update({
-  id: '/blog/$slug',
-  path: '/blog/$slug',
+const BlogSplatRoute = BlogSplatRouteImport.update({
+  id: '/blog/$',
+  path: '/blog/$',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiSearchRoute = ApiSearchRouteImport.update({
@@ -128,7 +128,7 @@ export interface FileRoutesByFullPath {
   '/robots.txt': typeof RobotsDottxtRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
   '/api/search': typeof ApiSearchRoute
-  '/blog/$slug': typeof BlogSlugRoute
+  '/blog/$': typeof BlogSplatRoute
   '/docs/$': typeof DocsSplatRoute
   '/for/$slug': typeof ForSlugRoute
   '/integrations/$slug': typeof IntegrationsSlugRoute
@@ -148,7 +148,7 @@ export interface FileRoutesByTo {
   '/robots.txt': typeof RobotsDottxtRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
   '/api/search': typeof ApiSearchRoute
-  '/blog/$slug': typeof BlogSlugRoute
+  '/blog/$': typeof BlogSplatRoute
   '/docs/$': typeof DocsSplatRoute
   '/for/$slug': typeof ForSlugRoute
   '/integrations/$slug': typeof IntegrationsSlugRoute
@@ -169,7 +169,7 @@ export interface FileRoutesById {
   '/robots.txt': typeof RobotsDottxtRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
   '/api/search': typeof ApiSearchRoute
-  '/blog/$slug': typeof BlogSlugRoute
+  '/blog/$': typeof BlogSplatRoute
   '/docs/$': typeof DocsSplatRoute
   '/for/$slug': typeof ForSlugRoute
   '/integrations/$slug': typeof IntegrationsSlugRoute
@@ -191,7 +191,7 @@ export interface FileRouteTypes {
     | '/robots.txt'
     | '/sitemap.xml'
     | '/api/search'
-    | '/blog/$slug'
+    | '/blog/$'
     | '/docs/$'
     | '/for/$slug'
     | '/integrations/$slug'
@@ -211,7 +211,7 @@ export interface FileRouteTypes {
     | '/robots.txt'
     | '/sitemap.xml'
     | '/api/search'
-    | '/blog/$slug'
+    | '/blog/$'
     | '/docs/$'
     | '/for/$slug'
     | '/integrations/$slug'
@@ -231,7 +231,7 @@ export interface FileRouteTypes {
     | '/robots.txt'
     | '/sitemap.xml'
     | '/api/search'
-    | '/blog/$slug'
+    | '/blog/$'
     | '/docs/$'
     | '/for/$slug'
     | '/integrations/$slug'
@@ -252,7 +252,7 @@ export interface RootRouteChildren {
   RobotsDottxtRoute: typeof RobotsDottxtRoute
   SitemapDotxmlRoute: typeof SitemapDotxmlRoute
   ApiSearchRoute: typeof ApiSearchRoute
-  BlogSlugRoute: typeof BlogSlugRoute
+  BlogSplatRoute: typeof BlogSplatRoute
   DocsSplatRoute: typeof DocsSplatRoute
   ForSlugRoute: typeof ForSlugRoute
   IntegrationsSlugRoute: typeof IntegrationsSlugRoute
@@ -371,11 +371,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DocsSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/blog/$slug': {
-      id: '/blog/$slug'
-      path: '/blog/$slug'
-      fullPath: '/blog/$slug'
-      preLoaderRoute: typeof BlogSlugRouteImport
+    '/blog/$': {
+      id: '/blog/$'
+      path: '/blog/$'
+      fullPath: '/blog/$'
+      preLoaderRoute: typeof BlogSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/search': {
@@ -404,7 +404,7 @@ const rootRouteChildren: RootRouteChildren = {
   RobotsDottxtRoute: RobotsDottxtRoute,
   SitemapDotxmlRoute: SitemapDotxmlRoute,
   ApiSearchRoute: ApiSearchRoute,
-  BlogSlugRoute: BlogSlugRoute,
+  BlogSplatRoute: BlogSplatRoute,
   DocsSplatRoute: DocsSplatRoute,
   ForSlugRoute: ForSlugRoute,
   IntegrationsSlugRoute: IntegrationsSlugRoute,

--- a/apps/web/src/routes/blog/$.tsx
+++ b/apps/web/src/routes/blog/$.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link, notFound } from '@tanstack/react-router';
+import { createFileRoute, Link, notFound, redirect } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { Suspense, useCallback, useEffect, useState } from 'react';
 import { useAnalytics } from '@/hooks/use-analytics';
@@ -12,10 +12,18 @@ import { useMDXComponents } from '@/components/mdx';
 import { seo } from '@/lib/seo';
 import { appConfig } from '@/lib/shared';
 
-export const Route = createFileRoute('/blog/$slug')({
+export const Route = createFileRoute('/blog/$')({
   component: BlogArticlePage,
   loader: async ({ params }) => {
-    const data = await serverLoader({ data: params.slug });
+    const slugs = params._splat?.split('/') ?? [];
+    const data = await serverLoader({ data: slugs });
+    if (data.redirectTo) {
+      throw redirect({
+        to: '/blog/$',
+        params: { _splat: data.redirectTo },
+        statusCode: 301,
+      });
+    }
     if (typeof window !== 'undefined') await clientLoader.preload(data.path);
     return data;
   },
@@ -49,10 +57,20 @@ export const Route = createFileRoute('/blog/$slug')({
 const serverLoader = createServerFn({
   method: 'GET',
 })
-  .inputValidator((slug: string) => slug)
-  .handler(async ({ data: slug }) => {
+  .inputValidator((slugs: string[]) => slugs)
+  .handler(async ({ data: slugs }) => {
     const pages = blogSource.getPages();
-    const page = pages.find((p) => p.slugs[p.slugs.length - 1] === slug);
+
+    let page = pages.find(
+      (p) => p.slugs.length === slugs.length && p.slugs.every((s, i) => s === slugs[i]),
+    );
+
+    let redirectTo: string | null = null;
+    if (!page && slugs.length === 1) {
+      page = pages.find((p) => p.slugs.at(-1) === slugs[0]);
+      if (page) redirectTo = page.slugs.join('/');
+    }
+
     if (!page) throw notFound();
 
     const post = mapPageToPost(page);
@@ -61,6 +79,7 @@ const serverLoader = createServerFn({
     return {
       path: page.path,
       slug: post.slug,
+      redirectTo,
       pageTitle: post.title,
       pageDescription: post.description || null,
       pageDate: post.date,
@@ -87,7 +106,7 @@ const clientLoader = browserCollections.blogPosts.createClientLoader({
 function ArticleFooter({ title, slug }: { title: string; slug: string }) {
   const [copied, setCopied] = useState(false);
   const analytics = useAnalytics('blog');
-  const articleUrl = `${appConfig.baseUrl}/blog/${slug}/`;
+  const articleUrl = `${appConfig.baseUrl}/blog/${slug}`;
 
   const shareOnX = useCallback(() => {
     analytics.track('share').action('click', { slug, platform: 'x' });

--- a/apps/web/src/routes/blog/$.tsx
+++ b/apps/web/src/routes/blog/$.tsx
@@ -67,8 +67,11 @@ const serverLoader = createServerFn({
 
     let redirectTo: string | null = null;
     if (!page && slugs.length === 1) {
-      page = pages.find((p) => p.slugs.at(-1) === slugs[0]);
-      if (page) redirectTo = page.slugs.join('/');
+      const tailMatches = pages.filter((p) => p.slugs.at(-1) === slugs[0]);
+      if (tailMatches.length === 1) {
+        page = tailMatches[0];
+        redirectTo = tailMatches[0]?.slugs.join('/') ?? null;
+      }
     }
 
     if (!page) throw notFound();

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -135,8 +135,8 @@ function BlogIndexPage() {
                     return (
                       <Link
                         key={post.slug}
-                        to="/blog/$slug"
-                        params={{ slug: post.slug }}
+                        to="/blog/$"
+                        params={{ _splat: post.slug }}
                         onClick={() =>
                           analytics.track('article').action('click', {
                             slug: post.slug,


### PR DESCRIPTION
# Overview

Fixes 3 blog URLs returning 404 errors reported by Google Search Console since May 16th.

# What's changed and why?

Blog posts live in nested directories (`announcements/`, `guides/`) but the route only matched single-segment URLs. Switched to a catch-all route pattern.

- **`apps/web/src/routes/blog/$slug.tsx` → `$.tsx`** — Replaced single-segment route with catch-all, added 301 redirect for flat URLs
- **`apps/web/src/lib/blog-source.ts`** — Slug now uses full path (`announcements/introducing-betternotify`)
- **`apps/web/src/routes/blog/index.tsx`** — Updated link params to catch-all format
- **`apps/web/src/components/landing/author.tsx`** — Updated link params to catch-all format
- **`apps/web/src/routeTree.gen.ts`** — Auto-regenerated

# How to test

1. Visit `/blog/announcements/introducing-betternotify` — should render the article
2. Visit `/blog/introducing-betternotify` — should 301 redirect to the nested URL
3. Visit `/blog` — all article links should point to nested paths

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic redirects added so old blog links continue to work with canonical nested URLs.

* **Refactor**
  * Blog now supports multi-segment (nested) post URLs for deeper paths.
  * Post cards and navigation updated to use the new nested-path routing.
  * Article share and copy-link no longer include a trailing slash.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-notify/better-notify/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->