### PR TITLE
fix(deps): use caret ranges for workspace deps to prevent duplicate core installs

### DIFF
--- a/apps/web/source.config.ts
+++ b/apps/web/source.config.ts
@@ -3,12 +3,14 @@ import { pageSchema } from 'fumadocs-core/source/schema';
 import { remarkNpm } from 'fumadocs-core/mdx-plugins';
 import { z } from 'zod';
 
+const docsSchema = pageSchema.extend({
+  channels: z.array(z.string()).optional(),
+});
+
 export const docs = defineDocs({
   dir: 'content/docs',
   docs: {
-    schema: pageSchema.extend({
-      channels: z.array(z.string()).optional(),
-    }),
+    schema: docsSchema,
     postprocess: {
       includeProcessedMarkdown: true,
     },

--- a/packages/autosend/package.json
+++ b/packages/autosend/package.json
@@ -27,8 +27,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
-    "@betternotify/email": "workspace:*"
+    "@betternotify/core": "workspace:^",
+    "@betternotify/email": "workspace:^"
   },
   "devDependencies": {
     "@internal/rolldown-config": "workspace:*",

--- a/packages/bullmq/package.json
+++ b/packages/bullmq/package.json
@@ -28,7 +28,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*"
+    "@betternotify/core": "workspace:^"
   },
   "devDependencies": {
     "@internal/rolldown-config": "workspace:*",

--- a/packages/cloudflare-email/package.json
+++ b/packages/cloudflare-email/package.json
@@ -28,8 +28,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
-    "@betternotify/email": "workspace:*"
+    "@betternotify/core": "workspace:^",
+    "@betternotify/email": "workspace:^"
   },
   "devDependencies": {
     "@internal/rolldown-config": "workspace:*",

--- a/packages/discord/package.json
+++ b/packages/discord/package.json
@@ -27,7 +27,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
+    "@betternotify/core": "workspace:^",
     "@standard-schema/spec": "catalog:",
     "zod": "catalog:"
   },

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -31,7 +31,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
+    "@betternotify/core": "workspace:^",
     "@standard-schema/spec": "catalog:"
   },
   "devDependencies": {

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -27,7 +27,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
+    "@betternotify/core": "workspace:^",
     "@standard-schema/spec": "catalog:",
     "zod": "catalog:"
   },

--- a/packages/handlebars/package.json
+++ b/packages/handlebars/package.json
@@ -27,8 +27,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
-    "@betternotify/email": "workspace:*"
+    "@betternotify/core": "workspace:^",
+    "@betternotify/email": "workspace:^"
   },
   "devDependencies": {
     "@internal/rolldown-config": "workspace:*",

--- a/packages/mailchimp/package.json
+++ b/packages/mailchimp/package.json
@@ -27,8 +27,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
-    "@betternotify/email": "workspace:*"
+    "@betternotify/core": "workspace:^",
+    "@betternotify/email": "workspace:^"
   },
   "devDependencies": {
     "@internal/rolldown-config": "workspace:*",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -27,7 +27,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
+    "@betternotify/core": "workspace:^",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/mjml/package.json
+++ b/packages/mjml/package.json
@@ -27,8 +27,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
-    "@betternotify/email": "workspace:*"
+    "@betternotify/core": "workspace:^",
+    "@betternotify/email": "workspace:^"
   },
   "devDependencies": {
     "@internal/rolldown-config": "workspace:*",

--- a/packages/onesignal/package.json
+++ b/packages/onesignal/package.json
@@ -27,10 +27,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
-    "@betternotify/email": "workspace:*",
-    "@betternotify/push": "workspace:*",
-    "@betternotify/sms": "workspace:*"
+    "@betternotify/core": "workspace:^",
+    "@betternotify/email": "workspace:^",
+    "@betternotify/push": "workspace:^",
+    "@betternotify/sms": "workspace:^"
   },
   "devDependencies": {
     "@internal/rolldown-config": "workspace:*",

--- a/packages/push/package.json
+++ b/packages/push/package.json
@@ -27,7 +27,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
+    "@betternotify/core": "workspace:^",
     "@standard-schema/spec": "catalog:"
   },
   "devDependencies": {

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -27,8 +27,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
-    "@betternotify/email": "workspace:*"
+    "@betternotify/core": "workspace:^",
+    "@betternotify/email": "workspace:^"
   },
   "devDependencies": {
     "@internal/rolldown-config": "workspace:*",

--- a/packages/resend/package.json
+++ b/packages/resend/package.json
@@ -27,8 +27,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
-    "@betternotify/email": "workspace:*"
+    "@betternotify/core": "workspace:^",
+    "@betternotify/email": "workspace:^"
   },
   "devDependencies": {
     "@internal/rolldown-config": "workspace:*",

--- a/packages/selligent/package.json
+++ b/packages/selligent/package.json
@@ -27,8 +27,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
-    "@betternotify/email": "workspace:*"
+    "@betternotify/core": "workspace:^",
+    "@betternotify/email": "workspace:^"
   },
   "devDependencies": {
     "@internal/rolldown-config": "workspace:*",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -27,7 +27,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
+    "@betternotify/core": "workspace:^",
     "@standard-schema/spec": "catalog:",
     "zod": "catalog:"
   },

