### PR TITLE
fix(ci): increase Node heap size to prevent tsc OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ permissions:
   contents: read
 
 env:
+  NODE_OPTIONS: '--max-old-space-size=6144'
   DO_NOT_TRACK: '1'
   TURBO_TELEMETRY_DISABLED: '1'
   TURBO_TELEMETRY_MESSAGE_DISABLED: '1'


### PR DESCRIPTION
# Overview

Fix OOM crash during `tsc --noEmit` in CI by increasing Node.js heap limit.

# What's changed and why?

- **`.github/workflows/ci.yml`** — Added `NODE_OPTIONS: '--max-old-space-size=6144'` to the workflow env, giving `tsc` up to 6GB of heap instead of the default ~4GB.

The `pnpm typecheck` step was crashing with `Allocation failed - JavaScript heap out of memory` on Renovate PRs. The CI workflow had no `NODE_OPTIONS` set, so tsc hit the default V8 heap limit.

# How to test

1. Verify CI passes on this PR (specifically the `pnpm typecheck` step)
2. Re-run any previously failing Renovate PR to confirm it passes

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI build process configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-notify/better-notify/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->