### PR TITLE
chore: add react-email npm support metadata

### DIFF
--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -8,6 +8,10 @@
     "url": "https://github.com/better-notify/better-notify",
     "directory": "packages/react-email"
   },
+  "homepage": "https://github.com/better-notify/better-notify/tree/main/packages/react-email#readme",
+  "bugs": {
+    "url": "https://github.com/better-notify/better-notify/issues"
+  },
   "files": [
     "dist",
     "README.md",


### PR DESCRIPTION
## Overview\n\nAdds npm support metadata for the published \@betternotify/react-email\ package.\n\n## What's changed and why\n\n- Adds \homepage\ pointing to the package README in this repository.\n- Adds \ugs.url\ pointing to the Better Notify issue tracker.\n\nThis helps npm users and package tooling navigate from the package page to documentation and issue reporting without changing runtime code, exports, dependencies, or build behavior.\n\n## How to test\n\n- Parsed \packages/react-email/package.json\ with Node \JSON.parse\.\n- Ran \git diff --check\.