--- a/packages/sms/package.json
+++ b/packages/sms/package.json
@@ -27,7 +27,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
+    "@betternotify/core": "workspace:^",
     "@standard-schema/spec": "catalog:"
   },
   "devDependencies": {

--- a/packages/smtp/package.json
+++ b/packages/smtp/package.json
@@ -28,8 +28,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
-    "@betternotify/email": "workspace:*",
+    "@betternotify/core": "workspace:^",
+    "@betternotify/email": "workspace:^",
     "nodemailer": "catalog:"
   },
   "devDependencies": {

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -27,7 +27,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
+    "@betternotify/core": "workspace:^",
     "@standard-schema/spec": "catalog:",
     "zod": "catalog:"
   },

--- a/packages/twilio/package.json
+++ b/packages/twilio/package.json
@@ -27,8 +27,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
-    "@betternotify/sms": "workspace:*"
+    "@betternotify/core": "workspace:^",
+    "@betternotify/sms": "workspace:^"
   },
   "devDependencies": {
     "@internal/rolldown-config": "workspace:*",

--- a/packages/webpush/package.json
+++ b/packages/webpush/package.json
@@ -31,7 +31,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
+    "@betternotify/core": "workspace:^",
     "@standard-schema/spec": "catalog:"
   },
   "devDependencies": {

--- a/packages/whatsapp/package.json
+++ b/packages/whatsapp/package.json
@@ -31,7 +31,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
+    "@betternotify/core": "workspace:^",
     "@standard-schema/spec": "catalog:",
     "zod": "catalog:"
   },

--- a/packages/zapier/package.json
+++ b/packages/zapier/package.json
@@ -27,8 +27,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@betternotify/core": "workspace:*",
-    "@betternotify/email": "workspace:*",
+    "@betternotify/core": "workspace:^",
+    "@betternotify/email": "workspace:^",
     "@standard-schema/spec": "catalog:",
     "zod": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,10 +505,10 @@ importers:
   packages/autosend:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@betternotify/email':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../email
     devDependencies:
       '@internal/rolldown-config':
@@ -530,7 +530,7 @@ importers:
   packages/bullmq:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       '@internal/rolldown-config':
@@ -552,10 +552,10 @@ importers:
   packages/cloudflare-email:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@betternotify/email':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../email
     devDependencies:
       '@internal/rolldown-config':
@@ -633,7 +633,7 @@ importers:
   packages/discord:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@standard-schema/spec':
         specifier: 'catalog:'
@@ -661,7 +661,7 @@ importers:
   packages/email:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@standard-schema/spec':
         specifier: 'catalog:'
@@ -689,7 +689,7 @@ importers:
   packages/github:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@standard-schema/spec':
         specifier: 'catalog:'
@@ -717,10 +717,10 @@ importers:
   packages/handlebars:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@betternotify/email':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../email
     devDependencies:
       '@internal/rolldown-config':
@@ -745,10 +745,10 @@ importers:
   packages/mailchimp:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@betternotify/email':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../email
     devDependencies:
       '@internal/rolldown-config':
