### PR TITLE
docs(readme): fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ npx create-better-notify@latest
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=better-notify%2Fbetter-notify&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#better-notify/better-notify&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=better-notify/better-notify&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=better-notify/better-notify&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=better-notify/better-notify&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=better-notify/better-notify&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=better-notify/better-notify&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=better-notify/better-notify&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README currently fails to load because the upstream data source is broken under GitHub's stargazer API restrictions. This updates the chart endpoint so it renders correctly again for visitors.

No badge links are touched; only the chart itself is fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History embeds to use the current `star-history.dera.page` URLs.
  * Replaced legacy Star History page and chart endpoints in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->