### PR TITLE
feat(slack): add unfurlLinks and unfurlMedia send options

### DIFF
--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -72,6 +72,9 @@ Plus `.input(schema)` and `.use(mw)`.
 ```ts
 notify.deployAlert.send({
   to: string, // Slack webhook URL or channel ID
+  threadTs?: string, // reply in a thread
+  unfurlLinks?: boolean, // enable/disable link unfurling (chat.postMessage)
+  unfurlMedia?: boolean, // enable/disable media unfurling (chat.postMessage)
   input: TInput,
 });
 ```

--- a/packages/slack/src/channel.test.ts
+++ b/packages/slack/src/channel.test.ts
@@ -47,6 +47,23 @@ describe('slackChannel', () => {
     });
   });
 
+  it('validateArgs accepts unfurlLinks and unfurlMedia', () => {
+    const ch = slackChannel();
+    expect(
+      ch.validateArgs({
+        to: '#general',
+        unfurlLinks: false,
+        unfurlMedia: true,
+        input: {},
+      }),
+    ).toEqual({
+      to: '#general',
+      unfurlLinks: false,
+      unfurlMedia: true,
+      input: {},
+    });
+  });
+
   it('render returns { text, to } from a function text resolver', async () => {
     const ch = slackChannel();
     const builder = buildBuilder(ch).text(({ input }) => `Hi ${(input as { name: string }).name}`);
@@ -92,6 +109,28 @@ describe('slackChannel', () => {
       {},
     );
     expect(out).toEqual({ text: 'reply', to: '#general', threadTs: '1111.2222' });
+  });
+
+  it('render includes unfurlLinks and unfurlMedia from args', async () => {
+    const ch = slackChannel();
+    const builder = buildBuilder(ch).text('no previews');
+    const def = ch.finalize(builder, 'link');
+    const out = await ch.render(
+      def,
+      {
+        to: '#general',
+        unfurlLinks: false,
+        unfurlMedia: false,
+        input: { name: 'X' },
+      },
+      {},
+    );
+    expect(out).toEqual({
+      text: 'no previews',
+      to: '#general',
+      unfurlLinks: false,
+      unfurlMedia: false,
+    });
   });
 
   it('render includes file when set', async () => {

--- a/packages/slack/src/channel.ts
+++ b/packages/slack/src/channel.ts
@@ -15,6 +15,8 @@ export type FileResolver<TInput> =
 const slackArgsSchema = z.object({
   to: z.string().min(1).optional(),
   threadTs: z.string().optional(),
+  unfurlLinks: z.boolean().optional(),
+  unfurlMedia: z.boolean().optional(),
   input: z.unknown(),
 });
 
@@ -46,6 +48,8 @@ export const slackChannel = () =>
     render: ({ runtime, args }): RenderedSlack => {
       const result: RenderedSlack = { text: runtime.text, to: args.to };
       if (args.threadTs !== undefined) result.threadTs = args.threadTs;
+      if (args.unfurlLinks !== undefined) result.unfurlLinks = args.unfurlLinks;
+      if (args.unfurlMedia !== undefined) result.unfurlMedia = args.unfurlMedia;
       if (runtime.blocks !== undefined) result.blocks = runtime.blocks;
       if (runtime.file !== undefined) result.file = runtime.file;
       return result;

--- a/packages/slack/src/integration.test.ts
+++ b/packages/slack/src/integration.test.ts
@@ -117,4 +117,35 @@ describe('slack channel end-to-end', () => {
       threadTs: '1111.2222',
     });
   });
+
+  it('sends unfurlLinks and unfurlMedia through the pipeline', async () => {
+    const rpc = createNotify({ channels: { slack: slackChannel() } });
+
+    const catalog = rpc.catalog({
+      share: rpc
+        .slack()
+        .input(z.object({ url: z.string() }))
+        .text(({ input }) => input.url),
+    });
+
+    const transport = mockSlackTransport();
+    const notify = createClient({
+      catalog,
+      channels: { slack: slackChannel() },
+      transportsByChannel: { slack: transport },
+    });
+
+    await notify.share.send({
+      to: '#general',
+      unfurlLinks: false,
+      unfurlMedia: false,
+      input: { url: 'https://example.com' },
+    });
+    expect(transport.messages[0]).toMatchObject({
+      text: 'https://example.com',
+      to: '#general',
+      unfurlLinks: false,
+      unfurlMedia: false,
+    });
+  });
 });

--- a/packages/slack/src/transports/slack.test.ts
+++ b/packages/slack/src/transports/slack.test.ts
@@ -65,6 +65,35 @@ describe('slackTransport', () => {
     expect(body.thread_ts).toBe('1111.2222');
   });
 
+  it('includes unfurl_links and unfurl_media when set (including false)', async () => {
+    const fetchMock = mockFetch({ ok: true, ts: '1.3', channel: 'C1' });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const t = slackTransport({ token: 'xoxb-test' });
+    await t.send(
+      { text: 'https://example.com', to: '#general', unfurlLinks: false, unfurlMedia: false },
+      ctx,
+    );
+
+    const call = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.unfurl_links).toBe(false);
+    expect(body.unfurl_media).toBe(false);
+  });
+
+  it('omits unfurl fields when not set', async () => {
+    const fetchMock = mockFetch({ ok: true, ts: '1.3', channel: 'C1' });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const t = slackTransport({ token: 'xoxb-test' });
+    await t.send({ text: 'https://example.com', to: '#general' }, ctx);
+
+    const call = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(call[1].body as string);
+    expect(body).not.toHaveProperty('unfurl_links');
+    expect(body).not.toHaveProperty('unfurl_media');
+  });
+
   it('uses defaultChannel when rendered.to is not set', async () => {
     const fetchMock = mockFetch({ ok: true, ts: '1.4', channel: 'C999' });
     vi.stubGlobal('fetch', fetchMock);

--- a/packages/slack/src/transports/slack.ts
+++ b/packages/slack/src/transports/slack.ts
@@ -267,6 +267,14 @@ export const slackTransport = (opts: SlackTransportOptions): Transport => {
         body.thread_ts = rendered.threadTs;
       }
 
+      if (rendered.unfurlLinks !== undefined) {
+        body.unfurl_links = rendered.unfurlLinks;
+      }
+
+      if (rendered.unfurlMedia !== undefined) {
+        body.unfurl_media = rendered.unfurlMedia;
+      }
+
       log.debug('calling Slack API', { method: 'chat.postMessage', channel });
 
       const json = await callApi('chat.postMessage', body);

--- a/packages/slack/src/types.ts
+++ b/packages/slack/src/types.ts
@@ -272,6 +272,8 @@ export type SlackFile = {
 export type SlackSendArgs<TInput = unknown> = {
   to?: string;
   threadTs?: string;
+  unfurlLinks?: boolean;
+  unfurlMedia?: boolean;
   input: TInput;
 };
 
@@ -280,5 +282,7 @@ export type RenderedSlack = {
   to?: string;
   blocks?: SlackBlock[];
   threadTs?: string;
+  unfurlLinks?: boolean;
+  unfurlMedia?: boolean;
   file?: SlackFile;
 };


### PR DESCRIPTION
Proxy optional chat.postMessage unfurl flags so callers can disable link and media previews per send.

This PR was created by Grok 4.5 and reviewed by me, pass the tests and should respect the convetions

Closes #187 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional controls for expanding links and media in Slack notifications.
  * Added support for sending notifications as replies within Slack threads.
  * Explicitly disabling link or media previews is now preserved when sending messages.

* **Documentation**
  * Updated Slack integration documentation with the new notification options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->