### PR TITLE
fix(core): make channel input slot optional when not defined

### DIFF
--- a/examples/welcome-text/apps/cli/src/examples/custom-channel-no-input.ts
+++ b/examples/welcome-text/apps/cli/src/examples/custom-channel-no-input.ts
@@ -1,0 +1,68 @@
+import { createNotify, createClient, defineChannel, slot } from '@betternotify/core';
+import { createMockTransport } from '@betternotify/core/transports';
+import { z } from 'zod';
+
+type RenderedInbox = {
+  userId: string;
+  type: string;
+  title: string;
+};
+
+type InboxTransportData = { id: string };
+
+const inboxChannel = defineChannel({
+  name: 'inbox' as const,
+  slots: {
+    type: slot.value<string>(),
+    title: slot.resolver<string>(),
+  },
+  validateArgs: z.object({ userId: z.string() }),
+  render: ({ runtime, args }): RenderedInbox => ({
+    userId: args.userId,
+    type: runtime.type,
+    title: runtime.title,
+  }),
+});
+
+export const runCustomChannelNoInput = async (): Promise<void> => {
+  const rpc = createNotify({ channels: { inbox: inboxChannel } });
+
+  const catalog = rpc.catalog({
+    order: rpc.catalog({
+      created: rpc.inbox().type('order.created').title('Your order is confirmed'),
+      shipped: rpc
+        .inbox()
+        .input(z.object({ trackingUrl: z.url() }))
+        .type('order.shipped')
+        .title(({ input }) => `Your order shipped — track it at ${input.trackingUrl}`),
+    }),
+  });
+
+  const mock = createMockTransport<RenderedInbox, InboxTransportData>({
+    name: 'mock-inbox',
+    reply: () => ({ id: `inbox_${Date.now()}` }),
+  });
+
+  const notify = createClient({
+    catalog,
+    transportsByChannel: { inbox: mock },
+  });
+
+  const created = await notify.order.created.send({ userId: 'user_42' });
+  console.log('created →', created.messageId, 'data:', created.data);
+
+  const shipped = await notify.order.shipped.send({
+    userId: 'user_42',
+    input: { trackingUrl: 'https://track.example.com/abc123' },
+  });
+  console.log('shipped →', shipped.messageId, 'data:', shipped.data);
+
+  console.log('---');
+  console.log(`captured ${mock.sent.length} sends:`);
+  for (const { rendered } of mock.sent) {
+    console.log(`  ${rendered.userId} ← [${rendered.type}] ${rendered.title}`);
+  }
+
+  console.log('---');
+  console.log('order.created declares no .input() — sent with only its channel args, no input slot.');
+};

--- a/examples/welcome-text/apps/cli/src/index.ts
+++ b/examples/welcome-text/apps/cli/src/index.ts
@@ -20,6 +20,7 @@ import { runPlugins } from './examples/plugins';
 import { runHttpTransport } from './examples/http-transport';
 import { runMultiChannel } from './examples/multi-channel';
 import { runCustomChannel } from './examples/custom-channel';
+import { runCustomChannelNoInput } from './examples/custom-channel-no-input';
 import { runPerTransportFrom } from './examples/per-transport-from';
 import { runTelegram } from './examples/telegram';
 import { runTelegramCrossTransport } from './examples/telegram-cross-transport';