@@ -770,7 +770,7 @@ importers:
   packages/mcp:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       zod:
         specifier: 'catalog:'
@@ -798,10 +798,10 @@ importers:
   packages/mjml:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@betternotify/email':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../email
     devDependencies:
       '@internal/rolldown-config':
@@ -832,16 +832,16 @@ importers:
   packages/onesignal:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@betternotify/email':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../email
       '@betternotify/push':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../push
       '@betternotify/sms':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../sms
     devDependencies:
       '@internal/rolldown-config':
@@ -863,7 +863,7 @@ importers:
   packages/push:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@standard-schema/spec':
         specifier: 'catalog:'
@@ -891,10 +891,10 @@ importers:
   packages/react-email:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@betternotify/email':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../email
     devDependencies:
       '@internal/rolldown-config':
@@ -934,10 +934,10 @@ importers:
   packages/resend:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@betternotify/email':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../email
     devDependencies:
       '@internal/rolldown-config':
@@ -959,10 +959,10 @@ importers:
   packages/selligent:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@betternotify/email':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../email
     devDependencies:
       '@internal/rolldown-config':
@@ -984,7 +984,7 @@ importers:
   packages/slack:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@standard-schema/spec':
         specifier: 'catalog:'
@@ -1012,7 +1012,7 @@ importers:
   packages/sms:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@standard-schema/spec':
         specifier: 'catalog:'
@@ -1040,10 +1040,10 @@ importers:
   packages/smtp:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@betternotify/email':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../email
       nodemailer:
         specifier: 'catalog:'
@@ -1071,7 +1071,7 @@ importers:
   packages/telegram:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@standard-schema/spec':
         specifier: 'catalog:'
@@ -1099,10 +1099,10 @@ importers:
   packages/twilio:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@betternotify/sms':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../sms
     devDependencies:
       '@internal/rolldown-config':
@@ -1124,7 +1124,7 @@ importers:
   packages/webpush:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@standard-schema/spec':
         specifier: 'catalog:'
@@ -1152,7 +1152,7 @@ importers:
   packages/whatsapp:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@standard-schema/spec':
         specifier: 'catalog:'
@@ -1180,10 +1180,10 @@ importers:
   packages/zapier:
     dependencies:
       '@betternotify/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@betternotify/email':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../email
       '@standard-schema/spec':
         specifier: 'catalog:'

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,12 @@
   "prerelease": true,
   "include-component-in-tag": true,
   "separate-pull-requests": false,
+  "plugins": [
+    {
+      "type": "node-workspace",
+      "updateAllPackages": true
+    }
+  ],
   "packages": {
     "packages/core": {
       "release-type": "node",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,8 @@
   "plugins": [
     {
       "type": "node-workspace",
-      "updateAllPackages": true
+      "updateAllPackages": true,
+      "always-link-local": true
     }
   ],
   "packages": {


### PR DESCRIPTION
# Overview

Fixes #168 — `NotifyRpcError: No channel registered for "email"` when following the README quick-start.

# What's changed and why?

When `@betternotify/email` was published, `workspace:*` resolved to an exact pinned version (e.g. `"@betternotify/core": "1.0.0-beta.4"`). Users installing both `@betternotify/core` and `@betternotify/email` got two separate copies of core — the old nested one missing `channelRef`, causing the error.

- **`packages/*/package.json`** (23 files) — changed `"workspace:*"` to `"workspace:^"` for all `@betternotify/*` dependencies so they publish as caret ranges
- **`release-please-config.json`** — added `node-workspace` plugin with `updateAllPackages: true` so dependents get bumped automatically when core is released
- **`pnpm-lock.yaml`** — lockfile updated

# How to test

1. Run `pnpm ci` — all builds, typechecks, and tests should pass
2. Verify no `"workspace:*"` remains in any `packages/*/package.json`
3. Confirm `release-please-config.json` has the `node-workspace` plugin

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined internal package dependency specifiers across multiple modules to tighten workspace version resolution.
  * Updated release automation configuration to improve monorepo package management workflow.
* **Documentation**
  * Cleaned up docs configuration by extracting and reusing a shared schema for the docs collection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/better-notify/better-notify/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->