@@ -86,6 +87,7 @@ const examples: Record<string, () => Promise<void>> = {
   'http-transport': runHttpTransport,
   'multi-channel': runMultiChannel,
   'custom-channel': runCustomChannel,
+  'custom-channel-no-input': runCustomChannelNoInput,
   'per-transport-from': runPerTransportFrom,
   telegram: runTelegram,
   'telegram-cross-transport': runTelegramCrossTransport,

--- a/packages/core/src/channel/define-channel.test-d.ts
+++ b/packages/core/src/channel/define-channel.test-d.ts
@@ -1,0 +1,29 @@
+import { expectTypeOf, describe, it } from 'vitest';
+import { z } from 'zod';
+import { defineChannel, slot } from './define-channel.js';
+
+const buildChannel = () =>
+  defineChannel({
+    name: 'test' as const,
+    slots: { body: slot.resolver<string>() },
+    validateArgs: (args: unknown): { to: string; input: unknown } =>
+      args as { to: string; input: unknown },
+    render: ({ runtime, args }) => ({ body: runtime.body, to: args.to }),
+  });
+
+describe('ChannelBuilder._args with optional input', () => {
+  it('omits the input key when .input() is never called', () => {
+    const builder = buildChannel().createBuilder({ ctx: undefined, rootMiddleware: [] }).body('hi');
+    expectTypeOf<typeof builder._args>().toEqualTypeOf<{ to: string }>();
+  });
+
+  it('requires the typed input key once .input() is called', () => {
+    const builder = buildChannel()
+      .createBuilder({ ctx: undefined, rootMiddleware: [] })
+      .input(z.object({ name: z.string() }))
+      .body('hi');
+    expectTypeOf<typeof builder._args>().toEqualTypeOf<
+      { to: string } & { input: { name: string } }
+    >();
+  });
+});

--- a/packages/core/src/channel/define-channel.test.ts
+++ b/packages/core/src/channel/define-channel.test.ts
@@ -41,10 +41,16 @@ describe('defineChannel', () => {
     expect(() => b.body('again' as never)).toThrow(/already set/);
   });
 
-  it('_finalize throws when input slot is missing', () => {
+  it('_finalize succeeds when input is omitted, defaulting to a passthrough schema', () => {
     const ch = buildSimpleChannel();
-    const b = ch.createBuilder({ ctx: undefined, rootMiddleware: [] });
-    expect(() => b._finalize('r1')).toThrow(/missing required slot: input/);
+    const def = ch
+      .createBuilder({ ctx: undefined, rootMiddleware: [] })
+      .body('hi')
+      .tag('m')
+      ._finalize('r1');
+    expect(def.schema).toBeDefined();
+    expect(def.schema['~standard'].validate({ anything: 1 })).toEqual({ value: { anything: 1 } });
+    expect(def.schema['~standard'].validate(undefined)).toEqual({ value: undefined });
   });
 
   it('_finalize throws when a declared slot is missing', () => {

--- a/packages/core/src/channel/define-channel.ts
+++ b/packages/core/src/channel/define-channel.ts
@@ -4,6 +4,12 @@ import type { AnyMiddleware, Middleware } from '../middlewares/types.js';
 import type { Transport } from '../transport.js';
 import type { AnyChannel, Channel, ChannelBuilderCtx, ChannelDefinition } from './types.js';
 
+export type UnsetInput = { readonly __betternotifyUnsetInput: 'unset' };
+
+type ArgsOf<TArgsBase, TInput> = [TInput] extends [UnsetInput]
+  ? TArgsBase
+  : TArgsBase & { input: TInput };
+
 export type ResolverSlot<TValue> = TValue | ((args: { input: any; ctx: unknown }) => TValue);
 
 export type SlotKind = 'resolver' | 'value';
@@ -30,7 +36,7 @@ export type ChannelBuilder<
 > = {
   readonly _channel: TChannel;
   readonly _state: BuilderState;
-  readonly _args: TArgsBase & { input: TInput };
+  readonly _args: ArgsOf<TArgsBase, TInput>;
   readonly _rendered: TRendered;
   input<TSchema extends AnyStandardSchema>(
     schema: TSchema,
@@ -38,7 +44,7 @@ export type ChannelBuilder<
   use<TCtxOut = unknown>(
     middleware: Middleware<TInput, unknown, TCtxOut>,
   ): ChannelBuilder<TInput, TSlotValues, TSlotConfig, TArgsBase, TRendered, TChannel>;
-  _finalize(id: string): ChannelDefinition<TArgsBase & { input: TInput }, TRendered>;
+  _finalize(id: string): ChannelDefinition<ArgsOf<TArgsBase, TInput>, TRendered>;
 } & {
   [K in keyof TSlotValues & keyof TSlotConfig & string]: (
     value: SlotValueType<TSlotConfig[K], TSlotValues[K], TInput>,
@@ -86,6 +92,14 @@ export type DefineChannelOptions<
 
 const isStandardSchema = (v: unknown): v is AnyStandardSchema =>
   !!v && typeof v === 'object' && '~standard' in v;
+
+const passthroughSchema: AnyStandardSchema = {
+  '~standard': {
+    version: 1,
+    vendor: 'betternotify',
+    validate: (value) => ({ value }),
+  },
+};
 
 const resolveRuntime = (
   rawRuntime: Record<string, unknown>,
@@ -144,10 +158,7 @@ const buildBuilder = <
     use(mw: AnyMiddleware) {
       return next({ middleware: [...state.middleware, mw] });
     },
-    _finalize(id: string): ChannelDefinition<TArgsBase & { input: TInput }, TRendered> {
-      if (!state.schema) {
-        throw new Error(`Channel "${channelName}" route "${id}" missing required slot: input.`);
-      }
+    _finalize(id: string): ChannelDefinition<ArgsOf<TArgsBase, TInput>, TRendered> {
       for (const key of Object.keys(slots)) {
         if (slots[key]?.required && state.runtime[key] === undefined) {
           throw new Error(`Channel "${channelName}" route "${id}" missing required slot: ${key}.`);
@@ -156,7 +167,7 @@ const buildBuilder = <
       return {
         id,
         channel: channelName,
-        schema: state.schema,
+        schema: state.schema ?? passthroughSchema,
         middleware: state.middleware,
         runtime: state.runtime,
         channelRef: getChannelRef(),
@@ -195,7 +206,7 @@ export const defineChannel = <
 ): Channel<
   TName,
   ChannelBuilder<
-    unknown,
+    UnsetInput,
     SlotValuesOf<TSlotConfig>,
     TSlotConfig,
     ArgsBase<ArgsFromValidator<TValidator>>,
@@ -209,7 +220,7 @@ export const defineChannel = <
   const channel: Channel<
     TName,
     ChannelBuilder<
-      unknown,
+      UnsetInput,
       SlotValuesOf<TSlotConfig>,
       TSlotConfig,
       ArgsBase<ArgsFromValidator<TValidator>>,
@@ -223,7 +234,7 @@ export const defineChannel = <
     name: opts.name,
     createBuilder: (ctx: ChannelBuilderCtx) =>
       buildBuilder<
-        unknown,
+        UnsetInput,
         SlotValuesOf<TSlotConfig>,
         TSlotConfig,
         ArgsBase<ArgsFromValidator<TValidator>>,
@@ -242,7 +253,7 @@ export const defineChannel = <
     finalize: (state, id) =>
       (
         state as ChannelBuilder<
-          unknown,
+          UnsetInput,
           SlotValuesOf<TSlotConfig>,
           TSlotConfig,
           ArgsBase<ArgsFromValidator<TValidator>>,

--- a/packages/core/src/client.no-input.test.ts
+++ b/packages/core/src/client.no-input.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { createClient } from './client.js';
+import { createNotify } from './notify.js';
+import { defineChannel, slot } from './channel/define-channel.js';
+
+type InboxRendered = { type: string; input: unknown };
+
+const inboxChannel = () =>
+  defineChannel({
+    name: 'inbox' as const,
+    slots: { type: slot.value<string>() },
+    validateArgs: z.object({}),
+    render: ({ runtime, args }): InboxRendered => ({ type: runtime.type, input: args.input }),
+  });
+
+const buildClient = () => {
+  const rpc = createNotify({ channels: { inbox: inboxChannel() } });
+  const catalog = rpc.catalog({
+    created: rpc.inbox().type('order.created'),
+  });
+  const sent: Array<{ rendered: InboxRendered }> = [];
+  const transport = {
+    name: 'mem',
+    send: async (rendered: InboxRendered, ctx: { messageId: string }) => {
+      sent.push({ rendered });
+      return { ok: true as const, data: { id: ctx.messageId } };
+    },
+  };
+  const mail = createClient({ catalog, transportsByChannel: { inbox: transport } });
+  return { mail, sent };
+};
+
+describe('createClient with a route that omits .input()', () => {
+  it('sends with no arguments at all', async () => {
+    const { mail, sent } = buildClient();
+    await mail.created.send();
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.rendered).toEqual({ type: 'order.created', input: undefined });
+  });
+
+  it('sends with an empty args object', async () => {
+    const { mail, sent } = buildClient();
+    await mail.created.send({});
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.rendered).toEqual({ type: 'order.created', input: undefined });
+  });
+});

--- a/packages/core/src/client.test-d.ts
+++ b/packages/core/src/client.test-d.ts
@@ -1,0 +1,44 @@
+import { describe, it } from 'vitest';
+import { z } from 'zod';
+import { createNotify } from './notify.js';
+import { createClient } from './client.js';
+import { defineChannel, slot } from './channel/define-channel.js';
+
+const inboxChannel = defineChannel({
+  name: 'inbox' as const,
+  slots: { type: slot.value<string>() },
+  validateArgs: (args: unknown): { input: unknown } => args as { input: unknown },
+  render: ({ args }) => ({ body: 'inbox', input: args.input }),
+});
+
+const rpc = createNotify({ channels: { inbox: inboxChannel } });
+const catalog = rpc.catalog({
+  noInput: rpc.inbox().type('order.created'),
+  withInput: rpc
+    .inbox()
+    .input(z.object({ orderId: z.string() }))
+    .type('order.shipped'),
+});
+
+const mail = createClient({ catalog, transportsByChannel: {} });
+
+describe('createClient send args with optional input', () => {
+  it('a route without .input() is sendable with no arguments', () => {
+    void mail.noInput.send();
+    void mail.noInput.send({});
+    void mail.noInput.send({ transport: {} });
+  });
+
+  it('a route without .input() rejects an input payload', () => {
+    // @ts-expect-error — this route declared no input slot
+    void mail.noInput.send({ input: { orderId: 'x' } });
+  });
+
+  it('a route with .input() still requires the typed input', () => {
+    void mail.withInput.send({ input: { orderId: 'x' } });
+    // @ts-expect-error — input is required for this route
+    void mail.withInput.send();
+    // @ts-expect-error — input must match the declared schema
+    void mail.withInput.send({ input: { orderId: 123 } });
+  });
+});

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -48,8 +48,10 @@ type TransportOverridesArg<TChannel extends string = string> = {
   transport?: TransportOverrides<TChannel>;
 };
 
+type SendArgTuple<T> = {} extends T ? [args?: T] : [args: T];
+
 type ChannelRouteMethods<TArgs, TChannel extends string = string> = {
-  send(args: TArgs & TransportOverridesArg<TChannel>): Promise<ChannelSendResult>;
+  send(...args: SendArgTuple<TArgs & TransportOverridesArg<TChannel>>): Promise<ChannelSendResult>;
   batch(
     entries: ReadonlyArray<TArgs & TransportOverridesArg<TChannel>>,
     opts?: BatchOptions,
@@ -131,7 +133,7 @@ export const createClient = <R extends AnyCatalog>(
 
   const buildProcMethods = (channelDef: ChannelDefinition<unknown, unknown>, flatKey: string) =>
     Object.freeze({
-      send: (rawArgs: unknown) => executeChannelSend(channelDef, rawArgs, flatKey),
+      send: (rawArgs?: unknown) => executeChannelSend(channelDef, rawArgs ?? {}, flatKey),
       batch: async (entries: ReadonlyArray<unknown>, batchOpts?: BatchOptions) => {
         if (entries.length === 0) {
           throw new NotifyRpcError({

--- a/packages/github/src/channel.test.ts
+++ b/packages/github/src/channel.test.ts
@@ -118,9 +118,10 @@ describe('githubChannel', () => {
       expect(() => ch.finalize(builder, 'r')).toThrow(/missing required slot: body/);
     });
 
-    it('finalize throws when input is missing', () => {
+    it('finalize succeeds when input is omitted (input slot is optional)', () => {
       const builder = issuePicker().issue().title('T').body('B');
-      expect(() => ch.finalize(builder, 'r')).toThrow(/missing required slot: input/);
+      const def = ch.finalize(builder, 'r');
+      expect(def.schema).toBeDefined();
     });
   });
 

--- a/packages/whatsapp/src/channel.test.ts
+++ b/packages/whatsapp/src/channel.test.ts
@@ -98,9 +98,10 @@ describe('whatsappChannel', () => {
       expect(() => ch.finalize(builder, 'r')).toThrow(/missing required slot: body/);
     });
 
-    it('finalize throws when input is missing', () => {
+    it('finalize succeeds when input is omitted (input slot is optional)', () => {
       const builder = picker().text().body('B');
-      expect(() => ch.finalize(builder, 'r')).toThrow(/missing required slot: input/);
+      const def = ch.finalize(builder, 'r');
+      expect(def.schema).toBeDefined();
     });
   });
 


### PR DESCRIPTION
# Overview

A custom channel route no longer needs an `input` slot. Before, any route defined without `.input()` crashed on startup and forced you to pass an empty `input` on every send (issue #183). Now `input` is optional per route.

# What's changed and why?

Important files changed:

- **packages/core/src/channel/define-channel.ts** — A route without `.input()` no longer throws on startup; it falls back to a pass-through that accepts no input.
- **packages/core/src/client.ts** — A route with no input can now be sent with no arguments at all (`send()`), while routes that declare input still require it.
- **packages/core/src/channel/define-channel.test.ts / client.no-input.test.ts / *.test-d.ts** — Tests covering the no-input route end to end and at the type level.
- **packages/github/src/channel.test.ts / packages/whatsapp/src/channel.test.ts** — Updated to the new behavior (no longer expect the old startup error).
- **examples/welcome-text/apps/cli/src/examples/custom-channel-no-input.ts** — New runnable example showing a custom channel whose route omits input. Registered in the example menu.

# How to test

1. `pnpm test`
2. `pnpm --filter @welcome-text/cli start custom-channel-no-input`
3. Confirm both notifications send and the `order.created` route works without any `input`.

<!-- start Preview packages update -->
<!-- end Preview packages update -->

<!-- start Preview docs URL -->
<!-- end Preview docs URL -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Channels and notification routes can now be defined without explicit input arguments; route `.send()` can be called with no arguments (or `{}`) when input isn’t configured.
  * When input is omitted, the rendered payload includes `input: undefined`, and channel definitions use a default passthrough schema.
* **Bug Fixes**
  * Channel finalization now succeeds when input isn’t configured, and the resulting definition includes a schema.
* **Tests**
  * Added and updated TypeScript and runtime tests across core and channel implementations to verify the optional-input behavior and `.send()` call signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->